### PR TITLE
Fix crash when right clicking canvas with no rewards

### DIFF
--- a/src/main/java/betterquesting/client/gui2/GuiQuest.java
+++ b/src/main/java/betterquesting/client/gui2/GuiQuest.java
@@ -98,7 +98,43 @@ public class GuiQuest extends GuiScreenCanvas implements IPEventListener, INeeds
         PEventBroadcaster.INSTANCE.register(this, PEventButton.class);
 
         // Background panel
-        CanvasTextured cvBackground = new CanvasTextured(new GuiTransform(GuiAlign.FULL_BOX, new GuiPadding(0, 0, 0, 0), 0), PresetTexture.PANEL_MAIN.getTexture());
+        CanvasTextured cvBackground = new CanvasTextured(new GuiTransform(GuiAlign.FULL_BOX, new GuiPadding(0, 0, 0, 0), 0), PresetTexture.PANEL_MAIN.getTexture()) {
+            @Override
+            public boolean onMouseClick(int mx, int my, int click) {
+                if(click != 1) {
+                    return super.onMouseClick(mx, my, click);
+                }
+
+                // There are no current rewards, so create the pane
+                if(rectReward == null && !rectTask.contains(mx, my) && QuestingAPI.getAPI(ApiReference.SETTINGS).canUserEdit(mc.player)) {
+                    rectReward = new GuiTransform(new Vector4f(0F, 0.5F, 0.5F, 1F), new GuiPadding(0, 0, 8, 16), 0);
+                    rectReward.setParent(cvInner.getTransform());
+
+                    PopContextMenu popup = new PopContextMenu(new GuiRectangle(mx, my, 76, 16), true);
+                    GuiRewardEditor editor = new GuiRewardEditor(new GuiQuest(parent, questID), quest);
+                    Runnable action = () -> mc.displayGuiScreen(editor);
+                    popup.addButton(QuestTranslation.translate("betterquesting.context.add_reward"), null, action);
+                    openPopup(popup);
+
+                    refreshDescPanel(true);
+                    refreshRewardPanel();
+                    return true;
+
+                }
+                // There are rewards, so just show the popup
+                else if(rectReward != null && rectReward.contains(mx, my) && QuestingAPI.getAPI(ApiReference.SETTINGS).canUserEdit(mc.player)) {
+                    PopContextMenu popup = new PopContextMenu(new GuiRectangle(mx, my, 76, 16), true);
+                    GuiRewardEditor editor = new GuiRewardEditor(new GuiQuest(parent, questID), quest);
+                    Runnable action = () -> mc.displayGuiScreen(editor);
+                    popup.addButton(QuestTranslation.translate("betterquesting.context.add_reward"), null, action);
+                    openPopup(popup);
+                    return true;
+                }
+                else {
+                    return super.onMouseClick(mx, my, click);
+                }
+            }
+        };
         this.addPanel(cvBackground);
 
         PanelTextBox panTxt = new PanelTextBox(new GuiTransform(GuiAlign.TOP_EDGE, new GuiPadding(0, 16, 0, -32), 0), QuestTranslation.translate(quest.getProperty(NativeProps.NAME))).setAlignment(1);
@@ -125,29 +161,6 @@ public class GuiQuest extends GuiScreenCanvas implements IPEventListener, INeeds
 
             rectReward = new GuiTransform(new Vector4f(0F, 0.5F, 0.5F, 1F), new GuiPadding(0, 0, 8, 16), 0);
             rectReward.setParent(cvInner.getTransform());
-
-            CanvasEmpty canvasRewardPopup = new CanvasEmpty(rectReward) {
-                @Override
-                public boolean onMouseClick(int mx, int my, int click) {
-                    if(click != 1) {
-                        return false;
-                    }
-
-                    if(rectReward.contains(mx, my) && QuestingAPI.getAPI(ApiReference.SETTINGS).canUserEdit(mc.player)) {
-                        PopContextMenu popup = new PopContextMenu(new GuiRectangle(mx, my, 76, 16), true);
-                        GuiRewardEditor editor = new GuiRewardEditor(new GuiQuest(parent, questID), quest);
-                        Runnable action = () -> mc.displayGuiScreen(editor);
-                        popup.addButton(QuestTranslation.translate("betterquesting.context.add_reward"), null, action);
-                        openPopup(popup);
-                        return true;
-                    }
-                    else {
-                        return false;
-                    }
-                }
-            };
-
-            cvInner.addPanel(canvasRewardPopup);
 
             refreshRewardPanel();
         } else {

--- a/src/main/java/betterquesting/client/gui2/GuiQuest.java
+++ b/src/main/java/betterquesting/client/gui2/GuiQuest.java
@@ -126,6 +126,29 @@ public class GuiQuest extends GuiScreenCanvas implements IPEventListener, INeeds
             rectReward = new GuiTransform(new Vector4f(0F, 0.5F, 0.5F, 1F), new GuiPadding(0, 0, 8, 16), 0);
             rectReward.setParent(cvInner.getTransform());
 
+            CanvasEmpty canvasRewardPopup = new CanvasEmpty(rectReward) {
+                @Override
+                public boolean onMouseClick(int mx, int my, int click) {
+                    if(click != 1) {
+                        return false;
+                    }
+
+                    if(rectReward.contains(mx, my) && QuestingAPI.getAPI(ApiReference.SETTINGS).canUserEdit(mc.player)) {
+                        PopContextMenu popup = new PopContextMenu(new GuiRectangle(mx, my, 76, 16), true);
+                        GuiRewardEditor editor = new GuiRewardEditor(new GuiQuest(parent, questID), quest);
+                        Runnable action = () -> mc.displayGuiScreen(editor);
+                        popup.addButton(QuestTranslation.translate("betterquesting.context.add_reward"), null, action);
+                        openPopup(popup);
+                        return true;
+                    }
+                    else {
+                        return false;
+                    }
+                }
+            };
+
+            cvInner.addPanel(canvasRewardPopup);
+
             refreshRewardPanel();
         } else {
             refreshDescPanel(false);
@@ -150,14 +173,6 @@ public class GuiQuest extends GuiScreenCanvas implements IPEventListener, INeeds
                     GuiTaskEditor editor = new GuiTaskEditor(new GuiQuest(parent, questID), quest);
                     Runnable action = () -> mc.displayGuiScreen(editor);
                     popup.addButton(QuestTranslation.translate("betterquesting.context.add_task"), null, action);
-                    openPopup(popup);
-                    return true;
-                }
-                else if(rectReward.contains(mx, my) && QuestingAPI.getAPI(ApiReference.SETTINGS).canUserEdit(mc.player)) {
-                    PopContextMenu popup = new PopContextMenu(new GuiRectangle(mx, my, 76, 16), true);
-                    GuiRewardEditor editor = new GuiRewardEditor(new GuiQuest(parent, questID), quest);
-                    Runnable action = () -> mc.displayGuiScreen(editor);
-                    popup.addButton(QuestTranslation.translate("betterquesting.context.add_reward"), null, action);
                     openPopup(popup);
                     return true;
                 }

--- a/src/main/java/betterquesting/client/gui2/GuiQuest.java
+++ b/src/main/java/betterquesting/client/gui2/GuiQuest.java
@@ -116,8 +116,11 @@ public class GuiQuest extends GuiScreenCanvas implements IPEventListener, INeeds
                     popup.addButton(QuestTranslation.translate("betterquesting.context.add_reward"), null, action);
                     openPopup(popup);
 
-                    refreshDescPanel(true);
-                    refreshRewardPanel();
+                    // Try to make sure that players have added rewards via the popup, instead of opening the popup, and then clicking off
+                    if(quest.getRewards().size() > 0) {
+                        refreshDescPanel(true);
+                        refreshRewardPanel();
+                    }
                     return true;
 
                 }


### PR DESCRIPTION
Fixes a crash that occurs when Right Clicking in a Quest Canvas when the quest has no rewards.

Also moves the right click to create reward option out of the right click for task canvas.

I want to eventually have right click create reward create the reward canvas if it does not exist, as that would be much nicer than first having to create the reward canvas in game via the edit menu.