### PR TITLE
Prevent edit mode from enabling on startup

### DIFF
--- a/src/main/java/betterquesting/commands/admin/QuestCommandDefaults.java
+++ b/src/main/java/betterquesting/commands/admin/QuestCommandDefaults.java
@@ -98,6 +98,7 @@ public class QuestCommandDefaults extends QuestCommandBase {
 
                 if (loader == null) {
                     QuestSettings.INSTANCE.readFromNBT(nbt1.getCompoundTag("questSettings"));
+                    QuestSettings.INSTANCE.setProperty(NativeProps.EDIT_MODE, false);
                     QuestDatabase.INSTANCE.readFromNBT(nbt1.getTagList("questDatabase", 10), false);
                     QuestLineDatabase.INSTANCE.readFromNBT(nbt1.getTagList("questLines", 10), false);
                 } else {

--- a/src/main/java/betterquesting/handlers/SaveLoadHandler.java
+++ b/src/main/java/betterquesting/handlers/SaveLoadHandler.java
@@ -224,6 +224,7 @@ public class SaveLoadHandler {
             legacyLoader.readFromJson(json);
         }
 
+        QuestSettings.INSTANCE.setProperty(NativeProps.EDIT_MODE, false); // don't enable edit mode on startup
         hasUpdate = packName.equals(QuestSettings.INSTANCE.getProperty(NativeProps.PACK_NAME)) && packVer > QuestSettings.INSTANCE.getProperty(NativeProps.PACK_VER);
     }
 


### PR DESCRIPTION
Also prevents if from enabling when loading a quest file