### PR TITLE
Optimize inventory and event checks

### DIFF
--- a/src/main/java/betterquesting/handlers/EventHandler.java
+++ b/src/main/java/betterquesting/handlers/EventHandler.java
@@ -483,7 +483,7 @@ public class EventHandler {
 
     @SubscribeEvent(priority = EventPriority.LOWEST)
     public void onRightClickItem(PlayerInteractEvent.RightClickItem event) {
-        if (event.getEntityPlayer() == null || event.getEntityLiving().world.isRemote || event.getEntityPlayer() instanceof FakePlayer || event.isCanceled()) return;
+        if (event.getEntityPlayer() == null || event.getEntityPlayer().world.isRemote || event.getEntityPlayer() instanceof FakePlayer || event.isCanceled()) return;
 
         EntityPlayer player = event.getEntityPlayer();
         ParticipantInfo pInfo = new ParticipantInfo(player);
@@ -500,7 +500,7 @@ public class EventHandler {
 
     @SubscribeEvent(priority = EventPriority.LOWEST)
     public void onRightClickBlock(PlayerInteractEvent.RightClickBlock event) {
-        if (event.getEntityPlayer() == null || event.getEntityLiving().world.isRemote || event.getEntityPlayer() instanceof FakePlayer || event.isCanceled()) return;
+        if (event.getEntityPlayer() == null || event.getEntityPlayer().world.isRemote || event.getEntityPlayer() instanceof FakePlayer || event.isCanceled()) return;
 
         EntityPlayer player = event.getEntityPlayer();
         ParticipantInfo pInfo = new ParticipantInfo(player);
@@ -519,7 +519,7 @@ public class EventHandler {
 
     @SubscribeEvent(priority = EventPriority.LOWEST)
     public void onLeftClickBlock(PlayerInteractEvent.LeftClickBlock event) {
-        if (event.getEntityPlayer() == null || event.getEntityLiving().world.isRemote || event.getEntityPlayer() instanceof FakePlayer || event.isCanceled()) return;
+        if (event.getEntityPlayer() == null || event.getEntityPlayer().world.isRemote || event.getEntityPlayer() instanceof FakePlayer || event.isCanceled()) return;
 
         EntityPlayer player = event.getEntityPlayer();
         ParticipantInfo pInfo = new ParticipantInfo(player);
@@ -539,14 +539,14 @@ public class EventHandler {
     @SubscribeEvent(priority = EventPriority.LOWEST)
     public void onRightClickEmpty(PlayerInteractEvent.RightClickEmpty event) // CLIENT SIDE ONLY EVENT
     {
-        if (event.getEntityPlayer() == null || !event.getEntityLiving().world.isRemote || event.getEntityPlayer() instanceof FakePlayer || event.isCanceled()) return;
+        if (event.getEntityPlayer() == null || !event.getEntityPlayer().world.isRemote || event.getEntityPlayer() instanceof FakePlayer || event.isCanceled()) return;
         NetTaskInteract.requestInteraction(false, event.getHand() == EnumHand.MAIN_HAND);
     }
 
     @SubscribeEvent(priority = EventPriority.LOWEST)
     public void onLeftClickAir(PlayerInteractEvent.LeftClickEmpty event) // CLIENT SIDE ONLY EVENT
     {
-        if (event.getEntityPlayer() == null || !event.getEntityLiving().world.isRemote || event.getEntityPlayer() instanceof FakePlayer || event.isCanceled()) return;
+        if (event.getEntityPlayer() == null || !event.getEntityPlayer().world.isRemote || event.getEntityPlayer() instanceof FakePlayer || event.isCanceled()) return;
         NetTaskInteract.requestInteraction(true, true);
     }
 

--- a/src/main/java/betterquesting/handlers/EventHandler.java
+++ b/src/main/java/betterquesting/handlers/EventHandler.java
@@ -55,6 +55,7 @@ import net.minecraft.world.GameType;
 import net.minecraftforge.client.event.ClientChatReceivedEvent;
 import net.minecraftforge.client.event.TextureStitchEvent;
 import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.common.util.FakePlayer;
 import net.minecraftforge.event.AttachCapabilitiesEvent;
 import net.minecraftforge.event.CommandEvent;
 import net.minecraftforge.event.entity.EntityJoinWorldEvent;
@@ -481,7 +482,7 @@ public class EventHandler {
 
     @SubscribeEvent(priority = EventPriority.LOWEST)
     public void onRightClickItem(PlayerInteractEvent.RightClickItem event) {
-        if (event.getEntityPlayer() == null || event.getEntityLiving().world.isRemote || event.isCanceled()) return;
+        if (event.getEntityPlayer() == null || event.getEntityPlayer() instanceof FakePlayer || event.getEntityLiving().world.isRemote || event.isCanceled()) return;
 
         EntityPlayer player = event.getEntityPlayer();
         ParticipantInfo pInfo = new ParticipantInfo(player);
@@ -498,7 +499,7 @@ public class EventHandler {
 
     @SubscribeEvent(priority = EventPriority.LOWEST)
     public void onRightClickBlock(PlayerInteractEvent.RightClickBlock event) {
-        if (event.getEntityPlayer() == null || event.getEntityLiving().world.isRemote || event.isCanceled()) return;
+        if (event.getEntityPlayer() == null || event.getEntityPlayer() instanceof FakePlayer || event.getEntityLiving().world.isRemote || event.isCanceled()) return;
 
         EntityPlayer player = event.getEntityPlayer();
         ParticipantInfo pInfo = new ParticipantInfo(player);
@@ -517,7 +518,7 @@ public class EventHandler {
 
     @SubscribeEvent(priority = EventPriority.LOWEST)
     public void onLeftClickBlock(PlayerInteractEvent.LeftClickBlock event) {
-        if (event.getEntityPlayer() == null || event.getEntityLiving().world.isRemote || event.isCanceled()) return;
+        if (event.getEntityPlayer() == null || event.getEntityPlayer() instanceof FakePlayer || event.getEntityLiving().world.isRemote || event.isCanceled()) return;
 
         EntityPlayer player = event.getEntityPlayer();
         ParticipantInfo pInfo = new ParticipantInfo(player);
@@ -537,20 +538,20 @@ public class EventHandler {
     @SubscribeEvent(priority = EventPriority.LOWEST)
     public void onRightClickEmpty(PlayerInteractEvent.RightClickEmpty event) // CLIENT SIDE ONLY EVENT
     {
-        if (event.getEntityPlayer() == null || !event.getEntityLiving().world.isRemote || event.isCanceled()) return;
+        if (event.getEntityPlayer() == null || event.getEntityPlayer() instanceof FakePlayer || !event.getEntityLiving().world.isRemote || event.isCanceled()) return;
         NetTaskInteract.requestInteraction(false, event.getHand() == EnumHand.MAIN_HAND);
     }
 
     @SubscribeEvent(priority = EventPriority.LOWEST)
     public void onLeftClickAir(PlayerInteractEvent.LeftClickEmpty event) // CLIENT SIDE ONLY EVENT
     {
-        if (event.getEntityPlayer() == null || !event.getEntityLiving().world.isRemote || event.isCanceled()) return;
+        if (event.getEntityPlayer() == null || event.getEntityPlayer() instanceof FakePlayer || !event.getEntityLiving().world.isRemote || event.isCanceled()) return;
         NetTaskInteract.requestInteraction(true, true);
     }
 
     @SubscribeEvent(priority = EventPriority.LOWEST)
     public void onEntityAttack(AttackEntityEvent event) {
-        if (event.getEntityPlayer() == null || event.getTarget() == null || event.getEntityPlayer().world.isRemote || event.isCanceled())
+        if (event.getEntityPlayer() == null || event.getEntityPlayer() instanceof FakePlayer || event.getTarget() == null || event.getEntityPlayer().world.isRemote || event.isCanceled())
             return;
 
         EntityPlayer player = event.getEntityPlayer();
@@ -568,7 +569,7 @@ public class EventHandler {
 
     @SubscribeEvent(priority = EventPriority.LOWEST)
     public void onEntityInteract(PlayerInteractEvent.EntityInteract event) {
-        if (event.getEntityPlayer() == null || event.getTarget() == null || event.getEntityPlayer().world.isRemote || event.isCanceled())
+        if (event.getEntityPlayer() == null || event.getEntityPlayer() instanceof FakePlayer || event.getTarget() == null || event.getEntityPlayer().world.isRemote || event.isCanceled())
             return;
 
         EntityPlayer player = event.getEntityPlayer();
@@ -586,7 +587,7 @@ public class EventHandler {
 
     @SubscribeEvent(priority = EventPriority.LOWEST)
     public void onItemCrafted(PlayerEvent.ItemCraftedEvent event) {
-        if (event.player == null || event.player.world.isRemote) return;
+        if (event.player == null || event.player instanceof FakePlayer || event.player.world.isRemote) return;
 
         ParticipantInfo pInfo = new ParticipantInfo(event.player);
 
@@ -602,7 +603,7 @@ public class EventHandler {
 
     @SubscribeEvent(priority = EventPriority.LOWEST)
     public void onItemSmelted(PlayerEvent.ItemSmeltedEvent event) {
-        if (event.player == null || event.player.world.isRemote) return;
+        if (event.player == null || event.player instanceof FakePlayer || event.player.world.isRemote) return;
 
         ParticipantInfo pInfo = new ParticipantInfo(event.player);
 
@@ -618,7 +619,7 @@ public class EventHandler {
 
     @SubscribeEvent(priority = EventPriority.LOWEST)
     public void onItemAnvil(AnvilRepairEvent event) {
-        if (event.getEntityPlayer() == null || event.getEntityPlayer().world.isRemote) return;
+        if (event.getEntityPlayer() == null || event.getEntityPlayer() instanceof FakePlayer || event.getEntityPlayer().world.isRemote) return;
 
         ParticipantInfo pInfo = new ParticipantInfo(event.getEntityPlayer());
         List<DBEntry<IQuest>> actQuest = QuestingAPI.getAPI(ApiReference.QUEST_DB).bulkLookup(pInfo.getSharedQuests());
@@ -633,7 +634,7 @@ public class EventHandler {
 
     @SubscribeEvent(priority = EventPriority.LOWEST)
     public void onEntityKilled(LivingDeathEvent event) {
-        if (event.getSource() == null || !(event.getSource().getTrueSource() instanceof EntityPlayer) || event.getSource().getTrueSource().world.isRemote || event.isCanceled())
+        if (event.getSource() == null || !(event.getSource().getTrueSource() instanceof EntityPlayer) || event.getSource().getTrueSource() instanceof FakePlayer || event.getSource().getTrueSource().world.isRemote || event.isCanceled())
             return;
 
         ParticipantInfo pInfo = new ParticipantInfo((EntityPlayer) event.getSource().getTrueSource());
@@ -664,7 +665,7 @@ public class EventHandler {
 
     @SubscribeEvent(priority = EventPriority.LOWEST)
     public void onBlockBreak(BlockEvent.BreakEvent event) {
-        if (event.getPlayer() == null || event.getPlayer().world.isRemote || event.isCanceled()) return;
+        if (event.getPlayer() == null || event.getPlayer() instanceof FakePlayer || event.getPlayer().world.isRemote || event.isCanceled()) return;
 
         ParticipantInfo pInfo = new ParticipantInfo(event.getPlayer());
 

--- a/src/main/java/betterquesting/handlers/EventHandler.java
+++ b/src/main/java/betterquesting/handlers/EventHandler.java
@@ -483,7 +483,7 @@ public class EventHandler {
 
     @SubscribeEvent(priority = EventPriority.LOWEST)
     public void onRightClickItem(PlayerInteractEvent.RightClickItem event) {
-        if (event.getEntityPlayer() == null || event.getEntityPlayer() instanceof FakePlayer || event.getEntityLiving().world.isRemote || event.isCanceled()) return;
+        if (event.getEntityPlayer() == null || event.getEntityLiving().world.isRemote || event.getEntityPlayer() instanceof FakePlayer || event.isCanceled()) return;
 
         EntityPlayer player = event.getEntityPlayer();
         ParticipantInfo pInfo = new ParticipantInfo(player);
@@ -500,7 +500,7 @@ public class EventHandler {
 
     @SubscribeEvent(priority = EventPriority.LOWEST)
     public void onRightClickBlock(PlayerInteractEvent.RightClickBlock event) {
-        if (event.getEntityPlayer() == null || event.getEntityPlayer() instanceof FakePlayer || event.getEntityLiving().world.isRemote || event.isCanceled()) return;
+        if (event.getEntityPlayer() == null || event.getEntityLiving().world.isRemote || event.getEntityPlayer() instanceof FakePlayer || event.isCanceled()) return;
 
         EntityPlayer player = event.getEntityPlayer();
         ParticipantInfo pInfo = new ParticipantInfo(player);
@@ -519,7 +519,7 @@ public class EventHandler {
 
     @SubscribeEvent(priority = EventPriority.LOWEST)
     public void onLeftClickBlock(PlayerInteractEvent.LeftClickBlock event) {
-        if (event.getEntityPlayer() == null || event.getEntityPlayer() instanceof FakePlayer || event.getEntityLiving().world.isRemote || event.isCanceled()) return;
+        if (event.getEntityPlayer() == null || event.getEntityLiving().world.isRemote || event.getEntityPlayer() instanceof FakePlayer || event.isCanceled()) return;
 
         EntityPlayer player = event.getEntityPlayer();
         ParticipantInfo pInfo = new ParticipantInfo(player);
@@ -539,20 +539,20 @@ public class EventHandler {
     @SubscribeEvent(priority = EventPriority.LOWEST)
     public void onRightClickEmpty(PlayerInteractEvent.RightClickEmpty event) // CLIENT SIDE ONLY EVENT
     {
-        if (event.getEntityPlayer() == null || event.getEntityPlayer() instanceof FakePlayer || !event.getEntityLiving().world.isRemote || event.isCanceled()) return;
+        if (event.getEntityPlayer() == null || !event.getEntityLiving().world.isRemote || event.getEntityPlayer() instanceof FakePlayer || event.isCanceled()) return;
         NetTaskInteract.requestInteraction(false, event.getHand() == EnumHand.MAIN_HAND);
     }
 
     @SubscribeEvent(priority = EventPriority.LOWEST)
     public void onLeftClickAir(PlayerInteractEvent.LeftClickEmpty event) // CLIENT SIDE ONLY EVENT
     {
-        if (event.getEntityPlayer() == null || event.getEntityPlayer() instanceof FakePlayer || !event.getEntityLiving().world.isRemote || event.isCanceled()) return;
+        if (event.getEntityPlayer() == null || !event.getEntityLiving().world.isRemote || event.getEntityPlayer() instanceof FakePlayer || event.isCanceled()) return;
         NetTaskInteract.requestInteraction(true, true);
     }
 
     @SubscribeEvent(priority = EventPriority.LOWEST)
     public void onEntityAttack(AttackEntityEvent event) {
-        if (event.getEntityPlayer() == null || event.getEntityPlayer() instanceof FakePlayer || event.getTarget() == null || event.getEntityPlayer().world.isRemote || event.isCanceled())
+        if (event.getEntityPlayer() == null || event.getEntityPlayer().world.isRemote || event.getEntityPlayer() instanceof FakePlayer || event.getTarget() == null || event.isCanceled())
             return;
 
         EntityPlayer player = event.getEntityPlayer();
@@ -570,7 +570,7 @@ public class EventHandler {
 
     @SubscribeEvent(priority = EventPriority.LOWEST)
     public void onEntityInteract(PlayerInteractEvent.EntityInteract event) {
-        if (event.getEntityPlayer() == null || event.getEntityPlayer() instanceof FakePlayer || event.getTarget() == null || event.getEntityPlayer().world.isRemote || event.isCanceled())
+        if (event.getEntityPlayer() == null || event.getEntityPlayer().world.isRemote || event.getEntityPlayer() instanceof FakePlayer || event.getTarget() == null || event.isCanceled())
             return;
 
         EntityPlayer player = event.getEntityPlayer();
@@ -588,7 +588,7 @@ public class EventHandler {
 
     @SubscribeEvent(priority = EventPriority.LOWEST)
     public void onItemCrafted(PlayerEvent.ItemCraftedEvent event) {
-        if (event.player == null || event.player instanceof FakePlayer || event.player.world.isRemote) return;
+        if (event.player == null || event.player.world.isRemote || event.player instanceof FakePlayer) return;
 
         ParticipantInfo pInfo = new ParticipantInfo(event.player);
 
@@ -604,7 +604,7 @@ public class EventHandler {
 
     @SubscribeEvent(priority = EventPriority.LOWEST)
     public void onItemSmelted(PlayerEvent.ItemSmeltedEvent event) {
-        if (event.player == null || event.player instanceof FakePlayer || event.player.world.isRemote) return;
+        if (event.player == null || event.player.world.isRemote || event.player instanceof FakePlayer) return;
 
         ParticipantInfo pInfo = new ParticipantInfo(event.player);
 
@@ -620,7 +620,7 @@ public class EventHandler {
 
     @SubscribeEvent(priority = EventPriority.LOWEST)
     public void onItemAnvil(AnvilRepairEvent event) {
-        if (event.getEntityPlayer() == null || event.getEntityPlayer() instanceof FakePlayer || event.getEntityPlayer().world.isRemote) return;
+        if (event.getEntityPlayer() == null || event.getEntityPlayer().world.isRemote || event.getEntityPlayer() instanceof FakePlayer) return;
 
         ParticipantInfo pInfo = new ParticipantInfo(event.getEntityPlayer());
         List<DBEntry<IQuest>> actQuest = QuestingAPI.getAPI(ApiReference.QUEST_DB).bulkLookup(pInfo.getSharedQuests());
@@ -635,7 +635,7 @@ public class EventHandler {
 
     @SubscribeEvent(priority = EventPriority.LOWEST)
     public void onEntityKilled(LivingDeathEvent event) {
-        if (event.getSource() == null || !(event.getSource().getTrueSource() instanceof EntityPlayer) || event.getSource().getTrueSource() instanceof FakePlayer || event.getSource().getTrueSource().world.isRemote || event.isCanceled())
+        if (event.getSource() == null || !(event.getSource().getTrueSource() instanceof EntityPlayer) || event.getSource().getTrueSource().world.isRemote || event.getSource().getTrueSource() instanceof FakePlayer || event.isCanceled())
             return;
 
         ParticipantInfo pInfo = new ParticipantInfo((EntityPlayer) event.getSource().getTrueSource());
@@ -666,7 +666,7 @@ public class EventHandler {
 
     @SubscribeEvent(priority = EventPriority.LOWEST)
     public void onBlockBreak(BlockEvent.BreakEvent event) {
-        if (event.getPlayer() == null || event.getPlayer() instanceof FakePlayer || event.getPlayer().world.isRemote || event.isCanceled()) return;
+        if (event.getPlayer() == null || event.getPlayer().world.isRemote || event.getPlayer() instanceof FakePlayer || event.isCanceled()) return;
 
         ParticipantInfo pInfo = new ParticipantInfo(event.getPlayer());
 

--- a/src/main/java/betterquesting/handlers/PlayerContainerListener.java
+++ b/src/main/java/betterquesting/handlers/PlayerContainerListener.java
@@ -50,7 +50,10 @@ public class PlayerContainerListener implements IContainerListener {
 
     @Override
     public void sendSlotContents(@Nonnull Container container, int i, @Nonnull ItemStack itemStack) {
-        updateTasks();
+        // Ignore changes outside of main inventory (e.g. crafting grid and armor)
+        if (i >= 9 && i <= 44) {
+            updateTasks();
+        }
     }
 
     @Override

--- a/src/main/java/betterquesting/handlers/PlayerContainerListener.java
+++ b/src/main/java/betterquesting/handlers/PlayerContainerListener.java
@@ -62,13 +62,6 @@ public class PlayerContainerListener implements IContainerListener {
     }
 
     private void updateTasks() {
-        ParticipantInfo pInfo = new ParticipantInfo(player);
-
-        for (DBEntry<IQuest> entry : QuestingAPI.getAPI(ApiReference.QUEST_DB).bulkLookup(pInfo.getSharedQuests())) {
-            for (DBEntry<ITask> task : entry.getValue().getTasks().getEntries()) {
-                if (task.getValue() instanceof ITaskInventory)
-                    ((ITaskInventory) task.getValue()).onInventoryChange(entry, pInfo);
-            }
-        }
+        EventHandler.schedulePlayerInventoryCheck(player);
     }
 }

--- a/src/main/java/betterquesting/questing/tasks/TaskRetrieval.java
+++ b/src/main/java/betterquesting/questing/tasks/TaskRetrieval.java
@@ -99,16 +99,16 @@ public class TaskRetrieval implements ITaskInventory, IItemTask {
         if (consume) {
             invoList = Collections.singletonList(pInfo.PLAYER.inventory);
         } else {
-            invoList = new ArrayList<>();
+            invoList = new ArrayList<>(pInfo.ACTIVE_PLAYERS.size());
             pInfo.ACTIVE_PLAYERS.forEach((p) -> invoList.add(p.inventory));
         }
 
+        int[] remCounts = new int[progress.size()];
         for (InventoryPlayer invo : invoList) {
             for (int i = 0; i < invo.getSizeInventory(); i++) {
                 ItemStack stack = invo.getStackInSlot(i);
                 if (stack.isEmpty()) continue;
                 // Allows the stack detection to split across multiple requirements. Counts may vary per person
-                int[] remCounts = new int[progress.size()];
                 Arrays.fill(remCounts, stack.getCount());
 
                 for (int j = 0; j < requiredItems.size(); j++) {
@@ -386,7 +386,7 @@ public class TaskRetrieval implements ITaskInventory, IItemTask {
 
     private List<Tuple<UUID, int[]>> getBulkProgress(@Nonnull List<UUID> uuids) {
         if (uuids.size() <= 0) return Collections.emptyList();
-        List<Tuple<UUID, int[]>> list = new ArrayList<>();
+        List<Tuple<UUID, int[]>> list = new ArrayList<>(uuids.size());
         uuids.forEach((key) -> list.add(new Tuple<>(key, getUsersProgress(key))));
         return list;
     }

--- a/src/main/java/betterquesting/questing/tasks/TaskRetrieval.java
+++ b/src/main/java/betterquesting/questing/tasks/TaskRetrieval.java
@@ -74,6 +74,7 @@ public class TaskRetrieval implements ITaskInventory, IItemTask {
     public void detect(ParticipantInfo pInfo, DBEntry<IQuest> quest) {
         if (isComplete(pInfo.UUID)) return;
 
+        // List of (player uuid, [progress per required item])
         final List<Tuple<UUID, int[]>> progress = getBulkProgress(consume ? Collections.singletonList(pInfo.UUID) : pInfo.ALL_UUIDS);
         boolean updated = false;
 
@@ -141,11 +142,15 @@ public class TaskRetrieval implements ITaskInventory, IItemTask {
         }
 
         if (updated) setBulkProgress(progress);
-        checkAndComplete(pInfo, quest, updated);
+        // Reuse progress
+        checkAndComplete(pInfo, quest, updated, progress);
     }
 
     private void checkAndComplete(ParticipantInfo pInfo, DBEntry<IQuest> quest, boolean resync) {
-        final List<Tuple<UUID, int[]>> progress = getBulkProgress(consume ? Collections.singletonList(pInfo.UUID) : pInfo.ALL_UUIDS);
+        checkAndComplete(pInfo, quest, resync, getBulkProgress(consume ? Collections.singletonList(pInfo.UUID) : pInfo.ALL_UUIDS));
+    }
+
+    private void checkAndComplete(ParticipantInfo pInfo, DBEntry<IQuest> quest, boolean resync, List<Tuple<UUID, int[]>> progress) {
         boolean updated = resync;
 
         topLoop:


### PR DESCRIPTION
Bring over some optimizations from GTNH fork, most notably the one that scans player inventories once per tick instead of on every slot change. The difference in performance can best be seen when a player has item(s) in their inventory with rapidly changing NBT values (such as chargeable items).

Changes grabbed from:
- GTNewHorizons/StandardQuestingPack#18
- GTNewHorizons/StandardQuestingPack#10
- GTNewHorizons/BetterQuesting#90

Testing with 4 charging jetpacks, singleplayer, and a large amount of active quests:
Before
![bq_before](https://github.com/CleanroomMC/BetterQuesting/assets/60687097/f5151b71-155e-4590-ae66-a180f47154c6)
After
![bq_after](https://github.com/CleanroomMC/BetterQuesting/assets/60687097/2f4a0310-7362-4f1c-8a00-3e5b548997be)