### PR TITLE
Fix server crash with questbook

### DIFF
--- a/src/main/java/betterquesting/handlers/GuiHandler.java
+++ b/src/main/java/betterquesting/handlers/GuiHandler.java
@@ -1,6 +1,8 @@
 package betterquesting.handlers;
 
+import betterquesting.api.storage.BQ_Settings;
 import betterquesting.blocks.TileSubmitStation;
+import betterquesting.client.gui2.GuiHome;
 import betterquesting.client.gui2.GuiQuestHelp;
 import betterquesting.client.gui2.editors.GuiEditLootGroup;
 import betterquesting.client.gui2.inventory.ContainerSubmitStation;
@@ -33,6 +35,14 @@ public class GuiHandler implements IGuiHandler {
             return new GuiQuestHelp(null);
         } else if (ID == 2) {
             return new GuiEditLootGroup(null);
+        }
+        else if(ID == 3) {
+            if(BQ_Settings.useBookmark && GuiHome.bookmark != null) {
+                return GuiHome.bookmark;
+            }
+            else {
+                return new GuiHome(null);
+            }
         }
 
         return null;

--- a/src/main/java/betterquesting/items/ItemQuestBook.java
+++ b/src/main/java/betterquesting/items/ItemQuestBook.java
@@ -11,6 +11,8 @@ import net.minecraft.util.ActionResult;
 import net.minecraft.util.EnumActionResult;
 import net.minecraft.util.EnumHand;
 import net.minecraft.world.World;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
 
 import javax.annotation.Nonnull;
 
@@ -24,6 +26,7 @@ public class ItemQuestBook extends Item {
 
     @Nonnull
     @Override
+    @SideOnly(Side.CLIENT)
     public ActionResult<ItemStack> onItemRightClick(@Nonnull World world, @Nonnull EntityPlayer player, @Nonnull EnumHand hand) {
 
         ItemStack stack = player.getHeldItem(hand);

--- a/src/main/java/betterquesting/items/ItemQuestBook.java
+++ b/src/main/java/betterquesting/items/ItemQuestBook.java
@@ -1,9 +1,6 @@
 package betterquesting.items;
 
-import betterquesting.api.storage.BQ_Settings;
-import betterquesting.client.gui2.GuiHome;
 import betterquesting.core.BetterQuesting;
-import net.minecraft.client.Minecraft;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
@@ -11,8 +8,6 @@ import net.minecraft.util.ActionResult;
 import net.minecraft.util.EnumActionResult;
 import net.minecraft.util.EnumHand;
 import net.minecraft.world.World;
-import net.minecraftforge.fml.relauncher.Side;
-import net.minecraftforge.fml.relauncher.SideOnly;
 
 import javax.annotation.Nonnull;
 
@@ -26,21 +21,12 @@ public class ItemQuestBook extends Item {
 
     @Nonnull
     @Override
-    @SideOnly(Side.CLIENT)
     public ActionResult<ItemStack> onItemRightClick(@Nonnull World world, @Nonnull EntityPlayer player, @Nonnull EnumHand hand) {
 
         ItemStack stack = player.getHeldItem(hand);
 
-        if(world.isRemote) {
-            if(stack.getItem() == BetterQuesting.questBook) {
-                Minecraft mc = Minecraft.getMinecraft();
-                if(BQ_Settings.useBookmark && GuiHome.bookmark != null) {
-                    mc.displayGuiScreen(GuiHome.bookmark);
-                }
-                else {
-                    mc.displayGuiScreen(new GuiHome(mc.currentScreen));
-                }
-            }
+        if(world.isRemote && stack.getItem() == BetterQuesting.questBook) {
+            player.openGui(BetterQuesting.instance, 3, world, player.getPosition().getX(), player.getPosition().getY(), player.getPosition().getZ());
         }
 
         return new ActionResult<>(EnumActionResult.PASS, stack);


### PR DESCRIPTION
Fixes a server crash with the questbook.

Since the only thing done in this method is opening GUIs, using `SideOnly(Client)` should be fine, but am open to better suggestions.