### PR TITLE
Add GitHub Workflows for CI Mod Releases

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,26 @@
+# This file must be named 'release.yml' for release configuration to work
+changelog:
+
+  exclude:
+    labels:
+      - ignore-for-release
+
+  categories:
+    - title: Breaking Changes
+      labels:
+        - breaking-change
+
+    - title: Features
+      labels:
+        - enhancement
+        - feature
+        - feat
+
+    - title: Bug Fixes
+      labels:
+        - bugfix
+        - fix
+
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/workflows/curseforge_release.yml
+++ b/.github/workflows/curseforge_release.yml
@@ -60,6 +60,7 @@ jobs:
           release_type: "release"
           changelog: "Changelog is available [here](${{ steps.get_release_tag.outputs.url }})."
           changelog_type: "markdown"
+          relations: "better-questing:incompatible,better-questing-standard-expansion:incompatible,bqtweaker:incompatible"
           file_path: build/libs/{{ steps.get_mod_name.outputs.name }}-{{ steps.get_version.outputs.version }}.jar
           project_id: "${{ secrets.CURSEFORGE_PROJECT_ID }}"
           token: "${{ secrets.CURSEFORGE_API_KEY }}"

--- a/.github/workflows/curseforge_release.yml
+++ b/.github/workflows/curseforge_release.yml
@@ -1,0 +1,65 @@
+# Requires a Release on GitHub of the current version
+name: Release to CurseForge
+
+# manually run, or automatically after the GitHub release is done
+on:
+  workflow_dispatch:
+  workflow_run:
+    workflows: ["Release to GitHub"]
+    types:
+      - completed
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+
+      - name: Set up JDK 8
+        uses: actions/setup-java@v2
+        with:
+          java-version: '8'
+          distribution: 'adopt'
+
+      - name: Use Cached Gradle Packages
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle.properties*') }}
+          restore-keys: ${{ runner.os }}-gradle-
+
+      - name: Build with Gradle
+        run: |
+          chmod +x gradlew
+          ./gradlew build
+
+      - name: Get Mod Version
+        id: get_version
+        run: echo ::set-output name=version::$(sed -n 's/^modVersion = \(.*\)/\1/p' < gradle.properties*)
+
+      - name: Get Mod Name
+        id: get_mod_name
+        run: echo ::set-output name=version::$(sed -n 's/^modBaseName = \(.*\)/\1/p' < gradle.properties*)
+
+      - name: Retrieve Release Notes from Release Tag
+        id: get_release_tag
+        uses: cardinalby/git-get-release-action@v1
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          tag: v${{ steps.get_version.outputs.version }}
+
+      - name: Create CurseForge Release
+        uses: itsmeow/curseforge-upload@v3
+        with:
+          game_versions: "Minecraft 1.12:1.12.2,Java 8,Forge"
+          game_endpoint: "minecraft"
+          release_type: "release"
+          changelog: "Changelog is available [here](${{ steps.get_release_tag.outputs.url }})."
+          changelog_type: "markdown"
+          file_path: build/libs/{{ steps.get_mod_name.outputs.name }}-{{ steps.get_version.outputs.version }}.jar
+          project_id: "${{ secrets.CURSEFORGE_PROJECT_ID }}"
+          token: "${{ secrets.CURSEFORGE_API_KEY }}"

--- a/.github/workflows/github_release.yml
+++ b/.github/workflows/github_release.yml
@@ -1,0 +1,48 @@
+# Creates a release on GitHub with a new tag of the current version
+name: Release to GitHub
+
+on:
+  workflow_dispatch:
+    inputs:
+      label:
+        description: 'Prepended Label'
+        required: false
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+
+      - name: Set up JDK 8
+        uses: actions/setup-java@v2
+        with:
+          java-version: '8'
+          distribution: 'adopt'
+
+      - name: Use Cached Gradle Packages
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle.properties*') }}
+          restore-keys: ${{ runner.os }}-gradle-
+
+      - name: Build with Gradle
+        run: |
+          chmod +x gradlew
+          ./gradlew build
+
+      - name: Get Mod Version
+        id: get_version
+        run: echo ::set-output name=version::$(sed -n 's/^modVersion = \(.*\)/\1/p' < gradle.properties*)
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: v${{ steps.get_version.outputs.version }}
+          files: build/libs/*.jar
+          body: "**${{ github.event.inputs.label }}**\n"
+          generate_release_notes: true


### PR DESCRIPTION
This PR adds CI for GitHub and CurseForge mod deployment.

The GitHub release must be manually run, with an optional label to append to the top of the autogenerated changelog. This is intended for adding text such as **HOTFIX** to a release.

The changelog autogeneration is done through GitHub, and categorizes based on pull request tags. This can be further configured in `release.yml`.

The CurseForge release is set to automatically run after the GitHub release completes successfully, and also can be run manually. This workflow depends on a GitHub release tag existing with the same version as the mod to be built. The changelog submitted to CurseForge is a link to the full GitHub release tag changelog.

Two GitHub secrets need to be added for curseforge releases:
* `CURSEFORGE_PROJECT_ID` - the projectid of the mod
* `CURSEFORGE_API_KEY` - the api key of someone with upload privileges on CurseForge