### PR TITLE
Fix a bug that caused recipes to open in the fluid selection gui

### DIFF
--- a/src/main/java/betterquesting/client/gui2/editors/nbt/GuiFluidSelection.java
+++ b/src/main/java/betterquesting/client/gui2/editors/nbt/GuiFluidSelection.java
@@ -133,7 +133,8 @@ public class GuiFluidSelection extends GuiScreenCanvas implements IPEventListene
             ItemStack tmp = inventory.getStackInSlot(i + 9);
             BigItemStack invoStack = tmp.isEmpty() ? null : new BigItemStack(tmp);
 
-            cvBottomLeft.addPanel(new PanelItemSlot(new GuiTransform(GuiAlign.TOP_LEFT, x, y, slotSize, slotSize, 0), 2, invoStack, true));
+            cvBottomLeft.addPanel(new PanelItemSlot(new GuiTransform(GuiAlign.TOP_LEFT, x, y, slotSize, slotSize, 0), 2, invoStack, true).setCallback(c -> {
+            }));
 
         }
 
@@ -144,7 +145,9 @@ public class GuiFluidSelection extends GuiScreenCanvas implements IPEventListene
             ItemStack tmp = inventory.getStackInSlot(i);
             BigItemStack invoStack = tmp.isEmpty() ? null : new BigItemStack(tmp);
 
-            cvBottomLeft.addPanel(new PanelItemSlot(new GuiTransform(GuiAlign.TOP_LEFT, x, 20 + (3 * slotSize), slotSize, slotSize, 0), 2, invoStack, true));
+            cvBottomLeft.addPanel(new PanelItemSlot(new GuiTransform(GuiAlign.TOP_LEFT, x, 20 + (3 * slotSize), slotSize, slotSize, 0), 2, invoStack, true)
+                    .setCallback(c -> {
+                    }));
         }
 
         // === DIVIDERS ===


### PR DESCRIPTION
Prevent opening the jei recipes if an inventory item is clicked on fluid selection gui.