### PR TITLE
Add View Mode button

### DIFF
--- a/src/main/java/betterquesting/api/storage/BQ_Settings.java
+++ b/src/main/java/betterquesting/api/storage/BQ_Settings.java
@@ -31,5 +31,6 @@ public class BQ_Settings
 
 	public static boolean claimAllConfirmation = true;
 	public static boolean lockTray = true;
+	public static boolean viewMode = false;
 	public static String defaultVisibility = "NORMAL";
 }

--- a/src/main/java/betterquesting/api2/cache/QuestCache.java
+++ b/src/main/java/betterquesting/api2/cache/QuestCache.java
@@ -5,6 +5,7 @@ import betterquesting.api.api.QuestingAPI;
 import betterquesting.api.enums.EnumQuestVisibility;
 import betterquesting.api.properties.NativeProps;
 import betterquesting.api.questing.IQuest;
+import betterquesting.api.storage.BQ_Settings;
 import betterquesting.api2.storage.DBEntry;
 import betterquesting.network.handlers.NetCacheSync;
 import betterquesting.questing.QuestDatabase;
@@ -239,7 +240,7 @@ public class QuestCache implements INBTSerializable<NBTTagCompound>
         
         EnumQuestVisibility vis = quest.getProperty(NativeProps.VISIBILITY);
         
-        if(QuestingAPI.getAPI(ApiReference.SETTINGS).canUserEdit(player) || vis == EnumQuestVisibility.ALWAYS) // Always shown or in edit mode
+        if(QuestingAPI.getAPI(ApiReference.SETTINGS).canUserEdit(player) || vis == EnumQuestVisibility.ALWAYS || BQ_Settings.viewMode) // Always shown or in edit mode, or in view mode
         {
             return true;
         } else if(vis == EnumQuestVisibility.HIDDEN)

--- a/src/main/java/betterquesting/api2/client/gui/controls/PanelButtonQuest.java
+++ b/src/main/java/betterquesting/api2/client/gui/controls/PanelButtonQuest.java
@@ -6,6 +6,7 @@ import betterquesting.api.enums.EnumQuestState;
 import betterquesting.api.properties.NativeProps;
 import betterquesting.api.questing.IQuest;
 import betterquesting.api.questing.tasks.ITask;
+import betterquesting.api.storage.BQ_Settings;
 import betterquesting.api.utils.BigItemStack;
 import betterquesting.api2.client.gui.misc.GuiRectangle;
 import betterquesting.api2.client.gui.resources.colors.IGuiColor;
@@ -77,7 +78,7 @@ public class PanelButtonQuest extends PanelButtonStorage<DBEntry<IQuest>>
         IGuiTexture btnTx = new GuiTextureColored(txFrame, txIconCol);
         setTextures(btnTx, btnTx, btnTx);
         setIcon(new OreDictTexture(1F, value == null ? new BigItemStack(Items.NETHER_STAR) : value.getValue().getProperty(NativeProps.ICON), false, true), 4);
-        setActive(QuestingAPI.getAPI(ApiReference.SETTINGS).canUserEdit(player) || !lock);
+        setActive(QuestingAPI.getAPI(ApiReference.SETTINGS).canUserEdit(player) || !lock || BQ_Settings.viewMode);
     }
     
     @Override

--- a/src/main/java/betterquesting/client/gui2/GuiQuestLines.java
+++ b/src/main/java/betterquesting/client/gui2/GuiQuestLines.java
@@ -87,12 +87,14 @@ public class GuiQuestLines extends GuiScreenCanvas implements IPEventListener, I
     private PanelButton btnDesign;
 
     private static boolean trayLock;
+    private static boolean viewMode;
     
     private final List<PanelButtonStorage<DBEntry<IQuestLine>>> btnListRef = new ArrayList<>();
 
     public GuiQuestLines(GuiScreen parent) {
         super(parent);
         trayLock = BQ_Settings.lockTray;
+        viewMode = BQ_Settings.viewMode;
     }
 
     @Override
@@ -283,6 +285,19 @@ public class GuiQuestLines extends GuiScreenCanvas implements IPEventListener, I
         btnTrayLock.setTooltip(Collections.singletonList(QuestTranslation.translate("betterquesting.btn.lock_tray")));
         cvBackground.addPanel(btnTrayLock);
 
+        // View Mode Button
+        PanelButton btnViewMode = new PanelButton(new GuiTransform(GuiAlign.TOP_LEFT, 8, 104, 32, 16, -2), -1, "").setIcon(viewMode ? PresetIcon.ICON_VISIBILITY_NORMAL.getTexture() : PresetIcon.ICON_VISIBILITY_HIDDEN.getTexture());
+        btnViewMode.setClickAction((b) -> {
+            viewMode = !viewMode;
+            b.setIcon(viewMode ? PresetIcon.ICON_VISIBILITY_NORMAL.getTexture() : PresetIcon.ICON_VISIBILITY_HIDDEN.getTexture());
+            ConfigHandler.config.get(Configuration.CATEGORY_GENERAL, "View mode", false).set(viewMode);
+            ConfigHandler.config.save();
+            ConfigHandler.initConfigs();
+            refreshGui();
+        });
+        btnViewMode.setTooltip(Collections.singletonList(QuestTranslation.translate("betterquesting.btn.view_mode")));
+        cvBackground.addPanel(btnViewMode);
+
         // === CHAPTER VIEWPORT ===
 
         CanvasQuestLine oldCvQuest = cvQuest;
@@ -400,6 +415,10 @@ public class GuiQuestLines extends GuiScreenCanvas implements IPEventListener, I
                 show = true;
                 unlocked = true;
                 complete = true;
+            }
+
+            if(viewMode) {
+                show = true;
             }
 
             for (DBEntry<IQuestLineEntry> qID : ql.getEntries()) {

--- a/src/main/java/betterquesting/handlers/ConfigHandler.java
+++ b/src/main/java/betterquesting/handlers/ConfigHandler.java
@@ -37,6 +37,7 @@ public class ConfigHandler
 		BQ_Settings.claimAllConfirmation = config.getBoolean("Claim all requires confirmation", Configuration.CATEGORY_GENERAL, true, "If true, then when you click on Claim all, a warning dialog will be displayed");
 		BQ_Settings.lockTray = config.getBoolean("Lock Tray", Configuration.CATEGORY_GENERAL, false, "If true, locks the quest chapter list and opens it initially");
 		BQ_Settings.skipHome = config.getBoolean("Skip Home", Configuration.CATEGORY_GENERAL, false, "If true, skip the home GUI and open quests at startup. This property will be changed by the mod itself.");
+		BQ_Settings.viewMode = config.getBoolean("View mode", Configuration.CATEGORY_GENERAL, false, "If view mode enabled, User can view all quests");
 
 		BQ_Settings.defaultVisibility = config.getString("Default Quest Visibility", Configuration.CATEGORY_GENERAL, "NORMAL", "The default visibility value used when creating quests");
 		config.save();

--- a/src/main/resources/assets/betterquesting/lang/en_us.lang
+++ b/src/main/resources/assets/betterquesting/lang/en_us.lang
@@ -55,6 +55,7 @@ betterquesting.btn.lock_tray=Lock Tray
 betterquesting.btn.visible_hidden=Always hide dependency line
 betterquesting.btn.visible_always=Always show dependency line
 betterquesting.btn.visible_implicit=Hover to show dependency line
+betterquesting.btn.view_mode=View Mode
 
 betterquesting.home.exit=Exit
 betterquesting.home.quests=Quests


### PR DESCRIPTION
Adds the View Mode button from https://github.com/GTNewHorizons/BetterQuesting/pull/37

Does not include the following PR which locked the button being visible behind a config option