### PR TITLE
Fixes crash on server

### DIFF
--- a/src/main/java/betterquesting/api/questing/IQuest.java
+++ b/src/main/java/betterquesting/api/questing/IQuest.java
@@ -16,11 +16,8 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.UUID;
 
-public interface IQuest extends INBTSaveLoad<NBTTagCompound>, INBTProgress<NBTTagCompound>, IPropertyContainer {
-    /**
-     * Deprecated, use the player version and then fetch UUID from the QuestingAPI
-     */
-    EnumQuestState getState(UUID uuid);
+public interface IQuest extends INBTSaveLoad<NBTTagCompound>, INBTProgress<NBTTagCompound>, IPropertyContainer
+{
 
     EnumQuestState getState(EntityPlayer player);
 

--- a/src/main/java/betterquesting/questing/QuestInstance.java
+++ b/src/main/java/betterquesting/questing/QuestInstance.java
@@ -308,11 +308,6 @@ public class QuestInstance implements IQuest {
     }
 
     @Override
-    public EnumQuestState getState(UUID uuid) {
-        return getState(Minecraft.getMinecraft().player);
-    }
-
-    @Override
     public NBTTagCompound getCompletionInfo(UUID uuid) {
         synchronized (completeUsers) {
             return completeUsers.get(uuid);


### PR DESCRIPTION
Fixes a crash while on a server due to using EntityPlayerSP.

This crash was introduced when I deprecated `getState(UUID)` in a preview PR and added a redirect to new new method. Since the problematic method was deprecated, I just removed it.