### PR TITLE
Convert EDIT_MODE into a Gamerule

### DIFF
--- a/src/main/java/betterquesting/api2/client/gui/controls/PanelButtonQuest.java
+++ b/src/main/java/betterquesting/api2/client/gui/controls/PanelButtonQuest.java
@@ -89,7 +89,7 @@ public class PanelButtonQuest extends PanelButtonStorage<DBEntry<IQuest>> {
     private List<String> getQuestTooltip(IQuest quest, EntityPlayer player, int qID) {
         List<String> tooltip = getStandardTooltip(quest, player, qID);
 
-        if (Minecraft.getMinecraft().gameSettings.advancedItemTooltips && QuestSettings.INSTANCE.getProperty(NativeProps.EDIT_MODE)) {
+        if (Minecraft.getMinecraft().gameSettings.advancedItemTooltips && QuestSettings.INSTANCE.getEditMode(player)) {
             tooltip.add("");
             tooltip.addAll(this.getAdvancedTooltip(quest, player, qID));
         }
@@ -130,7 +130,7 @@ public class PanelButtonQuest extends PanelButtonStorage<DBEntry<IQuest>> {
                 timeTxt += df.format(time % 60) + "s";
 
                 list.add(TextFormatting.GRAY + QuestTranslation.translate("betterquesting.tooltip.repeat", timeTxt));
-                if (QuestSettings.INSTANCE.getProperty(NativeProps.EDIT_MODE)) {
+                if (QuestSettings.INSTANCE.getEditMode(player)) {
                     list.add(TextFormatting.RED + QuestTranslation.translate("betterquesting.tooltip.repeat_with_edit_mode"));
                 }
             }

--- a/src/main/java/betterquesting/api2/client/gui/controls/PanelButtonQuest.java
+++ b/src/main/java/betterquesting/api2/client/gui/controls/PanelButtonQuest.java
@@ -89,7 +89,7 @@ public class PanelButtonQuest extends PanelButtonStorage<DBEntry<IQuest>> {
     private List<String> getQuestTooltip(IQuest quest, EntityPlayer player, int qID) {
         List<String> tooltip = getStandardTooltip(quest, player, qID);
 
-        if (Minecraft.getMinecraft().gameSettings.advancedItemTooltips && QuestSettings.INSTANCE.getEditMode(player)) {
+        if (Minecraft.getMinecraft().gameSettings.advancedItemTooltips && QuestSettings.INSTANCE.getEditMode()) {
             tooltip.add("");
             tooltip.addAll(this.getAdvancedTooltip(quest, player, qID));
         }
@@ -130,7 +130,7 @@ public class PanelButtonQuest extends PanelButtonStorage<DBEntry<IQuest>> {
                 timeTxt += df.format(time % 60) + "s";
 
                 list.add(TextFormatting.GRAY + QuestTranslation.translate("betterquesting.tooltip.repeat", timeTxt));
-                if (QuestSettings.INSTANCE.getEditMode(player)) {
+                if (QuestSettings.INSTANCE.getEditMode()) {
                     list.add(TextFormatting.RED + QuestTranslation.translate("betterquesting.tooltip.repeat_with_edit_mode"));
                 }
             }

--- a/src/main/java/betterquesting/blocks/TileSubmitStation.java
+++ b/src/main/java/betterquesting/blocks/TileSubmitStation.java
@@ -11,6 +11,7 @@ import betterquesting.api2.storage.DBEntry;
 import betterquesting.core.BetterQuesting;
 import betterquesting.questing.QuestDatabase;
 import betterquesting.storage.QuestSettings;
+import net.minecraft.client.Minecraft;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.inventory.ISidedInventory;
@@ -228,7 +229,7 @@ public class TileSubmitStation extends TileEntity implements IFluidHandler, ISid
 
     @Override
     public void update() {
-        if (world.isRemote || !isSetup() || QuestSettings.INSTANCE.getProperty(NativeProps.EDIT_MODE)) return;
+        if (world.isRemote || !isSetup() || QuestSettings.INSTANCE.getEditMode(Minecraft.getMinecraft().player)) return;
 
         long wtt = world.getTotalWorldTime();
         if (wtt % 5 == 0 && owner != null) {

--- a/src/main/java/betterquesting/blocks/TileSubmitStation.java
+++ b/src/main/java/betterquesting/blocks/TileSubmitStation.java
@@ -1,6 +1,5 @@
 package betterquesting.blocks;
 
-import betterquesting.api.properties.NativeProps;
 import betterquesting.api.questing.IQuest;
 import betterquesting.api.questing.tasks.IFluidTask;
 import betterquesting.api.questing.tasks.IItemTask;
@@ -11,7 +10,6 @@ import betterquesting.api2.storage.DBEntry;
 import betterquesting.core.BetterQuesting;
 import betterquesting.questing.QuestDatabase;
 import betterquesting.storage.QuestSettings;
-import net.minecraft.client.Minecraft;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.inventory.ISidedInventory;
@@ -237,7 +235,7 @@ public class TileSubmitStation extends TileEntity implements IFluidHandler, ISid
             player = server == null ? null : server.getPlayerList().getPlayerByUUID(owner);
         }
 
-        if (world.isRemote || !isSetup() || (player != null && QuestSettings.INSTANCE.getEditMode(player))) return;
+        if (world.isRemote || !isSetup() || (player != null && QuestSettings.INSTANCE.getEditMode())) return;
 
         long wtt = world.getTotalWorldTime();
         if (wtt % 5 == 0 && owner != null) {

--- a/src/main/java/betterquesting/blocks/TileSubmitStation.java
+++ b/src/main/java/betterquesting/blocks/TileSubmitStation.java
@@ -229,15 +229,21 @@ public class TileSubmitStation extends TileEntity implements IFluidHandler, ISid
 
     @Override
     public void update() {
-        if (world.isRemote || !isSetup() || QuestSettings.INSTANCE.getEditMode(Minecraft.getMinecraft().player)) return;
+
+        MinecraftServer server = world.getMinecraftServer();
+        EntityPlayerMP player = null;
+
+        if(owner != null) {
+            player = server == null ? null : server.getPlayerList().getPlayerByUUID(owner);
+        }
+
+        if (world.isRemote || !isSetup() || (player != null && QuestSettings.INSTANCE.getEditMode(player))) return;
 
         long wtt = world.getTotalWorldTime();
         if (wtt % 5 == 0 && owner != null) {
             if (wtt % 20 == 0) qCached = null; // Reset and lookup quest again once every second
             DBEntry<IQuest> q = getQuest();
             IItemTask t = getItemTask();
-            MinecraftServer server = world.getMinecraftServer();
-            EntityPlayerMP player = server == null ? null : server.getPlayerList().getPlayerByUUID(owner);
             QuestCache qc = player == null ? null : player.getCapability(CapabilityProviderQuestCache.CAP_QUEST_CACHE, null);
 
             // Check quest & task is present. Check input is populated and output is clear.

--- a/src/main/java/betterquesting/client/gui2/GuiHome.java
+++ b/src/main/java/betterquesting/client/gui2/GuiHome.java
@@ -183,7 +183,6 @@ public class GuiHome extends GuiScreenCanvas {
 
             if (qFile.exists()) {
                 FMLCommonHandler.instance().getMinecraftServerInstance().addScheduledTask(() -> {
-                    boolean editMode = QuestSettings.INSTANCE.getProperty(NativeProps.EDIT_MODE);
                     boolean hardMode = QuestSettings.INSTANCE.getProperty(NativeProps.HARDCORE);
 
                     NBTTagList jsonP = QuestDatabase.INSTANCE.writeProgressToNBT(new NBTTagList(), null);
@@ -193,7 +192,6 @@ public class GuiHome extends GuiScreenCanvas {
                     QuestLineDatabase.INSTANCE.readFromNBT(j1.getTagList("questLines", 10), false);
                     QuestDatabase.INSTANCE.readProgressFromNBT(jsonP, false);
 
-                    QuestSettings.INSTANCE.setProperty(NativeProps.EDIT_MODE, editMode);
                     QuestSettings.INSTANCE.setProperty(NativeProps.HARDCORE, hardMode);
 
                     NetSettingSync.sendSync(null);

--- a/src/main/java/betterquesting/commands/admin/QuestCommandDefaults.java
+++ b/src/main/java/betterquesting/commands/admin/QuestCommandDefaults.java
@@ -67,13 +67,9 @@ public class QuestCommandDefaults extends QuestCommandBase {
         }
 
         if (args[1].equalsIgnoreCase("save")) {
-            boolean editMode = QuestSettings.INSTANCE.getProperty(NativeProps.EDIT_MODE);
-
             NBTTagCompound base = new NBTTagCompound();
 
-            QuestSettings.INSTANCE.setProperty(NativeProps.EDIT_MODE, false);
             base.setTag("questSettings", QuestSettings.INSTANCE.writeToNBT(new NBTTagCompound()));
-            QuestSettings.INSTANCE.setProperty(NativeProps.EDIT_MODE, editMode);
             base.setTag("questDatabase", QuestDatabase.INSTANCE.writeToNBT(new NBTTagList(), null));
             base.setTag("questLines", QuestLineDatabase.INSTANCE.writeToNBT(new NBTTagList(), null));
             base.setString("format", BetterQuesting.FORMAT);
@@ -86,7 +82,6 @@ public class QuestCommandDefaults extends QuestCommandBase {
             }
         } else if (args[1].equalsIgnoreCase("load")) {
             if (qFile.exists()) {
-                boolean editMode = QuestSettings.INSTANCE.getProperty(NativeProps.EDIT_MODE);
                 boolean hardMode = QuestSettings.INSTANCE.getProperty(NativeProps.HARDCORE);
 
                 NBTTagList jsonP = QuestDatabase.INSTANCE.writeProgressToNBT(new NBTTagList(), null);
@@ -106,7 +101,6 @@ public class QuestCommandDefaults extends QuestCommandBase {
 
                 QuestDatabase.INSTANCE.readProgressFromNBT(jsonP, false);
 
-                QuestSettings.INSTANCE.setProperty(NativeProps.EDIT_MODE, editMode);
                 QuestSettings.INSTANCE.setProperty(NativeProps.HARDCORE, hardMode);
 
                 if (args.length == 3 && !args[2].equalsIgnoreCase("DefaultQuests")) {

--- a/src/main/java/betterquesting/commands/admin/QuestCommandEdit.java
+++ b/src/main/java/betterquesting/commands/admin/QuestCommandEdit.java
@@ -1,17 +1,12 @@
 package betterquesting.commands.admin;
 
-import betterquesting.api.properties.NativeProps;
 import betterquesting.commands.QuestCommandBase;
 import betterquesting.handlers.SaveLoadHandler;
 import betterquesting.network.handlers.NetSettingSync;
 import betterquesting.storage.QuestSettings;
-import net.minecraft.client.Minecraft;
-import net.minecraft.client.entity.EntityPlayerSP;
 import net.minecraft.command.CommandBase;
 import net.minecraft.command.CommandException;
 import net.minecraft.command.ICommandSender;
-import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.util.text.TextComponentTranslation;
 import net.minecraftforge.server.permission.DefaultPermissionLevel;
@@ -42,7 +37,7 @@ public class QuestCommandEdit extends QuestCommandBase {
 
     @Override
     public void runCommand(MinecraftServer server, CommandBase command, ICommandSender sender, String[] args) throws CommandException {
-        boolean flag = !QuestSettings.INSTANCE.getEditMode((EntityPlayer) sender);
+        boolean flag = !QuestSettings.INSTANCE.getEditMode();
 
         if (args.length == 2) {
             try {
@@ -58,9 +53,9 @@ public class QuestCommandEdit extends QuestCommandBase {
             }
         }
 
-        QuestSettings.INSTANCE.setEditMode((EntityPlayer) sender, flag);
+        QuestSettings.INSTANCE.setEditMode(flag);
 
-        sender.sendMessage(new TextComponentTranslation("betterquesting.cmd.edit", new TextComponentTranslation(QuestSettings.INSTANCE.getEditMode((EntityPlayer) sender) ? "options.on" : "options.off")));
+        sender.sendMessage(new TextComponentTranslation("betterquesting.cmd.edit", new TextComponentTranslation(QuestSettings.INSTANCE.getEditMode() ? "options.on" : "options.off")));
 
         SaveLoadHandler.INSTANCE.markDirty();
         NetSettingSync.sendSync(null);

--- a/src/main/java/betterquesting/commands/admin/QuestCommandEdit.java
+++ b/src/main/java/betterquesting/commands/admin/QuestCommandEdit.java
@@ -5,9 +5,13 @@ import betterquesting.commands.QuestCommandBase;
 import betterquesting.handlers.SaveLoadHandler;
 import betterquesting.network.handlers.NetSettingSync;
 import betterquesting.storage.QuestSettings;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.entity.EntityPlayerSP;
 import net.minecraft.command.CommandBase;
 import net.minecraft.command.CommandException;
 import net.minecraft.command.ICommandSender;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.util.text.TextComponentTranslation;
 import net.minecraftforge.server.permission.DefaultPermissionLevel;
@@ -38,7 +42,7 @@ public class QuestCommandEdit extends QuestCommandBase {
 
     @Override
     public void runCommand(MinecraftServer server, CommandBase command, ICommandSender sender, String[] args) throws CommandException {
-        boolean flag = !QuestSettings.INSTANCE.getProperty(NativeProps.EDIT_MODE);
+        boolean flag = !QuestSettings.INSTANCE.getEditMode((EntityPlayer) sender);
 
         if (args.length == 2) {
             try {
@@ -54,9 +58,9 @@ public class QuestCommandEdit extends QuestCommandBase {
             }
         }
 
-        QuestSettings.INSTANCE.setProperty(NativeProps.EDIT_MODE, flag);
+        QuestSettings.INSTANCE.setEditMode((EntityPlayer) sender, flag);
 
-        sender.sendMessage(new TextComponentTranslation("betterquesting.cmd.edit", new TextComponentTranslation(QuestSettings.INSTANCE.getProperty(NativeProps.EDIT_MODE) ? "options.on" : "options.off")));
+        sender.sendMessage(new TextComponentTranslation("betterquesting.cmd.edit", new TextComponentTranslation(QuestSettings.INSTANCE.getEditMode((EntityPlayer) sender) ? "options.on" : "options.off")));
 
         SaveLoadHandler.INSTANCE.markDirty();
         NetSettingSync.sendSync(null);

--- a/src/main/java/betterquesting/handlers/EventHandler.java
+++ b/src/main/java/betterquesting/handlers/EventHandler.java
@@ -25,7 +25,6 @@ import betterquesting.client.gui2.GuiHome;
 import betterquesting.client.gui2.GuiQuestLines;
 import betterquesting.client.themes.ThemeRegistry;
 import betterquesting.core.BetterQuesting;
-import betterquesting.items.ItemQuestBook;
 import betterquesting.network.handlers.*;
 import betterquesting.questing.QuestDatabase;
 import betterquesting.questing.party.PartyInvitations;
@@ -47,6 +46,7 @@ import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.integrated.IntegratedServer;
 import net.minecraft.util.EnumHand;
 import net.minecraft.util.text.TextComponentString;
+import net.minecraft.world.GameRules;
 import net.minecraft.world.GameType;
 import net.minecraftforge.client.event.TextureStitchEvent;
 import net.minecraftforge.common.MinecraftForge;
@@ -128,7 +128,7 @@ public class EventHandler {
 
         EntityPlayerMP player = (EntityPlayerMP) event.getEntityLiving();
         betterquesting.api2.cache.QuestCache qc = player.getCapability(CapabilityProviderQuestCache.CAP_QUEST_CACHE, null);
-        boolean editMode = QuestSettings.INSTANCE.getEditMode(player);
+        boolean editMode = QuestSettings.INSTANCE.getEditMode();
 
         if (qc == null) return;
 
@@ -265,6 +265,12 @@ public class EventHandler {
                 LootSaveLoad.INSTANCE.SaveLoot();
             }
         }
+    }
+
+    @SubscribeEvent
+    public void onWorldLoad(WorldEvent.Load event) {
+        GameRules rules = event.getWorld().getGameRules();
+        if (!rules.hasRule(QuestSettings.EDIT_MODE)) rules.addGameRule(QuestSettings.EDIT_MODE, "false", GameRules.ValueType.BOOLEAN_VALUE);
     }
 
     @SubscribeEvent
@@ -600,7 +606,7 @@ public class EventHandler {
 
     @SubscribeEvent
     public void onEntityLiving(LivingUpdateEvent event) {
-        if (!(event.getEntityLiving() instanceof EntityPlayer) || event.getEntityLiving().world.isRemote || event.getEntityLiving().ticksExisted % 20 != 0 || QuestSettings.INSTANCE.getEditMode((EntityPlayer) event.getEntityLiving()))
+        if (!(event.getEntityLiving() instanceof EntityPlayer) || event.getEntityLiving().world.isRemote || event.getEntityLiving().ticksExisted % 20 != 0 || QuestSettings.INSTANCE.getEditMode())
             return;
 
         EntityPlayer player = (EntityPlayer) event.getEntityLiving();

--- a/src/main/java/betterquesting/handlers/EventHandler.java
+++ b/src/main/java/betterquesting/handlers/EventHandler.java
@@ -128,7 +128,7 @@ public class EventHandler {
 
         EntityPlayerMP player = (EntityPlayerMP) event.getEntityLiving();
         betterquesting.api2.cache.QuestCache qc = player.getCapability(CapabilityProviderQuestCache.CAP_QUEST_CACHE, null);
-        boolean editMode = QuestSettings.INSTANCE.getProperty(NativeProps.EDIT_MODE);
+        boolean editMode = QuestSettings.INSTANCE.getEditMode(player);
 
         if (qc == null) return;
 
@@ -600,7 +600,7 @@ public class EventHandler {
 
     @SubscribeEvent
     public void onEntityLiving(LivingUpdateEvent event) {
-        if (!(event.getEntityLiving() instanceof EntityPlayer) || event.getEntityLiving().world.isRemote || event.getEntityLiving().ticksExisted % 20 != 0 || QuestingAPI.getAPI(ApiReference.SETTINGS).getProperty(NativeProps.EDIT_MODE))
+        if (!(event.getEntityLiving() instanceof EntityPlayer) || event.getEntityLiving().world.isRemote || event.getEntityLiving().ticksExisted % 20 != 0 || QuestSettings.INSTANCE.getEditMode((EntityPlayer) event.getEntityLiving()))
             return;
 
         EntityPlayer player = (EntityPlayer) event.getEntityLiving();

--- a/src/main/java/betterquesting/handlers/SaveLoadHandler.java
+++ b/src/main/java/betterquesting/handlers/SaveLoadHandler.java
@@ -21,7 +21,6 @@ import betterquesting.storage.NameCache;
 import betterquesting.storage.QuestSettings;
 import com.google.gson.JsonObject;
 import io.netty.util.internal.ConcurrentSet;
-import net.minecraft.client.Minecraft;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
 import net.minecraft.server.MinecraftServer;
@@ -122,7 +121,7 @@ public class SaveLoadHandler {
     public void saveDatabases() {
         List<Future<Void>> allFutures = new ArrayList<>();
 
-        if (isDirty || QuestSettings.INSTANCE.getEditMode(Minecraft.getMinecraft().player)) {
+        if (isDirty || QuestSettings.INSTANCE.getEditMode()) {
             allFutures.add(saveConfig());
         }
 

--- a/src/main/java/betterquesting/handlers/SaveLoadHandler.java
+++ b/src/main/java/betterquesting/handlers/SaveLoadHandler.java
@@ -21,6 +21,7 @@ import betterquesting.storage.NameCache;
 import betterquesting.storage.QuestSettings;
 import com.google.gson.JsonObject;
 import io.netty.util.internal.ConcurrentSet;
+import net.minecraft.client.Minecraft;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
 import net.minecraft.server.MinecraftServer;
@@ -121,7 +122,7 @@ public class SaveLoadHandler {
     public void saveDatabases() {
         List<Future<Void>> allFutures = new ArrayList<>();
 
-        if (isDirty || QuestSettings.INSTANCE.getProperty(NativeProps.EDIT_MODE)) {
+        if (isDirty || QuestSettings.INSTANCE.getEditMode(Minecraft.getMinecraft().player)) {
             allFutures.add(saveConfig());
         }
 

--- a/src/main/java/betterquesting/items/ItemLootChest.java
+++ b/src/main/java/betterquesting/items/ItemLootChest.java
@@ -9,6 +9,8 @@ import betterquesting.core.BetterQuesting;
 import betterquesting.network.handlers.NetLootClaim;
 import betterquesting.questing.rewards.loot.LootGroup;
 import betterquesting.questing.rewards.loot.LootRegistry;
+import betterquesting.storage.QuestSettings;
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.util.ITooltipFlag;
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.entity.player.EntityPlayer;
@@ -228,7 +230,7 @@ public class ItemLootChest extends Item {
 
         NBTTagCompound tag = stack.getTagCompound();
         boolean hideTooltip = tag == null || !tag.getBoolean("hideLootInfo");
-        if (hideTooltip && !QuestingAPI.getAPI(ApiReference.SETTINGS).getProperty(NativeProps.EDIT_MODE)) return;
+        if (hideTooltip && !QuestSettings.INSTANCE.getEditMode(Minecraft.getMinecraft().player)) return;
 
         if (stack.getItemDamage() == 104) {
             if (tag == null) return;

--- a/src/main/java/betterquesting/items/ItemLootChest.java
+++ b/src/main/java/betterquesting/items/ItemLootChest.java
@@ -2,7 +2,6 @@ package betterquesting.items;
 
 import betterquesting.api.api.ApiReference;
 import betterquesting.api.api.QuestingAPI;
-import betterquesting.api.properties.NativeProps;
 import betterquesting.api.utils.BigItemStack;
 import betterquesting.api2.utils.QuestTranslation;
 import betterquesting.core.BetterQuesting;
@@ -10,7 +9,6 @@ import betterquesting.network.handlers.NetLootClaim;
 import betterquesting.questing.rewards.loot.LootGroup;
 import betterquesting.questing.rewards.loot.LootRegistry;
 import betterquesting.storage.QuestSettings;
-import net.minecraft.client.Minecraft;
 import net.minecraft.client.util.ITooltipFlag;
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.entity.player.EntityPlayer;
@@ -230,7 +228,7 @@ public class ItemLootChest extends Item {
 
         NBTTagCompound tag = stack.getTagCompound();
         boolean hideTooltip = tag == null || !tag.getBoolean("hideLootInfo");
-        if (hideTooltip && !QuestSettings.INSTANCE.getEditMode(Minecraft.getMinecraft().player)) return;
+        if (hideTooltip && worldIn != null && !QuestSettings.INSTANCE.getEditMode()) return;
 
         if (stack.getItemDamage() == 104) {
             if (tag == null) return;

--- a/src/main/java/betterquesting/legacy/v0/LegacyLoader_v0.java
+++ b/src/main/java/betterquesting/legacy/v0/LegacyLoader_v0.java
@@ -44,7 +44,6 @@ public final class LegacyLoader_v0 implements ILegacyLoader {
 
         if (json.has("editMode")) // This IS the file you are looking for
         {
-            QuestSettings.INSTANCE.setProperty(NativeProps.EDIT_MODE, JsonHelper.GetBoolean(json, "editMode", true));
             QuestSettings.INSTANCE.setProperty(NativeProps.HARDCORE, JsonHelper.GetBoolean(json, "hardcore", false));
 
             QuestSettings.INSTANCE.setProperty(NativeProps.LIVES_DEF, JsonHelper.GetNumber(json, "defLives", 3).intValue());

--- a/src/main/java/betterquesting/questing/QuestInstance.java
+++ b/src/main/java/betterquesting/questing/QuestInstance.java
@@ -115,7 +115,7 @@ public class QuestInstance implements IQuest {
             return;
         }
 
-        if (isUnlocked(playerID) || QuestSettings.INSTANCE.getProperty(NativeProps.EDIT_MODE)) {
+        if (isUnlocked(playerID) || QuestSettings.INSTANCE.getEditMode(player)) {
             int done = 0;
             boolean update = false;
 
@@ -137,7 +137,7 @@ public class QuestInstance implements IQuest {
             // Note: Tasks can mark the quest dirty themselves if progress changed but hasn't fully completed.
             if (tasks.size() <= 0 || qInfo.getProperty(NativeProps.LOGIC_TASK).getResult(done, tasks.size())) {
                 // State won't be auto updated in edit mode so we force change it here and mark it for re-sync
-                if (QuestSettings.INSTANCE.getProperty(NativeProps.EDIT_MODE))
+                if (QuestSettings.INSTANCE.getEditMode(player))
                     setComplete(playerID, System.currentTimeMillis());
                 qc.markQuestDirty(questID);
             } else if (update && qInfo.getProperty(NativeProps.SIMULTANEOUS)) {

--- a/src/main/java/betterquesting/questing/QuestInstance.java
+++ b/src/main/java/betterquesting/questing/QuestInstance.java
@@ -115,7 +115,7 @@ public class QuestInstance implements IQuest {
             return;
         }
 
-        if (isUnlocked(playerID) || QuestSettings.INSTANCE.getEditMode(player)) {
+        if (isUnlocked(playerID) || QuestSettings.INSTANCE.getEditMode()) {
             int done = 0;
             boolean update = false;
 
@@ -137,7 +137,7 @@ public class QuestInstance implements IQuest {
             // Note: Tasks can mark the quest dirty themselves if progress changed but hasn't fully completed.
             if (tasks.size() <= 0 || qInfo.getProperty(NativeProps.LOGIC_TASK).getResult(done, tasks.size())) {
                 // State won't be auto updated in edit mode so we force change it here and mark it for re-sync
-                if (QuestSettings.INSTANCE.getEditMode(player))
+                if (QuestSettings.INSTANCE.getEditMode())
                     setComplete(playerID, System.currentTimeMillis());
                 qc.markQuestDirty(questID);
             } else if (update && qInfo.getProperty(NativeProps.SIMULTANEOUS)) {

--- a/src/main/java/betterquesting/storage/QuestSettings.java
+++ b/src/main/java/betterquesting/storage/QuestSettings.java
@@ -5,41 +5,33 @@ import betterquesting.api.properties.IPropertyType;
 import betterquesting.api.properties.NativeProps;
 import betterquesting.api.storage.IQuestSettings;
 import betterquesting.core.BetterQuesting;
-import net.minecraft.client.Minecraft;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.server.MinecraftServer;
+import net.minecraftforge.fml.common.FMLCommonHandler;
 
 public class QuestSettings extends PropertyContainer implements IQuestSettings {
-    private static final String EDIT_MODE = BetterQuesting.MODID + ".edit_mode";
+    public static final String EDIT_MODE = BetterQuesting.MODID + ":edit_mode";
     public static final QuestSettings INSTANCE = new QuestSettings();
 
     public QuestSettings() {
         this.setupProps();
     }
 
-    public void setEditMode(EntityPlayer player, boolean edit){
-        if (player == null) return;
-        NBTTagCompound playerData = player.getEntityData();
-        NBTTagCompound data = playerData.hasKey(EntityPlayer.PERSISTED_NBT_TAG) ? playerData.getCompoundTag(EntityPlayer.PERSISTED_NBT_TAG) : new NBTTagCompound();
-        data.setBoolean(EDIT_MODE, edit);
-        playerData.setTag(EntityPlayer.PERSISTED_NBT_TAG, data);
+    public void setEditMode(boolean edit){
+        MinecraftServer server = FMLCommonHandler.instance().getMinecraftServerInstance();
+        server.getEntityWorld().getGameRules().setOrCreateGameRule(EDIT_MODE, String.valueOf(edit));
     }
 
-    public boolean getEditMode(EntityPlayer player){
-        if (player == null) return false;
-        NBTTagCompound playerData = player.getEntityData();
-        NBTTagCompound data = playerData.hasKey(EntityPlayer.PERSISTED_NBT_TAG) ? playerData.getCompoundTag(EntityPlayer.PERSISTED_NBT_TAG) : null;
-
-        if (data == null)
-            return false;
-
-        return data.getBoolean(EDIT_MODE);
+    public boolean getEditMode() {
+        MinecraftServer server = FMLCommonHandler.instance().getMinecraftServerInstance();
+        return server.getEntityWorld().getGameRules().getBoolean(EDIT_MODE);
     }
 
     @Override
     public boolean canUserEdit(EntityPlayer player) {
         if (player == null) return false;
-        return getEditMode(player) && NameCache.INSTANCE.isOP(QuestingAPI.getQuestingUUID(player));
+        return getEditMode() && NameCache.INSTANCE.isOP(QuestingAPI.getQuestingUUID(player));
     }
 
     @Override

--- a/src/main/java/betterquesting/storage/QuestSettings.java
+++ b/src/main/java/betterquesting/storage/QuestSettings.java
@@ -4,20 +4,42 @@ import betterquesting.api.api.QuestingAPI;
 import betterquesting.api.properties.IPropertyType;
 import betterquesting.api.properties.NativeProps;
 import betterquesting.api.storage.IQuestSettings;
+import betterquesting.core.BetterQuesting;
+import net.minecraft.client.Minecraft;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.nbt.NBTTagCompound;
 
 public class QuestSettings extends PropertyContainer implements IQuestSettings {
+    private static final String EDIT_MODE = BetterQuesting.MODID + ".edit_mode";
     public static final QuestSettings INSTANCE = new QuestSettings();
 
     public QuestSettings() {
         this.setupProps();
     }
 
+    public void setEditMode(EntityPlayer player, boolean edit){
+        if (player == null) return;
+        NBTTagCompound playerData = player.getEntityData();
+        NBTTagCompound data = playerData.hasKey(EntityPlayer.PERSISTED_NBT_TAG) ? playerData.getCompoundTag(EntityPlayer.PERSISTED_NBT_TAG) : new NBTTagCompound();
+        data.setBoolean(EDIT_MODE, edit);
+        playerData.setTag(EntityPlayer.PERSISTED_NBT_TAG, data);
+    }
+
+    public boolean getEditMode(EntityPlayer player){
+        if (player == null) return false;
+        NBTTagCompound playerData = player.getEntityData();
+        NBTTagCompound data = playerData.hasKey(EntityPlayer.PERSISTED_NBT_TAG) ? playerData.getCompoundTag(EntityPlayer.PERSISTED_NBT_TAG) : null;
+
+        if (data == null)
+            return false;
+
+        return data.getBoolean(EDIT_MODE);
+    }
+
     @Override
     public boolean canUserEdit(EntityPlayer player) {
         if (player == null) return false;
-        return this.getProperty(NativeProps.EDIT_MODE) && NameCache.INSTANCE.isOP(QuestingAPI.getQuestingUUID(player));
+        return getEditMode(player) && NameCache.INSTANCE.isOP(QuestingAPI.getQuestingUUID(player));
     }
 
     @Override
@@ -37,7 +59,6 @@ public class QuestSettings extends PropertyContainer implements IQuestSettings {
         this.setupValue(NativeProps.PACK_VER);
 
         this.setupValue(NativeProps.PARTY_ENABLE);
-        this.setupValue(NativeProps.EDIT_MODE);
         this.setupValue(NativeProps.HARDCORE);
         this.setupValue(NativeProps.LIVES_DEF);
         this.setupValue(NativeProps.LIVES_MAX);


### PR DESCRIPTION
Convert edit mode into a gamerule (defaults to false). This does not change the command (`/bq_admin edit` works the exact same).
This prevents an issue where edit mode would unexpectedly be considered enabled. 
Additionally, since it is no longer shipped in the `DefaultQuests.json` file, this also means pack makers no longer have to remember to disable edit mode when saving quests.