### PR TITLE
Change version numbering to start at 4.0.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 modGroup = betterquesting
-modVersion = 1.0.0
+modVersion = 4.0.0
 modBaseName = BetterQuesting
 modBaseClass = BetterQuesting.java
 


### PR DESCRIPTION
Starting at 1.0.0 breaks compatibility with otherwise compatible mods expecting version 3.5.x or higher

![image](https://user-images.githubusercontent.com/11907282/173415334-977613ea-1586-4a2c-bcc7-2519ad9016de.png)
