### PR TITLE
Mark the player dirty after using the quest reset button

### DIFF
--- a/src/main/java/betterquesting/client/toolbox/tools/ToolboxToolReset.java
+++ b/src/main/java/betterquesting/client/toolbox/tools/ToolboxToolReset.java
@@ -3,8 +3,10 @@ package betterquesting.client.toolbox.tools;
 import betterquesting.api.client.toolbox.IToolboxTool;
 import betterquesting.api2.client.gui.controls.PanelButtonQuest;
 import betterquesting.api2.client.gui.panels.lists.CanvasQuestLine;
+import betterquesting.api2.utils.DirtyPlayerMarker;
 import betterquesting.client.gui2.editors.designer.PanelToolController;
 import betterquesting.network.handlers.NetQuestEdit;
+import net.minecraft.client.Minecraft;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.NonNullList;
 import org.lwjgl.input.Keyboard;
@@ -30,14 +32,23 @@ public class ToolboxToolReset implements IToolboxTool {
 
     @Override
     public boolean onMouseClick(int mx, int my, int click) {
-        if (click != 0 || !gui.getTransform().contains(mx, my)) return false;
 
-        PanelButtonQuest btn = gui.getButtonAt(mx, my);
+        if (click != 0 || !gui.getTransform().contains(mx, my)) {
+            return false;
+        }
 
-        if (btn == null) return false;
-        if (PanelToolController.selected.size() > 0 && !PanelToolController.selected.contains(btn)) return false;
+        PanelButtonQuest resetButton = gui.getButtonAt(mx, my);
 
-        List<PanelButtonQuest> btnList = PanelToolController.selected.size() > 0 ? PanelToolController.selected : Collections.singletonList(btn);
+        if (resetButton == null) {
+            return false;
+        }
+
+        if (PanelToolController.selected.size() > 0 && !PanelToolController.selected.contains(resetButton)) {
+            return false;
+        }
+
+        List<PanelButtonQuest> btnList = PanelToolController.selected.size() > 0 ? PanelToolController.selected : Collections.singletonList(resetButton);
+
         int[] questIDs = new int[btnList.size()];
 
         for (int i = 0; i < btnList.size(); i++) {
@@ -49,6 +60,7 @@ public class ToolboxToolReset implements IToolboxTool {
         payload.setBoolean("state", false);
         payload.setInteger("action", 2);
         NetQuestEdit.sendEdit(payload);
+        DirtyPlayerMarker.markDirty(Minecraft.getMinecraft().player.getUniqueID());
 
         return true;
     }
@@ -92,6 +104,7 @@ public class ToolboxToolReset implements IToolboxTool {
         payload.setBoolean("state", false);
         payload.setInteger("action", 2);
         NetQuestEdit.sendEdit(payload);
+        DirtyPlayerMarker.markDirty(Minecraft.getMinecraft().player.getUniqueID());
 
         return true;
     }

--- a/src/main/java/betterquesting/commands/admin/QuestCommandReset.java
+++ b/src/main/java/betterquesting/commands/admin/QuestCommandReset.java
@@ -4,6 +4,7 @@ import betterquesting.api.properties.NativeProps;
 import betterquesting.api.questing.IQuest;
 import betterquesting.api2.storage.DBEntry;
 import betterquesting.commands.QuestCommandBase;
+import betterquesting.handlers.SaveLoadHandler;
 import betterquesting.network.handlers.NetQuestSync;
 import betterquesting.questing.QuestDatabase;
 import betterquesting.storage.NameCache;
@@ -80,6 +81,8 @@ public class QuestCommandReset extends QuestCommandBase {
                 }
             }
 
+            SaveLoadHandler.INSTANCE.markDirty();
+
             if (uuid != null) {
                 sender.sendMessage(new TextComponentTranslation("betterquesting.cmd.reset.player_all", pName));
                 if (player != null) NetQuestSync.sendSync(player, null, false, true);
@@ -95,10 +98,12 @@ public class QuestCommandReset extends QuestCommandBase {
 
                 if (uuid != null) {
                     quest.resetUser(uuid, true); // Clear progress and state
+                    SaveLoadHandler.INSTANCE.markDirty();
                     sender.sendMessage(new TextComponentTranslation("betterquesting.cmd.reset.player_single", new TextComponentTranslation(quest.getProperty(NativeProps.NAME)), pName));
                     if (player != null) NetQuestSync.sendSync(player, new int[]{id}, false, true);
                 } else {
                     quest.resetUser(null, true);
+                    SaveLoadHandler.INSTANCE.markDirty();
                     sender.sendMessage(new TextComponentTranslation("betterquesting.cmd.reset.all_single", new TextComponentTranslation(quest.getProperty(NativeProps.NAME))));
                     NetQuestSync.quickSync(id, false, true);
                 }


### PR DESCRIPTION
As a follow up to #38, this PR uses the system introduced there to mark the player as dirty after they use the quest reset button in the quest designer.

Need to check on a server, and also need to check the reset command.