### PR TITLE
Add config option for default quest visibility when making quests

### DIFF
--- a/src/main/java/betterquesting/api/enums/EnumQuestVisibility.java
+++ b/src/main/java/betterquesting/api/enums/EnumQuestVisibility.java
@@ -7,5 +7,5 @@ public enum EnumQuestVisibility
 	NORMAL,
 	COMPLETED,
 	CHAIN,
-	ALWAYS;
+	ALWAYS
 }

--- a/src/main/java/betterquesting/api/properties/NativeProps.java
+++ b/src/main/java/betterquesting/api/properties/NativeProps.java
@@ -1,5 +1,6 @@
 package betterquesting.api.properties;
 
+import betterquesting.api.storage.BQ_Settings;
 import net.minecraft.init.Items;
 import net.minecraft.util.ResourceLocation;
 import betterquesting.api.enums.EnumLogic;
@@ -30,7 +31,7 @@ public class NativeProps
 	public static final IPropertyType<Boolean> LOCKED_PROGRESS =			new PropertyTypeBoolean(new ResourceLocation("betterquesting:lockedProgress"), false);
 	public static final IPropertyType<Boolean> SIMULTANEOUS =				new PropertyTypeBoolean(new ResourceLocation("betterquesting:simultaneous"), false);
 	
-	public static final IPropertyType<EnumQuestVisibility> VISIBILITY =		new PropertyTypeEnum<>(new ResourceLocation("betterquesting:visibility"), EnumQuestVisibility.NORMAL);
+	public static final IPropertyType<EnumQuestVisibility> VISIBILITY =		new PropertyTypeEnum<>(new ResourceLocation("betterquesting:visibility"), findVisibility());
 	public static final IPropertyType<EnumLogic> LOGIC_TASK =				new PropertyTypeEnum<>(new ResourceLocation("betterquesting:taskLogic"), EnumLogic.AND);
 	public static final IPropertyType<EnumLogic> LOGIC_QUEST =				new PropertyTypeEnum<>(new ResourceLocation("betterquesting:questLogic"), EnumLogic.AND);
 	
@@ -63,4 +64,15 @@ public class NativeProps
 	
 	public static final IPropertyType<Integer> PACK_VER =					new PropertyTypeInteger(new ResourceLocation("betterquesting:pack_version"), 0);
 	public static final IPropertyType<String> PACK_NAME =					new PropertyTypeString(new ResourceLocation("betterquesting:pack_name"), "");
+
+	private static EnumQuestVisibility findVisibility() {
+		String visibility = BQ_Settings.defaultVisibility;
+		for(EnumQuestVisibility enumVisibility : EnumQuestVisibility.values()) {
+			if(enumVisibility.toString().equals(visibility)) {
+				return enumVisibility;
+			}
+		}
+
+		return EnumQuestVisibility.NORMAL;
+	}
 }

--- a/src/main/java/betterquesting/api/storage/BQ_Settings.java
+++ b/src/main/java/betterquesting/api/storage/BQ_Settings.java
@@ -29,4 +29,5 @@ public class BQ_Settings
 
 	public static boolean claimAllConfirmation = true;
 	public static boolean lockTray = true;
+	public static String defaultVisibility = "NORMAL";
 }

--- a/src/main/java/betterquesting/handlers/ConfigHandler.java
+++ b/src/main/java/betterquesting/handlers/ConfigHandler.java
@@ -36,6 +36,7 @@ public class ConfigHandler
 
 		BQ_Settings.claimAllConfirmation = config.getBoolean("Claim all requires confirmation", Configuration.CATEGORY_GENERAL, true, "If true, then when you click on Claim all, a warning dialog will be displayed");
 		BQ_Settings.lockTray = config.getBoolean("Lock Tray", Configuration.CATEGORY_GENERAL, false, "If true, locks the quest chapter list and opens it initially");
+		BQ_Settings.defaultVisibility = config.getString("Default Quest Visibility", Configuration.CATEGORY_GENERAL, "NORMAL", "The default visibility value used when creating quests");
 		config.save();
 	}
 }

--- a/src/main/java/betterquesting/questing/QuestInstance.java
+++ b/src/main/java/betterquesting/questing/QuestInstance.java
@@ -70,7 +70,7 @@ public class QuestInstance implements IQuest
 		setupValue(NativeProps.MAIN, false);
 		setupValue(NativeProps.GLOBAL_SHARE, false);
 		setupValue(NativeProps.SIMULTANEOUS, false);
-		setupValue(NativeProps.VISIBILITY, EnumQuestVisibility.NORMAL);
+		setupValue(NativeProps.VISIBILITY, NativeProps.VISIBILITY.getDefault());
 	}
 	
 	private <T> void setupValue(IPropertyType<T> prop)

--- a/src/main/java/betterquesting/questing/QuestLine.java
+++ b/src/main/java/betterquesting/questing/QuestLine.java
@@ -1,6 +1,5 @@
 package betterquesting.questing;
 
-import betterquesting.api.enums.EnumQuestVisibility;
 import betterquesting.api.properties.IPropertyType;
 import betterquesting.api.properties.NativeProps;
 import betterquesting.api.questing.IQuestLine;
@@ -30,7 +29,7 @@ public class QuestLine extends SimpleDatabase<IQuestLineEntry> implements IQuest
 		this.setupValue(NativeProps.NAME, "New Quest Line");
 		this.setupValue(NativeProps.DESC, "No Description");
 		this.setupValue(NativeProps.ICON, new BigItemStack(Items.BOOK));
-		this.setupValue(NativeProps.VISIBILITY, EnumQuestVisibility.NORMAL);
+		this.setupValue(NativeProps.VISIBILITY, NativeProps.VISIBILITY.getDefault());
 		this.setupValue(NativeProps.BG_IMAGE);
 		this.setupValue(NativeProps.BG_SIZE);
 	}


### PR DESCRIPTION
Adds a config option for default quest visibility when creating quests. Defaults to "NORMAL"