### PR TITLE
make requirements appear in order based on database, add button(s) to control order

### DIFF
--- a/src/main/java/betterquesting/client/gui2/editors/GuiPrerequisiteEditor.java
+++ b/src/main/java/betterquesting/client/gui2/editors/GuiPrerequisiteEditor.java
@@ -241,7 +241,12 @@ public class GuiPrerequisiteEditor extends GuiScreenCanvas implements IPEventLis
         int[] orig = quest.getRequirements();
 
         int indexToShift = -1;
-        for (int i = 0; i < orig.length; i++) if (orig[i] == id) indexToShift = i;
+        for (int i = 0; i < orig.length; i++) {
+            if (orig[i] == id) {
+                indexToShift = i;
+                break;
+            }
+        }
         if (indexToShift < 0) return;
 
         int indexFrom = (indexToShift - 1 + orig.length) % orig.length;

--- a/src/main/java/betterquesting/client/gui2/editors/GuiPrerequisiteEditor.java
+++ b/src/main/java/betterquesting/client/gui2/editors/GuiPrerequisiteEditor.java
@@ -157,11 +157,11 @@ public class GuiPrerequisiteEditor extends GuiScreenCanvas implements IPEventLis
 
         List<DBEntry<IQuest>> arrReq = QuestDatabase.INSTANCE.bulkLookup(quest.getRequirements());
         for (int i = 0; i < arrReq.size(); i++) {
-            PanelButtonStorage<DBEntry<IQuest>> btnEdit = new PanelButtonStorage<>(new GuiRectangle(0, i * 16, width - 32, 16, 0), 1,
+            PanelButtonStorage<DBEntry<IQuest>> btnEdit = new PanelButtonStorage<>(new GuiRectangle(0, i * 16, width - 48, 16, 0), 1,
                     QuestTranslation.translate(arrReq.get(i).getValue().getProperty(NativeProps.NAME)), arrReq.get(i));
             canvasPreReq.addPanel(btnEdit);
 
-            PanelButtonStorage<DBEntry<IQuest>> btnType = new PanelButtonStorage<>(new GuiRectangle(width - 32, i * 16, 16, 16, 0), 6, "", arrReq.get(i));
+            PanelButtonStorage<DBEntry<IQuest>> btnType = new PanelButtonStorage<>(new GuiRectangle(width - 48, i * 16, 16, 16, 0), 6, "", arrReq.get(i));
             int arrReqID = arrReq.get(i).getID();
             btnType.setIcon(quest.getRequirementType(arrReqID).getIcon().getTexture());
             if (quest.getRequirementType(arrReqID) == IQuest.RequirementType.NORMAL)
@@ -171,6 +171,11 @@ public class GuiPrerequisiteEditor extends GuiScreenCanvas implements IPEventLis
             else
                 btnType.setTooltip(Collections.singletonList(QuestTranslation.translate("betterquesting.btn.visible_hidden")));
             canvasPreReq.addPanel(btnType);
+
+            PanelButtonStorage<DBEntry<IQuest>> btnUp = new PanelButtonStorage<>(new GuiRectangle(width - 32, i * 16, 16, 16, 0), 7, "", arrReq.get(i));
+            btnUp.setIcon(PresetIcon.ICON_UP.getTexture());
+            btnUp.setActive(i > 0);
+            canvasPreReq.addPanel(btnUp);
 
             PanelButtonStorage<DBEntry<IQuest>> btnRem = new PanelButtonStorage<>(new GuiRectangle(width - 16, i * 16, 16, 16, 0), 3, "", arrReq.get(i));
             btnRem.setIcon(PresetIcon.ICON_NEGATIVE.getTexture());
@@ -220,12 +225,31 @@ public class GuiPrerequisiteEditor extends GuiScreenCanvas implements IPEventLis
             DBEntry<IQuest> entry = ((PanelButtonStorage<DBEntry<IQuest>>) btn).getStoredValue();
             quest.setRequirementType(entry.getID(), quest.getRequirementType(entry.getID()).next());
             SendChanges();
+        } else if (btn.getButtonID() == 7) { // Reorder
+            DBEntry<IQuest> entry = ((PanelButtonStorage<DBEntry<IQuest>>) btn).getStoredValue();
+            reorderReq(quest, entry.getID());
+            SendChanges();
         }
     }
 
     private boolean containsReq(IQuest quest, int id) {
         for (int reqID : quest.getRequirements()) if (id == reqID) return true;
         return false;
+    }
+
+    private void reorderReq(IQuest quest, int id) {
+        int[] orig = quest.getRequirements();
+        if (orig.length <= 0) return;
+
+        int indexToShift = -1;
+        for (int i = 0; i < orig.length; i++) if (orig[i] == id) indexToShift = i;
+        if (indexToShift <= 0) return;
+
+        int tmp = orig[indexToShift];
+        orig[indexToShift] = orig[indexToShift - 1];
+        orig[indexToShift - 1] = tmp;
+
+        quest.setRequirements(orig);
     }
 
     private void removeReq(IQuest quest, int id) {

--- a/src/main/java/betterquesting/client/gui2/editors/GuiPrerequisiteEditor.java
+++ b/src/main/java/betterquesting/client/gui2/editors/GuiPrerequisiteEditor.java
@@ -174,7 +174,7 @@ public class GuiPrerequisiteEditor extends GuiScreenCanvas implements IPEventLis
 
             PanelButtonStorage<DBEntry<IQuest>> btnUp = new PanelButtonStorage<>(new GuiRectangle(width - 32, i * 16, 16, 16, 0), 7, "", arrReq.get(i));
             btnUp.setIcon(PresetIcon.ICON_UP.getTexture());
-            btnUp.setActive(i > 0);
+            btnUp.setActive(arrReq.size() > 1);
             canvasPreReq.addPanel(btnUp);
 
             PanelButtonStorage<DBEntry<IQuest>> btnRem = new PanelButtonStorage<>(new GuiRectangle(width - 16, i * 16, 16, 16, 0), 3, "", arrReq.get(i));
@@ -239,15 +239,15 @@ public class GuiPrerequisiteEditor extends GuiScreenCanvas implements IPEventLis
 
     private void reorderReq(IQuest quest, int id) {
         int[] orig = quest.getRequirements();
-        if (orig.length <= 0) return;
 
         int indexToShift = -1;
         for (int i = 0; i < orig.length; i++) if (orig[i] == id) indexToShift = i;
-        if (indexToShift <= 0) return;
+        if (indexToShift < 0) return;
 
+        int indexFrom = (indexToShift - 1 + orig.length) % orig.length;
         int tmp = orig[indexToShift];
-        orig[indexToShift] = orig[indexToShift - 1];
-        orig[indexToShift - 1] = tmp;
+        orig[indexToShift] = orig[indexFrom];
+        orig[indexFrom] = tmp;
 
         quest.setRequirements(orig);
     }

--- a/src/main/java/betterquesting/client/gui2/editors/GuiQuestLinesEditor.java
+++ b/src/main/java/betterquesting/client/gui2/editors/GuiQuestLinesEditor.java
@@ -309,7 +309,7 @@ public class GuiQuestLinesEditor extends GuiScreenCanvas implements IPEventListe
             lineList.addPanel(tmp);
             lineList.addPanel(new PanelButtonStorage<>(new GuiRectangle(w - 32, i * 16, 16, 16, 0), 6, "", entry).setIcon(PresetIcon.ICON_TRASH.getTexture()));
             PanelButton btnUp = new PanelButtonStorage<>(new GuiRectangle(w - 16, i * 16, 16, 16, 0), 7, "", entry).setIcon(PresetIcon.ICON_UP.getTexture());
-            btnUp.setActive(i > 0);
+            btnUp.setActive(QuestLineDatabase.INSTANCE.getSortedEntries().size() > 1);
             lineList.addPanel(btnUp);
             i++;
         }
@@ -328,7 +328,7 @@ public class GuiQuestLinesEditor extends GuiScreenCanvas implements IPEventListe
     }
 
     private void SendReorder(int indexToShift) {
-        if (indexToShift <= 0) return;
+        if (indexToShift < 0) return;
         List<DBEntry<IQuestLine>> entries = QuestLineDatabase.INSTANCE.getSortedEntries();
         if (indexToShift >= entries.size()) return;
         int[] chapterIDs = new int[entries.size()];
@@ -336,9 +336,10 @@ public class GuiQuestLinesEditor extends GuiScreenCanvas implements IPEventListe
             chapterIDs[i] = entries.get(i).getID();
         }
 
+        int indexFrom = (indexToShift - 1 + chapterIDs.length) % chapterIDs.length;
         int tmp = chapterIDs[indexToShift];
-        chapterIDs[indexToShift] = chapterIDs[indexToShift - 1];
-        chapterIDs[indexToShift - 1] = tmp;
+        chapterIDs[indexToShift] = chapterIDs[indexFrom];
+        chapterIDs[indexFrom] = tmp;
 
         NBTTagCompound payload = new NBTTagCompound();
         payload.setIntArray("chapterIDs", chapterIDs);

--- a/src/main/java/betterquesting/questing/QuestInstance.java
+++ b/src/main/java/betterquesting/questing/QuestInstance.java
@@ -374,8 +374,7 @@ public class QuestInstance implements IQuest {
     }
 
     public void setRequirements(@Nonnull int[] req) {
-        Arrays.sort(req);
-        prereqTypes.retainEntries((a, b) -> Arrays.binarySearch(req, a) >= 0);
+        prereqTypes.retainEntries((a, b) -> Arrays.stream(req).anyMatch(i -> i == a));
         this.preRequisites = req;
     }
 


### PR DESCRIPTION
this allows developers to control the order of quest requirements in quest descriptions. this order is defined by the order listed in the database.
this adds a button while editing requirements to easily control the order.