### PR TITLE
Reduce default values of the quest file

### DIFF
--- a/src/main/java/betterquesting/NBTReplaceUtil.java
+++ b/src/main/java/betterquesting/NBTReplaceUtil.java
@@ -1,0 +1,10 @@
+package betterquesting;
+
+import net.minecraft.nbt.NBTBase;
+
+@Deprecated
+public class NBTReplaceUtil {
+    public static <T extends NBTBase> T replaceStrings(T baseTag, String key, String replace) {
+        return NBTUtil.replaceStrings(baseTag, key, replace);
+    }
+}

--- a/src/main/java/betterquesting/NBTUtil.java
+++ b/src/main/java/betterquesting/NBTUtil.java
@@ -5,7 +5,7 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
 import net.minecraft.nbt.NBTTagString;
 
-public class NBTReplaceUtil {
+public class NBTUtil {
     @SuppressWarnings("unchecked")
     public static <T extends NBTBase> T replaceStrings(T baseTag, String key, String replace) {
         if (baseTag == null) {

--- a/src/main/java/betterquesting/NBTUtil.java
+++ b/src/main/java/betterquesting/NBTUtil.java
@@ -1,5 +1,7 @@
 package betterquesting;
 
+import javax.annotation.Nullable;
+
 import net.minecraft.nbt.NBTBase;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
@@ -31,4 +33,34 @@ public class NBTUtil {
 
         return baseTag; // Either isn't a string or doesn't contain one
     }
+
+    public static boolean getBoolean(NBTTagCompound tag, String key, boolean defaultValue) {
+        return tag.hasKey(key, 99) ? tag.getBoolean(key) : defaultValue;
+    }
+
+    public static int getInteger(NBTTagCompound tag, String key, int defaultValue) {
+        return tag.hasKey(key, 99) ? tag.getInteger(key) : defaultValue;
+    }
+
+    public static float getFloat(NBTTagCompound tag, String key, float defaultValue) {
+        return tag.hasKey(key, 99) ? tag.getFloat(key) : defaultValue;
+    }
+
+    public static String getString(NBTTagCompound tag, String key, String defaultValue) {
+        return tag.hasKey(key, 8) ? tag.getString(key) : defaultValue;
+    }
+
+    public static <E extends Enum<E>> E getEnum(NBTTagCompound tag, String key, Class<E> enumClass, boolean ignoreCases, @Nullable E defaultValue) {
+        if (tag.hasKey(key, 8)) {
+            String valueStr = tag.getString(key);
+            for (E value : enumClass.getEnumConstants()) {
+                boolean equals = ignoreCases ? value.name().equalsIgnoreCase(valueStr) : value.name().equals(valueStr);
+                if (equals) {
+                    return value;
+                }
+            }
+        }
+        return defaultValue;
+    }
+
 }

--- a/src/main/java/betterquesting/NbtBlockType.java
+++ b/src/main/java/betterquesting/NbtBlockType.java
@@ -32,21 +32,25 @@ public class NbtBlockType // TODO: Make a version of this for the base mod and g
         this.tags = new NBTTagCompound();
     }
 
-    public NBTTagCompound writeToNBT(NBTTagCompound json) {
-        json.setString("blockID", b.getRegistryName().toString());
-        json.setInteger("meta", m);
-        json.setTag("nbt", tags);
-        json.setInteger("amount", n);
-        json.setString("oreDict", oreDict);
-        return json;
+    public NBTTagCompound writeToNBT(NBTTagCompound nbt, boolean reduce) {
+        nbt.setString("blockID", b.getRegistryName().toString());
+        if (!reduce || m != -1)
+            nbt.setInteger("meta", m);
+        if (!reduce || !tags.isEmpty())
+            nbt.setTag("nbt", tags);
+        if (!reduce || n != 1)
+            nbt.setInteger("amount", n);
+        if (!reduce || !oreDict.isEmpty())
+            nbt.setString("oreDict", oreDict);
+        return nbt;
     }
 
-    public void readFromNBT(NBTTagCompound json) {
-        b = Block.REGISTRY.getObject(new ResourceLocation(json.getString("blockID")));
-        m = json.getInteger("meta");
-        tags = json.getCompoundTag("nbt");
-        n = json.getInteger("amount");
-        oreDict = json.getString("oreDict");
+    public void readFromNBT(NBTTagCompound nbt) {
+        b = Block.REGISTRY.getObject(new ResourceLocation(nbt.getString("blockID")));
+        m = NBTUtil.getInteger(nbt, "meta", -1);
+        tags = nbt.getCompoundTag("nbt");
+        n = NBTUtil.getInteger(nbt, "amount", 1);
+        oreDict = NBTUtil.getString(nbt, "oreDict", "");
     }
 
     public BigItemStack getItemStack() {

--- a/src/main/java/betterquesting/NbtBlockType.java
+++ b/src/main/java/betterquesting/NbtBlockType.java
@@ -32,6 +32,11 @@ public class NbtBlockType // TODO: Make a version of this for the base mod and g
         this.tags = new NBTTagCompound();
     }
 
+    @Deprecated
+    public NBTTagCompound writeToNBT(NBTTagCompound nbt) {
+        return writeToNBT(nbt, false);
+    }
+
     public NBTTagCompound writeToNBT(NBTTagCompound nbt, boolean reduce) {
         nbt.setString("blockID", b.getRegistryName().toString());
         if (!reduce || m != -1)

--- a/src/main/java/betterquesting/ScoreBQ.java
+++ b/src/main/java/betterquesting/ScoreBQ.java
@@ -28,7 +28,7 @@ public class ScoreBQ implements INBTPartial<NBTTagList, UUID> {
     }
 
     @Override
-    public synchronized NBTTagList writeToNBT(NBTTagList nbt, @Nullable List<UUID> subset) {
+    public synchronized NBTTagList writeToNBT(NBTTagList nbt, @Nullable List<UUID> subset, boolean reduce) {
         for (Entry<UUID, Integer> entry : playerScores.entrySet()) {
             if (subset != null && !subset.contains(entry.getKey())) continue;
             NBTTagCompound jObj = new NBTTagCompound();

--- a/src/main/java/betterquesting/ScoreBQ.java
+++ b/src/main/java/betterquesting/ScoreBQ.java
@@ -27,6 +27,12 @@ public class ScoreBQ implements INBTPartial<NBTTagList, UUID> {
         return playerScores.containsKey(uuid);
     }
 
+    @Deprecated
+    @Override
+    public synchronized NBTTagList writeToNBT(NBTTagList nbt, @Nullable List<UUID> subset) {
+        return writeToNBT(nbt, subset, false);
+    }
+
     @Override
     public synchronized NBTTagList writeToNBT(NBTTagList nbt, @Nullable List<UUID> subset, boolean reduce) {
         for (Entry<UUID, Integer> entry : playerScores.entrySet()) {

--- a/src/main/java/betterquesting/ScoreboardBQ.java
+++ b/src/main/java/betterquesting/ScoreboardBQ.java
@@ -37,11 +37,11 @@ public class ScoreboardBQ implements INBTPartial<NBTTagList, UUID> {
     }
 
     @Override
-    public synchronized NBTTagList writeToNBT(NBTTagList nbt, @Nullable List<UUID> users) {
+    public synchronized NBTTagList writeToNBT(NBTTagList nbt, @Nullable List<UUID> users, boolean reduce) {
         for (Entry<String, ScoreBQ> entry : objectives.entrySet()) {
             NBTTagCompound jObj = new NBTTagCompound();
             jObj.setString("name", entry.getKey());
-            jObj.setTag("scores", entry.getValue().writeToNBT(new NBTTagList(), users));
+            jObj.setTag("scores", entry.getValue().writeToNBT(new NBTTagList(), users, reduce));
             nbt.appendTag(jObj);
         }
 

--- a/src/main/java/betterquesting/ScoreboardBQ.java
+++ b/src/main/java/betterquesting/ScoreboardBQ.java
@@ -36,6 +36,12 @@ public class ScoreboardBQ implements INBTPartial<NBTTagList, UUID> {
         }
     }
 
+    @Deprecated
+    @Override
+    public synchronized NBTTagList writeToNBT(NBTTagList nbt, @Nullable List<UUID> users) {
+        return writeToNBT(nbt, users, false);
+    }
+
     @Override
     public synchronized NBTTagList writeToNBT(NBTTagList nbt, @Nullable List<UUID> users, boolean reduce) {
         for (Entry<String, ScoreBQ> entry : objectives.entrySet()) {

--- a/src/main/java/betterquesting/api/placeholders/rewards/RewardPlaceholder.java
+++ b/src/main/java/betterquesting/api/placeholders/rewards/RewardPlaceholder.java
@@ -22,7 +22,7 @@ public class RewardPlaceholder implements IReward {
     }
 
     @Override
-    public NBTTagCompound writeToNBT(NBTTagCompound nbt) {
+    public NBTTagCompound writeToNBT(NBTTagCompound nbt, boolean reduce) {
         nbt.setTag("orig_data", nbtSaved);
 
         return nbt;

--- a/src/main/java/betterquesting/api/placeholders/rewards/RewardPlaceholder.java
+++ b/src/main/java/betterquesting/api/placeholders/rewards/RewardPlaceholder.java
@@ -21,6 +21,12 @@ public class RewardPlaceholder implements IReward {
         return nbtSaved;
     }
 
+    @Deprecated
+    @Override
+    public NBTTagCompound writeToNBT(NBTTagCompound nbt) {
+        return writeToNBT(nbt, false);
+    }
+
     @Override
     public NBTTagCompound writeToNBT(NBTTagCompound nbt, boolean reduce) {
         nbt.setTag("orig_data", nbtSaved);

--- a/src/main/java/betterquesting/api/placeholders/tasks/TaskPlaceholder.java
+++ b/src/main/java/betterquesting/api/placeholders/tasks/TaskPlaceholder.java
@@ -33,6 +33,12 @@ public class TaskPlaceholder implements ITask {
         return nbtData.getCompoundTag("orig_prog");
     }
 
+    @Deprecated
+    @Override
+    public NBTTagCompound writeToNBT(NBTTagCompound nbt) {
+        return writeToNBT(nbt, false);
+    }
+
     @Override
     public NBTTagCompound writeToNBT(NBTTagCompound nbt, boolean reduce) {
         nbt.setTag("orig_data", nbtData.getCompoundTag("orig_data"));

--- a/src/main/java/betterquesting/api/placeholders/tasks/TaskPlaceholder.java
+++ b/src/main/java/betterquesting/api/placeholders/tasks/TaskPlaceholder.java
@@ -34,7 +34,7 @@ public class TaskPlaceholder implements ITask {
     }
 
     @Override
-    public NBTTagCompound writeToNBT(NBTTagCompound nbt) {
+    public NBTTagCompound writeToNBT(NBTTagCompound nbt, boolean reduce) {
         nbt.setTag("orig_data", nbtData.getCompoundTag("orig_data"));
         return nbt;
     }

--- a/src/main/java/betterquesting/api/properties/IPropertyReducible.java
+++ b/src/main/java/betterquesting/api/properties/IPropertyReducible.java
@@ -1,0 +1,9 @@
+package betterquesting.api.properties;
+
+import net.minecraft.nbt.NBTBase;
+
+public interface IPropertyReducible<T> extends IPropertyType<T> {
+
+    NBTBase reduceNBT(NBTBase nbt);
+
+}

--- a/src/main/java/betterquesting/api/properties/basic/PropertyTypeItemStack.java
+++ b/src/main/java/betterquesting/api/properties/basic/PropertyTypeItemStack.java
@@ -1,12 +1,14 @@
 package betterquesting.api.properties.basic;
 
+import betterquesting.api.properties.IPropertyReducible;
 import betterquesting.api.utils.BigItemStack;
 import betterquesting.api.utils.JsonHelper;
 import net.minecraft.nbt.NBTBase;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.ResourceLocation;
 
-public class PropertyTypeItemStack extends PropertyTypeBase<BigItemStack> {
+public class PropertyTypeItemStack extends PropertyTypeBase<BigItemStack> implements IPropertyReducible<BigItemStack> {
+
     public PropertyTypeItemStack(ResourceLocation key, BigItemStack def) {
         super(key, def);
     }
@@ -25,11 +27,23 @@ public class PropertyTypeItemStack extends PropertyTypeBase<BigItemStack> {
         NBTTagCompound nbt = new NBTTagCompound();
 
         if (value == null || value.getBaseStack() == null) {
-            getDefault().writeToNBT(nbt);
+            getDefault().writeToNBT(nbt, false);
         } else {
-            value.writeToNBT(nbt);
+            value.writeToNBT(nbt, false);
         }
 
         return nbt;
     }
+
+    @Override
+    public NBTBase reduceNBT(NBTBase nbt) {
+        BigItemStack value;
+        if (nbt == null || nbt.getId() != 10) {
+            value = this.getDefault();
+        } else {
+            value = JsonHelper.JsonToItemStack((NBTTagCompound) nbt);
+        }
+        return value.writeToNBT(new NBTTagCompound(), true);
+    }
+
 }

--- a/src/main/java/betterquesting/api/utils/BigItemStack.java
+++ b/src/main/java/betterquesting/api/utils/BigItemStack.java
@@ -1,5 +1,6 @@
 package betterquesting.api.utils;
 
+import betterquesting.NBTUtil;
 import net.minecraft.block.Block;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
@@ -144,16 +145,22 @@ public class BigItemStack {
         if (tags.hasKey("id", 99)) {
             itemNBT.setString("id", "" + tags.getShort("id"));
         }
-        this.stackSize = tags.getInteger("Count");
+        this.stackSize = NBTUtil.getInteger(tags, "Count", 1);
         this.setOreDict(tags.getString("OreDict"));
         this.baseStack = new ItemStack(itemNBT); // Minecraft does the ID conversions for me
         if (tags.getShort("Damage") < 0) this.baseStack.setItemDamage(OreDictionary.WILDCARD_VALUE);
     }
 
-    public NBTTagCompound writeToNBT(NBTTagCompound tags) {
+    public NBTTagCompound writeToNBT(NBTTagCompound tags, boolean reduce) {
         baseStack.writeToNBT(tags);
-        tags.setInteger("Count", stackSize);
-        tags.setString("OreDict", oreDict);
+        if (reduce && stackSize == 1)
+            tags.removeTag("Count");
+        else
+            tags.setInteger("Count", stackSize);
+        if (!reduce || !oreDict.isEmpty())
+            tags.setString("OreDict", oreDict);
+        if (reduce && tags.getShort("Damage") == 0)
+            tags.removeTag("Damage");
         return tags;
     }
 }

--- a/src/main/java/betterquesting/api/utils/BigItemStack.java
+++ b/src/main/java/betterquesting/api/utils/BigItemStack.java
@@ -151,6 +151,11 @@ public class BigItemStack {
         if (tags.getShort("Damage") < 0) this.baseStack.setItemDamage(OreDictionary.WILDCARD_VALUE);
     }
 
+    @Deprecated
+    public NBTTagCompound writeToNBT(NBTTagCompound tags) {
+        return writeToNBT(tags, false);
+    }
+
     public NBTTagCompound writeToNBT(NBTTagCompound tags, boolean reduce) {
         baseStack.writeToNBT(tags);
         if (reduce && stackSize == 1)

--- a/src/main/java/betterquesting/api/utils/JsonHelper.java
+++ b/src/main/java/betterquesting/api/utils/JsonHelper.java
@@ -1,5 +1,6 @@
 package betterquesting.api.utils;
 
+import betterquesting.NBTUtil;
 import betterquesting.api.api.QuestingAPI;
 import betterquesting.api.placeholders.ItemPlaceholder;
 import betterquesting.api.placeholders.PlaceholderConverter;
@@ -156,7 +157,7 @@ public class JsonHelper {
 				QuestingAPI.getLogger().error("An error occured while saving JSON to file (Directory setup):", e);
 				return null;
 			}
-			
+
 			// NOTE: These are now split due to an edge case in the previous implementation where resource leaking can occur should the outer constructor fail
 			try (FileOutputStream fos = new FileOutputStream(tmp);
 				 OutputStreamWriter fw = new OutputStreamWriter(fos, StandardCharsets.UTF_8);
@@ -168,7 +169,7 @@ public class JsonHelper {
 				QuestingAPI.getLogger().error("An error occurred while saving JSON to file (File write):", e);
 				return null;
 			}
-			
+
 			// NOTE: These are now split due to an edge case in the previous implementation where resource leaking can occur should the outer constructor fail
 			try(FileInputStream fis = new FileInputStream(tmp); InputStreamReader fr = new InputStreamReader(fis, StandardCharsets.UTF_8))
             {
@@ -179,7 +180,7 @@ public class JsonHelper {
 				QuestingAPI.getLogger().error("An error occured while saving JSON to file (Validation check):", e);
 				return null;
             }
-			
+
 			try
             {
                 if(file.exists()) file.delete();
@@ -278,15 +279,26 @@ public class JsonHelper {
      */
     public static BigItemStack JsonToItemStack(NBTTagCompound nbt) {
         Item preCheck = Item.getByNameOrId(nbt.hasKey("id", 99) ? "" + nbt.getShort("id") : nbt.getString("id"));
-        if (preCheck != null && preCheck != ItemPlaceholder.placeholder) return new BigItemStack(nbt);
-        return PlaceholderConverter.convertItem(preCheck, nbt.getString("id"), nbt.getInteger("Count"), nbt.getShort("Damage"), nbt.getString("OreDict"), !nbt.hasKey("tag", 10) ? null : nbt.getCompoundTag("tag"));
+        if (preCheck != null && preCheck != ItemPlaceholder.placeholder)
+            return new BigItemStack(nbt);
+        return PlaceholderConverter.convertItem(preCheck,
+                                                nbt.getString("id"),
+                                                NBTUtil.getInteger(nbt, "Count", 1),
+                                                nbt.getShort("Damage"),
+                                                nbt.getString("OreDict"),
+                                                !nbt.hasKey("tag", 10) ? null : nbt.getCompoundTag("tag"));
     }
 
     /**
      * Use this for quests instead of converter NBT because this doesn't use ID numbers
      */
     public static NBTTagCompound ItemStackToJson(BigItemStack stack, NBTTagCompound nbt) {
-        if (stack != null) stack.writeToNBT(nbt);
+        return ItemStackToJson(stack, nbt, false);
+    }
+
+    public static NBTTagCompound ItemStackToJson(BigItemStack stack, NBTTagCompound nbt, boolean reduce) {
+        if (stack != null)
+            stack.writeToNBT(nbt, reduce);
         return nbt;
     }
 

--- a/src/main/java/betterquesting/api2/client/gui/controls/PanelButton.java
+++ b/src/main/java/betterquesting/api2/client/gui/controls/PanelButton.java
@@ -260,7 +260,7 @@ public class PanelButton implements IPanelButton, IGuiPanel, INBTSaveLoad<NBTTag
     }
 
     @Override
-    public NBTTagCompound writeToNBT(NBTTagCompound nbt) {
+    public NBTTagCompound writeToNBT(NBTTagCompound nbt, boolean reduce) {
         // TODO: Fix me
         return nbt;
     }

--- a/src/main/java/betterquesting/api2/client/gui/controls/PanelButton.java
+++ b/src/main/java/betterquesting/api2/client/gui/controls/PanelButton.java
@@ -259,6 +259,12 @@ public class PanelButton implements IPanelButton, IGuiPanel, INBTSaveLoad<NBTTag
     public void onRightButtonClick() {
     }
 
+    @Deprecated
+    @Override
+    public NBTTagCompound writeToNBT(NBTTagCompound nbt) {
+        return writeToNBT(nbt, false);
+    }
+
     @Override
     public NBTTagCompound writeToNBT(NBTTagCompound nbt, boolean reduce) {
         // TODO: Fix me

--- a/src/main/java/betterquesting/api2/storage/INBTPartial.java
+++ b/src/main/java/betterquesting/api2/storage/INBTPartial.java
@@ -7,7 +7,12 @@ import java.util.List;
 
 // Used when the base data set can safely be split. Can be used in place of INBTSaveLoad
 public interface INBTPartial<T extends NBTBase, K> {
-    T writeToNBT(T nbt, @Nullable List<K> subset, boolean reduce);
+    @Deprecated
+    T writeToNBT(T nbt, @Nullable List<K> subset);
+
+    default T writeToNBT(T nbt, @Nullable List<K> subset, boolean reduce) {
+        return writeToNBT(nbt, subset);
+    }
 
     void readFromNBT(T nbt, boolean merge);
 }

--- a/src/main/java/betterquesting/api2/storage/INBTPartial.java
+++ b/src/main/java/betterquesting/api2/storage/INBTPartial.java
@@ -7,7 +7,7 @@ import java.util.List;
 
 // Used when the base data set can safely be split. Can be used in place of INBTSaveLoad
 public interface INBTPartial<T extends NBTBase, K> {
-    T writeToNBT(T nbt, @Nullable List<K> subset);
+    T writeToNBT(T nbt, @Nullable List<K> subset, boolean reduce);
 
     void readFromNBT(T nbt, boolean merge);
 }

--- a/src/main/java/betterquesting/api2/storage/INBTSaveLoad.java
+++ b/src/main/java/betterquesting/api2/storage/INBTSaveLoad.java
@@ -4,7 +4,12 @@ import net.minecraft.nbt.NBTBase;
 
 // TODO: Replace usage with INBTSerializable?
 public interface INBTSaveLoad<T extends NBTBase> {
-    T writeToNBT(T nbt, boolean reduce);
+    @Deprecated
+    T writeToNBT(T nbt);
+
+    default T writeToNBT(T nbt, boolean reduce){
+        return writeToNBT(nbt);
+    }
 
     void readFromNBT(T nbt);
 }

--- a/src/main/java/betterquesting/api2/storage/INBTSaveLoad.java
+++ b/src/main/java/betterquesting/api2/storage/INBTSaveLoad.java
@@ -4,7 +4,7 @@ import net.minecraft.nbt.NBTBase;
 
 // TODO: Replace usage with INBTSerializable?
 public interface INBTSaveLoad<T extends NBTBase> {
-    T writeToNBT(T nbt);
+    T writeToNBT(T nbt, boolean reduce);
 
     void readFromNBT(T nbt);
 }

--- a/src/main/java/betterquesting/api2/supporter/SupporterDB.java
+++ b/src/main/java/betterquesting/api2/supporter/SupporterDB.java
@@ -45,8 +45,8 @@ public class SupporterDB implements INBTSaveLoad<NBTTagCompound> {
 
     @Nonnull
     @Override
-    public synchronized NBTTagCompound writeToNBT(@Nonnull NBTTagCompound nbt) {
-        mapDB.forEach((key, value) -> nbt.setTag(key.toString(), value.writeToNBT(new NBTTagCompound())));
+    public synchronized NBTTagCompound writeToNBT(@Nonnull NBTTagCompound nbt, boolean reduce) {
+        mapDB.forEach((key, value) -> nbt.setTag(key.toString(), value.writeToNBT(new NBTTagCompound(), reduce)));
         return nbt;
     }
 

--- a/src/main/java/betterquesting/api2/supporter/SupporterDB.java
+++ b/src/main/java/betterquesting/api2/supporter/SupporterDB.java
@@ -31,7 +31,7 @@ public class SupporterDB implements INBTSaveLoad<NBTTagCompound> {
     public synchronized SupporterEntry getValue(@Nonnull UUID playerID) {
         return mapDB.get(playerID);
     }
-    
+
     /*@Nullable
     public UUID getKey(@Nonnull SupporterEntry entry)
     {
@@ -39,9 +39,16 @@ public class SupporterDB implements INBTSaveLoad<NBTTagCompound> {
         {
             if(pair.getValue() == entry) return pair.getKey();
         }
-        
+
         return null;
     }*/
+
+    @Deprecated
+    @Nonnull
+    @Override
+    public synchronized NBTTagCompound writeToNBT(@Nonnull NBTTagCompound nbt) {
+        return writeToNBT(nbt, false);
+    }
 
     @Nonnull
     @Override

--- a/src/main/java/betterquesting/api2/supporter/SupporterEntry.java
+++ b/src/main/java/betterquesting/api2/supporter/SupporterEntry.java
@@ -14,6 +14,12 @@ public class SupporterEntry implements INBTSaveLoad<NBTTagCompound> {
         return this.services.computeIfAbsent(token, (t) -> new HashMap<>());
     }
 
+    @Deprecated
+    @Override
+    public NBTTagCompound writeToNBT(NBTTagCompound nbt) {
+        return writeToNBT(nbt, false);
+    }
+
     @Override
     public NBTTagCompound writeToNBT(NBTTagCompound nbt, boolean reduce) {
         return nbt;

--- a/src/main/java/betterquesting/api2/supporter/SupporterEntry.java
+++ b/src/main/java/betterquesting/api2/supporter/SupporterEntry.java
@@ -15,7 +15,7 @@ public class SupporterEntry implements INBTSaveLoad<NBTTagCompound> {
     }
 
     @Override
-    public NBTTagCompound writeToNBT(NBTTagCompound nbt) {
+    public NBTTagCompound writeToNBT(NBTTagCompound nbt, boolean reduce) {
         return nbt;
     }
 

--- a/src/main/java/betterquesting/client/gui2/GuiHome.java
+++ b/src/main/java/betterquesting/client/gui2/GuiHome.java
@@ -172,7 +172,7 @@ public class GuiHome extends GuiScreenCanvas {
             mc.displayGuiScreen(new GuiThemes(this));
         } else if (btn.getButtonID() == 4) // Editor
         {
-            mc.displayGuiScreen(new GuiNbtEditor(this, QuestSettings.INSTANCE.writeToNBT(new NBTTagCompound()), (value) ->
+            mc.displayGuiScreen(new GuiNbtEditor(this, QuestSettings.INSTANCE.writeToNBT(new NBTTagCompound(), false), (value) ->
             {
                 QuestSettings.INSTANCE.readFromNBT(value);
                 NetSettingSync.requestEdit();

--- a/src/main/java/betterquesting/client/gui2/editors/GuiEditLootEntry.java
+++ b/src/main/java/betterquesting/client/gui2/editors/GuiEditLootEntry.java
@@ -113,7 +113,7 @@ public class GuiEditLootEntry extends GuiScreenCanvas {
             @Override
             public void onButtonClick() {
                 if (selEntry != null) {
-                    final NBTTagCompound eTag = selEntry.writeToNBT(new NBTTagCompound());
+                    final NBTTagCompound eTag = selEntry.writeToNBT(new NBTTagCompound(), false);
                     mc.displayGuiScreen(QuestingAPI.getAPI(ApiReference.THEME_REG).getGui(PresetGUIs.EDIT_NBT, new GArgsNBT<>(screenRef, eTag.getTagList("items", 10), value -> {
                         LootGroup lg = LootRegistry.INSTANCE.getValue(groupID);
                         LootGroup.LootEntry le = lg == null ? null : lg.getValue(selectedID);
@@ -211,6 +211,6 @@ public class GuiEditLootEntry extends GuiScreenCanvas {
     }
 
     private void sendChanges() {
-        NetLootImport.importLoot(LootRegistry.INSTANCE.writeToNBT(new NBTTagCompound(), null));
+        NetLootImport.importLoot(LootRegistry.INSTANCE.writeToNBT(new NBTTagCompound(), null, true));
     }
 }

--- a/src/main/java/betterquesting/client/gui2/editors/GuiEditLootGroup.java
+++ b/src/main/java/betterquesting/client/gui2/editors/GuiEditLootGroup.java
@@ -205,6 +205,6 @@ public class GuiEditLootGroup extends GuiScreenCanvas implements IVolatileScreen
     }
 
     private void SendChanges() {
-        NetLootImport.importLoot(LootRegistry.INSTANCE.writeToNBT(new NBTTagCompound(), null));
+        NetLootImport.importLoot(LootRegistry.INSTANCE.writeToNBT(new NBTTagCompound(), null, true));
     }
 }

--- a/src/main/java/betterquesting/client/gui2/editors/GuiPrerequisiteEditor.java
+++ b/src/main/java/betterquesting/client/gui2/editors/GuiPrerequisiteEditor.java
@@ -308,7 +308,7 @@ public class GuiPrerequisiteEditor extends GuiScreenCanvas implements IPEventLis
         NBTTagList dataList = new NBTTagList();
         NBTTagCompound entry = new NBTTagCompound();
         entry.setInteger("questID", questID);
-        entry.setTag("config", quest.writeToNBT(new NBTTagCompound()));
+        entry.setTag("config", quest.writeToNBT(new NBTTagCompound(), true));
         dataList.appendTag(entry);
         payload.setTag("data", dataList);
         payload.setInteger("action", 0);

--- a/src/main/java/betterquesting/client/gui2/editors/GuiQuestEditor.java
+++ b/src/main/java/betterquesting/client/gui2/editors/GuiQuestEditor.java
@@ -194,7 +194,7 @@ public class GuiQuestEditor extends GuiScreenCanvas implements IPEventListener, 
             }
             case 4: // Advanced
             {
-                mc.displayGuiScreen(new GuiNbtEditor(this, quest.writeToNBT(new NBTTagCompound()), value -> {
+                mc.displayGuiScreen(new GuiNbtEditor(this, quest.writeToNBT(new NBTTagCompound(), false), value -> {
                     quest.readFromNBT(value);
                     SendChanges();
                 }));
@@ -239,7 +239,7 @@ public class GuiQuestEditor extends GuiScreenCanvas implements IPEventListener, 
         NBTTagList dataList = new NBTTagList();
         NBTTagCompound entry = new NBTTagCompound();
         entry.setInteger("questID", questID);
-        entry.setTag("config", quest.writeToNBT(new NBTTagCompound()));
+        entry.setTag("config", quest.writeToNBT(new NBTTagCompound(), true));
         dataList.appendTag(entry);
         payload.setTag("data", dataList);
         payload.setInteger("action", 0);

--- a/src/main/java/betterquesting/client/gui2/editors/GuiQuestLineAddRemove.java
+++ b/src/main/java/betterquesting/client/gui2/editors/GuiQuestLineAddRemove.java
@@ -267,7 +267,7 @@ public class GuiQuestLineAddRemove extends GuiScreenCanvas implements IPEventLis
         NBTTagList dataList = new NBTTagList();
         NBTTagCompound entry = new NBTTagCompound();
         entry.setInteger("chapterID", lineID);
-        entry.setTag("config", questLine.writeToNBT(new NBTTagCompound(), null));
+        entry.setTag("config", questLine.writeToNBT(new NBTTagCompound(), null, true));
         dataList.appendTag(entry);
         payload.setTag("data", dataList);
         payload.setInteger("action", 0);

--- a/src/main/java/betterquesting/client/gui2/editors/GuiQuestLinesEditor.java
+++ b/src/main/java/betterquesting/client/gui2/editors/GuiQuestLinesEditor.java
@@ -320,7 +320,7 @@ public class GuiQuestLinesEditor extends GuiScreenCanvas implements IPEventListe
         NBTTagList dataList = new NBTTagList();
         NBTTagCompound entry = new NBTTagCompound();
         entry.setInteger("chapterID", chapter.getID());
-        entry.setTag("config", chapter.getValue().writeToNBT(new NBTTagCompound(), null));
+        entry.setTag("config", chapter.getValue().writeToNBT(new NBTTagCompound(), null, true));
         dataList.appendTag(entry);
         payload.setTag("data", dataList);
         payload.setInteger("action", 0);

--- a/src/main/java/betterquesting/client/gui2/editors/GuiRewardEditor.java
+++ b/src/main/java/betterquesting/client/gui2/editors/GuiRewardEditor.java
@@ -172,7 +172,7 @@ public class GuiRewardEditor extends GuiScreenCanvas implements IPEventListener,
             if (editor != null) {
                 mc.displayGuiScreen(editor);
             } else {
-                mc.displayGuiScreen(new GuiNbtEditor(this, reward.writeToNBT(new NBTTagCompound()), value -> {
+                mc.displayGuiScreen(new GuiNbtEditor(this, reward.writeToNBT(new NBTTagCompound(), false), value -> {
                     reward.readFromNBT(value);
                     SendChanges();
                 }));
@@ -198,7 +198,7 @@ public class GuiRewardEditor extends GuiScreenCanvas implements IPEventListener,
         NBTTagList dataList = new NBTTagList();
         NBTTagCompound entry = new NBTTagCompound();
         entry.setInteger("questID", qID);
-        entry.setTag("config", quest.writeToNBT(new NBTTagCompound()));
+        entry.setTag("config", quest.writeToNBT(new NBTTagCompound(), true));
         dataList.appendTag(entry);
         payload.setTag("data", dataList);
         payload.setInteger("action", 0);

--- a/src/main/java/betterquesting/client/gui2/editors/GuiTaskEditor.java
+++ b/src/main/java/betterquesting/client/gui2/editors/GuiTaskEditor.java
@@ -172,7 +172,7 @@ public class GuiTaskEditor extends GuiScreenCanvas implements IPEventListener, I
             if (editor != null) {
                 mc.displayGuiScreen(editor);
             } else {
-                mc.displayGuiScreen(new GuiNbtEditor(this, task.writeToNBT(new NBTTagCompound()), value -> {
+                mc.displayGuiScreen(new GuiNbtEditor(this, task.writeToNBT(new NBTTagCompound(), false), value -> {
                     task.readFromNBT(value);
                     SendChanges();
                 }));
@@ -198,7 +198,7 @@ public class GuiTaskEditor extends GuiScreenCanvas implements IPEventListener, I
         NBTTagList dataList = new NBTTagList();
         NBTTagCompound entry = new NBTTagCompound();
         entry.setInteger("questID", qID);
-        entry.setTag("config", quest.writeToNBT(new NBTTagCompound()));
+        entry.setTag("config", quest.writeToNBT(new NBTTagCompound(), true));
         dataList.appendTag(entry);
         payload.setTag("data", dataList);
         payload.setInteger("action", 0);

--- a/src/main/java/betterquesting/client/gui2/editors/TextEditorFrame.java
+++ b/src/main/java/betterquesting/client/gui2/editors/TextEditorFrame.java
@@ -145,7 +145,7 @@ public class TextEditorFrame extends JFrame {
         NBTTagList dataList = new NBTTagList();
         NBTTagCompound entry = new NBTTagCompound();
         entry.setInteger("questID", questID);
-        entry.setTag("config", quest.writeToNBT(new NBTTagCompound()));
+        entry.setTag("config", quest.writeToNBT(new NBTTagCompound(), true));
         dataList.appendTag(entry);
         payload.setTag("data", dataList);
         payload.setInteger("action", 0);

--- a/src/main/java/betterquesting/client/gui2/editors/tasks/GuiEditTaskAdvancement.java
+++ b/src/main/java/betterquesting/client/gui2/editors/tasks/GuiEditTaskAdvancement.java
@@ -121,7 +121,7 @@ public class GuiEditTaskAdvancement extends GuiScreenCanvas implements IVolatile
         NBTTagList dataList = new NBTTagList();
         NBTTagCompound entry = new NBTTagCompound();
         entry.setInteger("questID", quest.getID());
-        entry.setTag("config", quest.getValue().writeToNBT(new NBTTagCompound()));
+        entry.setTag("config", quest.getValue().writeToNBT(new NBTTagCompound(), true));
         dataList.appendTag(entry);
         payload.setTag("data", dataList);
         payload.setInteger("action", 0); // Action: Update data

--- a/src/main/java/betterquesting/client/gui2/editors/tasks/GuiEditTaskHunt.java
+++ b/src/main/java/betterquesting/client/gui2/editors/tasks/GuiEditTaskHunt.java
@@ -89,7 +89,8 @@ public class GuiEditTaskHunt extends GuiScreenCanvas implements IVolatileScreen 
         cvBackground.addPanel(new PanelButton(new GuiTransform(GuiAlign.MID_CENTER, -100, 32, 200, 16, 0), -1, QuestTranslation.translate("betterquesting.btn.advanced")) {
             @Override
             public void onButtonClick() {
-                mc.displayGuiScreen(QuestingAPI.getAPI(ApiReference.THEME_REG).getGui(PresetGUIs.EDIT_NBT, new GArgsNBT<>(screenRef, task.writeToNBT(new NBTTagCompound()), task::readFromNBT, null)));
+                mc.displayGuiScreen(QuestingAPI.getAPI(ApiReference.THEME_REG)
+                        .getGui(PresetGUIs.EDIT_NBT, new GArgsNBT<>(screenRef, task.writeToNBT(new NBTTagCompound(), false), task::readFromNBT, null)));
             }
         });
 
@@ -109,7 +110,7 @@ public class GuiEditTaskHunt extends GuiScreenCanvas implements IVolatileScreen 
         NBTTagList dataList = new NBTTagList();
         NBTTagCompound entry = new NBTTagCompound();
         entry.setInteger("questID", quest.getID());
-        entry.setTag("config", quest.getValue().writeToNBT(new NBTTagCompound()));
+        entry.setTag("config", quest.getValue().writeToNBT(new NBTTagCompound(), true));
         dataList.appendTag(entry);
         payload.setTag("data", dataList);
         payload.setInteger("action", 0); // Action: Update data

--- a/src/main/java/betterquesting/client/gui2/editors/tasks/GuiEditTaskMeeting.java
+++ b/src/main/java/betterquesting/client/gui2/editors/tasks/GuiEditTaskMeeting.java
@@ -87,7 +87,8 @@ public class GuiEditTaskMeeting extends GuiScreenCanvas implements IVolatileScre
         cvBackground.addPanel(new PanelButton(new GuiTransform(GuiAlign.MID_CENTER, -100, 32, 200, 16, 0), -1, QuestTranslation.translate("betterquesting.btn.advanced")) {
             @Override
             public void onButtonClick() {
-                mc.displayGuiScreen(QuestingAPI.getAPI(ApiReference.THEME_REG).getGui(PresetGUIs.EDIT_NBT, new GArgsNBT<>(screenRef, task.writeToNBT(new NBTTagCompound()), task::readFromNBT, null)));
+                mc.displayGuiScreen(QuestingAPI.getAPI(ApiReference.THEME_REG)
+                        .getGui(PresetGUIs.EDIT_NBT, new GArgsNBT<>(screenRef, task.writeToNBT(new NBTTagCompound(), false), task::readFromNBT, null)));
             }
         });
 
@@ -107,7 +108,7 @@ public class GuiEditTaskMeeting extends GuiScreenCanvas implements IVolatileScre
         NBTTagList dataList = new NBTTagList();
         NBTTagCompound entry = new NBTTagCompound();
         entry.setInteger("questID", quest.getID());
-        entry.setTag("config", quest.getValue().writeToNBT(new NBTTagCompound()));
+        entry.setTag("config", quest.getValue().writeToNBT(new NBTTagCompound(), true));
         dataList.appendTag(entry);
         payload.setTag("data", dataList);
         payload.setInteger("action", 0); // Action: Update data

--- a/src/main/java/betterquesting/client/gui2/editors/tasks/GuiEditTaskScoreboard.java
+++ b/src/main/java/betterquesting/client/gui2/editors/tasks/GuiEditTaskScoreboard.java
@@ -75,7 +75,8 @@ public class GuiEditTaskScoreboard extends GuiScreenCanvas {
         cvBackground.addPanel(new PanelButton(new GuiTransform(GuiAlign.MID_CENTER, -100, 16, 200, 16, 0), -1, QuestTranslation.translate("betterquesting.btn.advanced")) {
             @Override
             public void onButtonClick() {
-                mc.displayGuiScreen(QuestingAPI.getAPI(ApiReference.THEME_REG).getGui(PresetGUIs.EDIT_NBT, new GArgsNBT<>(screenRef, task.writeToNBT(new NBTTagCompound()), task::readFromNBT, null)));
+                mc.displayGuiScreen(QuestingAPI.getAPI(ApiReference.THEME_REG)
+                        .getGui(PresetGUIs.EDIT_NBT, new GArgsNBT<>(screenRef, task.writeToNBT(new NBTTagCompound(), false), task::readFromNBT, null)));
             }
         });
 
@@ -95,7 +96,7 @@ public class GuiEditTaskScoreboard extends GuiScreenCanvas {
         NBTTagList dataList = new NBTTagList();
         NBTTagCompound entry = new NBTTagCompound();
         entry.setInteger("questID", quest.getID());
-        entry.setTag("config", quest.getValue().writeToNBT(new NBTTagCompound()));
+        entry.setTag("config", quest.getValue().writeToNBT(new NBTTagCompound(), true));
         dataList.appendTag(entry);
         payload.setTag("data", dataList);
         payload.setInteger("action", 0); // Action: Update data

--- a/src/main/java/betterquesting/client/gui2/editors/tasks/GuiEditTaskTame.java
+++ b/src/main/java/betterquesting/client/gui2/editors/tasks/GuiEditTaskTame.java
@@ -89,7 +89,8 @@ public class GuiEditTaskTame extends GuiScreenCanvas implements IVolatileScreen 
         cvBackground.addPanel(new PanelButton(new GuiTransform(GuiAlign.MID_CENTER, -100, 32, 200, 16, 0), -1, QuestTranslation.translate("betterquesting.btn.advanced")) {
             @Override
             public void onButtonClick() {
-                mc.displayGuiScreen(QuestingAPI.getAPI(ApiReference.THEME_REG).getGui(PresetGUIs.EDIT_NBT, new GArgsNBT<>(screenRef, task.writeToNBT(new NBTTagCompound()), task::readFromNBT, null)));
+                mc.displayGuiScreen(QuestingAPI.getAPI(ApiReference.THEME_REG)
+                        .getGui(PresetGUIs.EDIT_NBT, new GArgsNBT<>(screenRef, task.writeToNBT(new NBTTagCompound(), false), task::readFromNBT, null)));
             }
         });
 
@@ -109,7 +110,7 @@ public class GuiEditTaskTame extends GuiScreenCanvas implements IVolatileScreen 
         NBTTagList dataList = new NBTTagList();
         NBTTagCompound entry = new NBTTagCompound();
         entry.setInteger("questID", quest.getID());
-        entry.setTag("config", quest.getValue().writeToNBT(new NBTTagCompound()));
+        entry.setTag("config", quest.getValue().writeToNBT(new NBTTagCompound(), true));
         dataList.appendTag(entry);
         payload.setTag("data", dataList);
         payload.setInteger("action", 0); // Action: Update data

--- a/src/main/java/betterquesting/client/importers/ImportedQuestLines.java
+++ b/src/main/java/betterquesting/client/importers/ImportedQuestLines.java
@@ -47,10 +47,10 @@ public class ImportedQuestLines extends SimpleDatabase<IQuestLine> implements IQ
     }
 
     @Override
-    public NBTTagList writeToNBT(NBTTagList json, List<Integer> subset) {
+    public NBTTagList writeToNBT(NBTTagList json, List<Integer> subset, boolean reduce) {
         for (DBEntry<IQuestLine> entry : getEntries()) {
             if (subset != null && !subset.contains(entry.getID())) continue;
-            NBTTagCompound jObj = entry.getValue().writeToNBT(new NBTTagCompound(), null);
+            NBTTagCompound jObj = entry.getValue().writeToNBT(new NBTTagCompound(), null, reduce);
             jObj.setInteger("lineID", entry.getID());
             jObj.setInteger("order", getOrderIndex(entry.getID()));
             json.appendTag(jObj);

--- a/src/main/java/betterquesting/client/importers/ImportedQuestLines.java
+++ b/src/main/java/betterquesting/client/importers/ImportedQuestLines.java
@@ -46,17 +46,23 @@ public class ImportedQuestLines extends SimpleDatabase<IQuestLine> implements IQ
         return ary;
     }
 
+    @Deprecated
     @Override
-    public NBTTagList writeToNBT(NBTTagList json, List<Integer> subset, boolean reduce) {
+    public NBTTagList writeToNBT(NBTTagList nbt, List<Integer> subset) {
+        return writeToNBT(nbt, subset, false);
+    }
+
+    @Override
+    public NBTTagList writeToNBT(NBTTagList nbt, List<Integer> subset, boolean reduce) {
         for (DBEntry<IQuestLine> entry : getEntries()) {
             if (subset != null && !subset.contains(entry.getID())) continue;
             NBTTagCompound jObj = entry.getValue().writeToNBT(new NBTTagCompound(), null, reduce);
             jObj.setInteger("lineID", entry.getID());
             jObj.setInteger("order", getOrderIndex(entry.getID()));
-            json.appendTag(jObj);
+            nbt.appendTag(jObj);
         }
 
-        return json;
+        return nbt;
     }
 
     @Override

--- a/src/main/java/betterquesting/client/importers/ImportedQuests.java
+++ b/src/main/java/betterquesting/client/importers/ImportedQuests.java
@@ -37,11 +37,11 @@ public class ImportedQuests extends SimpleDatabase<IQuest> implements IQuestData
     }
 
     @Override
-    public NBTTagList writeToNBT(NBTTagList nbt, List<Integer> subset) {
+    public NBTTagList writeToNBT(NBTTagList nbt, List<Integer> subset, boolean reduce) {
         for (DBEntry<IQuest> entry : this.getEntries()) {
             if (subset != null && !subset.contains(entry.getID())) continue;
             NBTTagCompound jq = new NBTTagCompound();
-            entry.getValue().writeToNBT(jq);
+            entry.getValue().writeToNBT(jq, reduce);
             jq.setInteger("questID", entry.getID());
             nbt.appendTag(jq);
         }

--- a/src/main/java/betterquesting/client/importers/ImportedQuests.java
+++ b/src/main/java/betterquesting/client/importers/ImportedQuests.java
@@ -36,6 +36,12 @@ public class ImportedQuests extends SimpleDatabase<IQuest> implements IQuestData
         return values;
     }
 
+    @Deprecated
+    @Override
+    public NBTTagList writeToNBT(NBTTagList nbt, List<Integer> subset) {
+        return writeToNBT(nbt, subset, false);
+    }
+
     @Override
     public NBTTagList writeToNBT(NBTTagList nbt, List<Integer> subset, boolean reduce) {
         for (DBEntry<IQuest> entry : this.getEntries()) {

--- a/src/main/java/betterquesting/client/toolbox/PanelTabMain.java
+++ b/src/main/java/betterquesting/client/toolbox/PanelTabMain.java
@@ -56,7 +56,7 @@ public class PanelTabMain extends CanvasEmpty {
             @Override
             public void onButtonClick() {
                 Minecraft mc = Minecraft.getMinecraft();
-                mc.displayGuiScreen(new GuiNbtEditor(mc.currentScreen, cvQuestLine.getQuestLine().writeToNBT(new NBTTagCompound(), null), value -> {
+                mc.displayGuiScreen(new GuiNbtEditor(mc.currentScreen, cvQuestLine.getQuestLine().writeToNBT(new NBTTagCompound(), null, false), value -> {
                     NBTTagCompound payload = new NBTTagCompound();
                     NBTTagList dataList = new NBTTagList();
                     NBTTagCompound entry = new NBTTagCompound();

--- a/src/main/java/betterquesting/client/toolbox/tools/ToolboxToolCopy.java
+++ b/src/main/java/betterquesting/client/toolbox/tools/ToolboxToolCopy.java
@@ -135,7 +135,7 @@ public class ToolboxToolCopy implements IToolboxTool {
             if (qLine.getValue(qID) == null)
                 qLine.add(qID, new QuestLineEntry(grab.btn.rect.x, grab.btn.rect.y, grab.btn.rect.w, grab.btn.rect.h));
 
-            NBTTagCompound questTags = quest.writeToNBT(new NBTTagCompound());
+            NBTTagCompound questTags = quest.writeToNBT(new NBTTagCompound(), true);
 
             int[] oldIDs = Arrays.copyOf(quest.getRequirements(), quest.getRequirements().length);
 
@@ -167,7 +167,7 @@ public class ToolboxToolCopy implements IToolboxTool {
         NBTTagList cdList = new NBTTagList();
         NBTTagCompound tagEntry = new NBTTagCompound();
         tagEntry.setInteger("chapterID", lID);
-        tagEntry.setTag("config", qLine.writeToNBT(new NBTTagCompound(), null));
+        tagEntry.setTag("config", qLine.writeToNBT(new NBTTagCompound(), null, true));
         cdList.appendTag(tagEntry);
         chPayload.setTag("data", cdList);
         chPayload.setInteger("action", 0);

--- a/src/main/java/betterquesting/client/toolbox/tools/ToolboxToolFrame.java
+++ b/src/main/java/betterquesting/client/toolbox/tools/ToolboxToolFrame.java
@@ -69,7 +69,7 @@ public class ToolboxToolFrame implements IToolboxTool {
 
             NBTTagCompound entry = new NBTTagCompound();
             entry.setInteger("questID", btn.getStoredValue().getID());
-            entry.setTag("config", btn.getStoredValue().getValue().writeToNBT(new NBTTagCompound()));
+            entry.setTag("config", btn.getStoredValue().getValue().writeToNBT(new NBTTagCompound(), true));
             dataList.appendTag(entry);
         }
 

--- a/src/main/java/betterquesting/client/toolbox/tools/ToolboxToolGrab.java
+++ b/src/main/java/betterquesting/client/toolbox/tools/ToolboxToolGrab.java
@@ -138,7 +138,7 @@ public class ToolboxToolGrab implements IToolboxTool {
             NBTTagList cdList = new NBTTagList();
             NBTTagCompound tagEntry = new NBTTagCompound();
             tagEntry.setInteger("chapterID", lID);
-            tagEntry.setTag("config", qLine.writeToNBT(new NBTTagCompound(), null));
+            tagEntry.setTag("config", qLine.writeToNBT(new NBTTagCompound(), null, true));
             cdList.appendTag(tagEntry);
             chPayload.setTag("data", cdList);
             chPayload.setInteger("action", 0);

--- a/src/main/java/betterquesting/client/toolbox/tools/ToolboxToolIcon.java
+++ b/src/main/java/betterquesting/client/toolbox/tools/ToolboxToolIcon.java
@@ -56,7 +56,7 @@ public class ToolboxToolIcon implements IToolboxTool {
 
                 NBTTagCompound entry = new NBTTagCompound();
                 entry.setInteger("questID", b.getStoredValue().getID());
-                entry.setTag("config", b.getStoredValue().getValue().writeToNBT(new NBTTagCompound()));
+                entry.setTag("config", b.getStoredValue().getValue().writeToNBT(new NBTTagCompound(), true));
                 dataList.appendTag(entry);
             }
 

--- a/src/main/java/betterquesting/client/toolbox/tools/ToolboxToolLink.java
+++ b/src/main/java/betterquesting/client/toolbox/tools/ToolboxToolLink.java
@@ -117,7 +117,7 @@ public class ToolboxToolLink implements IToolboxTool {
                     if (mod1) {
                         NBTTagCompound entry = new NBTTagCompound();
                         entry.setInteger("questID", b1.getStoredValue().getID());
-                        entry.setTag("config", b1.getStoredValue().getValue().writeToNBT(new NBTTagCompound()));
+                        entry.setTag("config", b1.getStoredValue().getValue().writeToNBT(new NBTTagCompound(), true));
                         dataList.appendTag(entry);
                     }
                 }
@@ -125,7 +125,7 @@ public class ToolboxToolLink implements IToolboxTool {
                 if (mod2) {
                     NBTTagCompound entry = new NBTTagCompound();
                     entry.setInteger("questID", b2.getStoredValue().getID());
-                    entry.setTag("config", q2.writeToNBT(new NBTTagCompound()));
+                    entry.setTag("config", q2.writeToNBT(new NBTTagCompound(), true));
                     dataList.appendTag(entry);
                 }
 

--- a/src/main/java/betterquesting/client/toolbox/tools/ToolboxToolNew.java
+++ b/src/main/java/betterquesting/client/toolbox/tools/ToolboxToolNew.java
@@ -102,7 +102,7 @@ public class ToolboxToolNew implements IToolboxTool {
         NBTTagList cdList = new NBTTagList();
         NBTTagCompound cTag = new NBTTagCompound();
         cTag.setInteger("chapterID", lID);
-        cTag.setTag("config", qLine.writeToNBT(new NBTTagCompound(), null));
+        cTag.setTag("config", qLine.writeToNBT(new NBTTagCompound(), null, true));
         cdList.appendTag(cTag);
         chPayload.setTag("data", cdList);
         chPayload.setInteger("action", 0);

--- a/src/main/java/betterquesting/client/toolbox/tools/ToolboxToolRemove.java
+++ b/src/main/java/betterquesting/client/toolbox/tools/ToolboxToolRemove.java
@@ -53,7 +53,7 @@ public class ToolboxToolRemove implements IToolboxTool {
             NBTTagList cdList = new NBTTagList();
             NBTTagCompound cTag = new NBTTagCompound();
             cTag.setInteger("chapterID", QuestLineDatabase.INSTANCE.getID(line));
-            cTag.setTag("config", line.writeToNBT(new NBTTagCompound(), null));
+            cTag.setTag("config", line.writeToNBT(new NBTTagCompound(), null, true));
             cdList.appendTag(cTag);
             chPayload.setTag("data", cdList);
             chPayload.setInteger("action", 0);
@@ -98,7 +98,7 @@ public class ToolboxToolRemove implements IToolboxTool {
             NBTTagList cdList = new NBTTagList();
             NBTTagCompound cTag = new NBTTagCompound();
             cTag.setInteger("chapterID", QuestLineDatabase.INSTANCE.getID(line));
-            cTag.setTag("config", line.writeToNBT(new NBTTagCompound(), null));
+            cTag.setTag("config", line.writeToNBT(new NBTTagCompound(), null, true));
             cdList.appendTag(cTag);
             chPayload.setTag("data", cdList);
             chPayload.setInteger("action", 0);

--- a/src/main/java/betterquesting/client/toolbox/tools/ToolboxToolScale.java
+++ b/src/main/java/betterquesting/client/toolbox/tools/ToolboxToolScale.java
@@ -154,7 +154,7 @@ public class ToolboxToolScale implements IToolboxTool {
             NBTTagList cdList = new NBTTagList();
             NBTTagCompound tagEntry = new NBTTagCompound();
             tagEntry.setInteger("chapterID", lID);
-            tagEntry.setTag("config", qLine.writeToNBT(new NBTTagCompound(), null));
+            tagEntry.setTag("config", qLine.writeToNBT(new NBTTagCompound(), null, true));
             cdList.appendTag(tagEntry);
             chPayload.setTag("data", cdList);
             chPayload.setInteger("action", 0);

--- a/src/main/java/betterquesting/client/ui_builder/ComponentPanel.java
+++ b/src/main/java/betterquesting/client/ui_builder/ComponentPanel.java
@@ -79,7 +79,7 @@ public class ComponentPanel implements INBTSaveLoad<NBTTagCompound> {
     }
 
     @Override
-    public NBTTagCompound writeToNBT(NBTTagCompound nbt) {
+    public NBTTagCompound writeToNBT(NBTTagCompound nbt, boolean reduce) {
         nbt.setString("ref_name", refName);
         nbt.setString("panel_type", panelType);
 

--- a/src/main/java/betterquesting/client/ui_builder/ComponentPanel.java
+++ b/src/main/java/betterquesting/client/ui_builder/ComponentPanel.java
@@ -78,6 +78,12 @@ public class ComponentPanel implements INBTSaveLoad<NBTTagCompound> {
         return ComponentRegistry.INSTANCE.createNew(res, transform, panelData);
     }
 
+    @Deprecated
+    @Override
+    public NBTTagCompound writeToNBT(NBTTagCompound nbt) {
+        return writeToNBT(nbt, false);
+    }
+
     @Override
     public NBTTagCompound writeToNBT(NBTTagCompound nbt, boolean reduce) {
         nbt.setString("ref_name", refName);

--- a/src/main/java/betterquesting/client/ui_builder/GuiBuilderMain.java
+++ b/src/main/java/betterquesting/client/ui_builder/GuiBuilderMain.java
@@ -94,7 +94,7 @@ public class GuiBuilderMain extends GuiScreenCanvas implements IVolatileScreen {
             } else if (selectedID >= 0 && !(toolMode == 0 || toolMode == 2)) {
                 ComponentPanel com = COM_DB.getValue(selectedID);
                 // TODO: Add a callback here so the component can read in changes
-                if (com != null) openTrayNBT(com.writeToNBT(new NBTTagCompound()));
+                if (com != null) openTrayNBT(com.writeToNBT(new NBTTagCompound(), false));
             } else if (toolMode == 3) {
                 openTrayPalette();
             }

--- a/src/main/java/betterquesting/commands/admin/QuestCommandDefaults.java
+++ b/src/main/java/betterquesting/commands/admin/QuestCommandDefaults.java
@@ -73,10 +73,10 @@ public class QuestCommandDefaults extends QuestCommandBase {
             NBTTagCompound base = new NBTTagCompound();
 
             QuestSettings.INSTANCE.setProperty(NativeProps.EDIT_MODE, false);
-            base.setTag("questSettings", QuestSettings.INSTANCE.writeToNBT(new NBTTagCompound()));
+            base.setTag("questSettings", QuestSettings.INSTANCE.writeToNBT(new NBTTagCompound(), true));
             QuestSettings.INSTANCE.setProperty(NativeProps.EDIT_MODE, editMode);
-            base.setTag("questDatabase", QuestDatabase.INSTANCE.writeToNBT(new NBTTagList(), null));
-            base.setTag("questLines", QuestLineDatabase.INSTANCE.writeToNBT(new NBTTagList(), null));
+            base.setTag("questDatabase", QuestDatabase.INSTANCE.writeToNBT(new NBTTagList(), null, true));
+            base.setTag("questLines", QuestLineDatabase.INSTANCE.writeToNBT(new NBTTagList(), null, true));
             base.setString("format", BetterQuesting.FORMAT);
             base.setString("build", ModReference.VERSION);
             JsonHelper.WriteToFile(qFile, NBTConverter.NBTtoJSON_Compound(base, new JsonObject(), true));

--- a/src/main/java/betterquesting/commands/bqs/BQS_Commands.java
+++ b/src/main/java/betterquesting/commands/bqs/BQS_Commands.java
@@ -41,7 +41,7 @@ public class BQS_Commands extends CommandBase {
         if (args[0].equalsIgnoreCase("default")) {
             if (args[1].equalsIgnoreCase("save")) {
                 NBTTagCompound jsonQ = new NBTTagCompound();
-                LootRegistry.INSTANCE.writeToNBT(jsonQ, null);
+                LootRegistry.INSTANCE.writeToNBT(jsonQ, null, true);
                 JsonHelper.WriteToFile(new File(server.getFile("config/betterquesting/"), "DefaultLoot.json"), NBTConverter.NBTtoJSON_Compound(jsonQ, new JsonObject(), true));
                 sender.sendMessage(new TextComponentString("Loot database set as global default"));
             } else if (args[1].equalsIgnoreCase("load")) {

--- a/src/main/java/betterquesting/core/BetterQuesting.java
+++ b/src/main/java/betterquesting/core/BetterQuesting.java
@@ -48,7 +48,7 @@ import org.apache.logging.log4j.Logger;
 @Mod(modid = ModReference.MODID, version = BetterQuesting.VERSION, name = ModReference.NAME, guiFactory = "betterquesting.handlers.ConfigGuiFactory")
 public class BetterQuesting {
     public static final String VERSION = ModReference.VERSION;
-    public static final String FORMAT = "2.0.0";
+    public static final String FORMAT = "2.1.0";
 
     // Used for some legacy compat
     public static final String MODID_STD = "bq_standard";

--- a/src/main/java/betterquesting/handlers/LootSaveLoad.java
+++ b/src/main/java/betterquesting/handlers/LootSaveLoad.java
@@ -41,7 +41,7 @@ public class LootSaveLoad {
     }
 
     public void SaveLoot() {
-        JsonHelper.WriteToFile(new File(worldDir, "QuestLoot.json"), NBTConverter.NBTtoJSON_Compound(LootRegistry.INSTANCE.writeToNBT(new NBTTagCompound(), null), new JsonObject(), true));
+        JsonHelper.WriteToFile(new File(worldDir, "QuestLoot.json"), NBTConverter.NBTtoJSON_Compound(LootRegistry.INSTANCE.writeToNBT(new NBTTagCompound(), null, true), new JsonObject(), true));
     }
 
     public void UnloadLoot() {

--- a/src/main/java/betterquesting/handlers/SaveLoadHandler.java
+++ b/src/main/java/betterquesting/handlers/SaveLoadHandler.java
@@ -295,9 +295,9 @@ public class SaveLoadHandler {
     private Future<Void> saveConfig() {
         NBTTagCompound json = new NBTTagCompound();
 
-        json.setTag("questSettings", QuestSettings.INSTANCE.writeToNBT(new NBTTagCompound()));
-        json.setTag("questDatabase", QuestDatabase.INSTANCE.writeToNBT(new NBTTagList(), null));
-        json.setTag("questLines", QuestLineDatabase.INSTANCE.writeToNBT(new NBTTagList(), null));
+        json.setTag("questSettings", QuestSettings.INSTANCE.writeToNBT(new NBTTagCompound(), true));
+        json.setTag("questDatabase", QuestDatabase.INSTANCE.writeToNBT(new NBTTagList(), null, true));
+        json.setTag("questLines", QuestLineDatabase.INSTANCE.writeToNBT(new NBTTagList(), null, true));
 
         json.setString("format", BetterQuesting.FORMAT);
         json.setString("build", ModReference.VERSION);
@@ -314,7 +314,7 @@ public class SaveLoadHandler {
     private Future<Void> saveParties() {
         NBTTagCompound json = new NBTTagCompound();
 
-        json.setTag("parties", PartyManager.INSTANCE.writeToNBT(new NBTTagList(), null));
+        json.setTag("parties", PartyManager.INSTANCE.writeToNBT(new NBTTagList(), null, true));
 
         return JsonHelper.WriteToFile(fileParties, NBTConverter.NBTtoJSON_Compound(json, new JsonObject(), true));
     }
@@ -322,7 +322,7 @@ public class SaveLoadHandler {
     private Future<Void> saveNames() {
         NBTTagCompound json = new NBTTagCompound();
 
-        json.setTag("nameCache", NameCache.INSTANCE.writeToNBT(new NBTTagList(), null));
+        json.setTag("nameCache", NameCache.INSTANCE.writeToNBT(new NBTTagList(), null, true));
 
         return JsonHelper.WriteToFile(fileNames, NBTConverter.NBTtoJSON_Compound(json, new JsonObject(), true));
     }
@@ -330,7 +330,7 @@ public class SaveLoadHandler {
     private Future<Void> saveLives() {
         NBTTagCompound json = new NBTTagCompound();
 
-        json.setTag("lifeDatabase", LifeDatabase.INSTANCE.writeToNBT(new NBTTagCompound(), null));
+        json.setTag("lifeDatabase", LifeDatabase.INSTANCE.writeToNBT(new NBTTagCompound(), null, true));
 
         return JsonHelper.WriteToFile(fileLives, NBTConverter.NBTtoJSON_Compound(json, new JsonObject(), true));
     }

--- a/src/main/java/betterquesting/importers/hqm/HQMBagImporter.java
+++ b/src/main/java/betterquesting/importers/hqm/HQMBagImporter.java
@@ -117,7 +117,7 @@ public class HQMBagImporter implements IImporter {
 
         for (LootGroup group : hqmLoot) {
             NBTTagCompound jGrp = new NBTTagCompound();
-            group.writeToNBT(jGrp);
+            group.writeToNBT(jGrp, true);
             jAry.appendTag(jGrp);
         }
 

--- a/src/main/java/betterquesting/importers/hqm/converters/tasks/HQMTaskBlockPlace.java
+++ b/src/main/java/betterquesting/importers/hqm/converters/tasks/HQMTaskBlockPlace.java
@@ -22,7 +22,7 @@ public class HQMTaskBlockPlace {
 
             TaskInteractItem task = new TaskInteractItem();
             BigItemStack stack = HQMUtilities.HQMStackT1(JsonHelper.GetObject(jObj, "item"));
-            task.targetItem = new BigItemStack(stack.writeToNBT(new NBTTagCompound()));
+            task.targetItem = new BigItemStack(stack.writeToNBT(new NBTTagCompound(), false));
             task.required = JsonHelper.GetNumber(jObj, "required", 1).intValue();
             tList.add(task);
         }

--- a/src/main/java/betterquesting/items/ItemLootChest.java
+++ b/src/main/java/betterquesting/items/ItemLootChest.java
@@ -202,7 +202,7 @@ public class ItemLootChest extends Item {
         tag = new NBTTagCompound();
         tag.setBoolean("hideLootInfo", true);
         NBTTagList tagList = new NBTTagList();
-        tagList.appendTag(new BigItemStack(Blocks.STONE).writeToNBT(new NBTTagCompound()));
+        tagList.appendTag(new BigItemStack(Blocks.STONE).writeToNBT(new NBTTagCompound(), false));
         ItemStack fixedLootStack = new ItemStack(this, 1, 104);
         tag.setTag("fixedLootList", tagList);
         tag.setString("fixedLootName", "Item Set");

--- a/src/main/java/betterquesting/network/handlers/NetChapterSync.java
+++ b/src/main/java/betterquesting/network/handlers/NetChapterSync.java
@@ -45,7 +45,7 @@ public class NetChapterSync {
                 NBTTagCompound entry = new NBTTagCompound();
                 entry.setInteger("chapterID", chapter.getID());
                 //entry.setInteger("order", QuestLineDatabase.INSTANCE.getOrderIndex(chapter.getID()));
-                entry.setTag("config", chapter.getValue().writeToNBT(new NBTTagCompound(), null));
+                entry.setTag("config", chapter.getValue().writeToNBT(new NBTTagCompound(), null, true));
                 data.appendTag(entry);
             }
 

--- a/src/main/java/betterquesting/network/handlers/NetImport.java
+++ b/src/main/java/betterquesting/network/handlers/NetImport.java
@@ -41,8 +41,8 @@ public class NetImport {
 
     public static void sendImport(@Nonnull IQuestDatabase questDB, @Nonnull IQuestLineDatabase chapterDB) {
         NBTTagCompound payload = new NBTTagCompound();
-        payload.setTag("quests", questDB.writeToNBT(new NBTTagList(), null));
-        payload.setTag("chapters", chapterDB.writeToNBT(new NBTTagList(), null));
+        payload.setTag("quests", questDB.writeToNBT(new NBTTagList(), null, true));
+        payload.setTag("chapters", chapterDB.writeToNBT(new NBTTagList(), null, true));
         PacketSender.INSTANCE.sendToServer(new QuestingPacket(ID_NAME, payload));
     }
 

--- a/src/main/java/betterquesting/network/handlers/NetInviteSync.java
+++ b/src/main/java/betterquesting/network/handlers/NetInviteSync.java
@@ -36,7 +36,7 @@ public class NetInviteSync {
         NBTTagCompound payload = new NBTTagCompound();
         UUID playerID = QuestingAPI.getQuestingUUID(player);
         payload.setInteger("action", 0);
-        payload.setTag("data", PartyInvitations.INSTANCE.writeToNBT(new NBTTagList(), Collections.singletonList(playerID)));
+        payload.setTag("data", PartyInvitations.INSTANCE.writeToNBT(new NBTTagList(), Collections.singletonList(playerID), true));
         PacketSender.INSTANCE.sendToPlayers(new QuestingPacket(ID_NAME, payload), player);
     }
 

--- a/src/main/java/betterquesting/network/handlers/NetLifeSync.java
+++ b/src/main/java/betterquesting/network/handlers/NetLifeSync.java
@@ -27,7 +27,7 @@ public class NetLifeSync {
 
     public static void sendSync(@Nullable EntityPlayerMP[] players, @Nullable UUID[] playerIDs) {
         NBTTagCompound payload = new NBTTagCompound();
-        payload.setTag("data", LifeDatabase.INSTANCE.writeToNBT(new NBTTagCompound(), playerIDs == null ? null : Arrays.asList(playerIDs)));
+        payload.setTag("data", LifeDatabase.INSTANCE.writeToNBT(new NBTTagCompound(), playerIDs == null ? null : Arrays.asList(playerIDs), true));
         payload.setBoolean("merge", playerIDs != null);
 
         if (players != null) {

--- a/src/main/java/betterquesting/network/handlers/NetLootClaim.java
+++ b/src/main/java/betterquesting/network/handlers/NetLootClaim.java
@@ -31,7 +31,7 @@ public class NetLootClaim {
         NBTTagCompound payload = new NBTTagCompound();
         NBTTagList list = new NBTTagList();
         for (BigItemStack stack : items) {
-            list.appendTag(stack.writeToNBT(new NBTTagCompound()));
+            list.appendTag(stack.writeToNBT(new NBTTagCompound(), true));
         }
         payload.setTag("rewards", list);
         payload.setString("title", title);

--- a/src/main/java/betterquesting/network/handlers/NetLootSync.java
+++ b/src/main/java/betterquesting/network/handlers/NetLootSync.java
@@ -37,7 +37,7 @@ public class NetLootSync {
 
     public static void sendSync(@Nullable EntityPlayerMP player) {
         NBTTagCompound payload = new NBTTagCompound();
-        payload.setTag("data", LootRegistry.INSTANCE.writeToNBT(new NBTTagCompound(), null));
+        payload.setTag("data", LootRegistry.INSTANCE.writeToNBT(new NBTTagCompound(), null, true));
 
         if (player == null) {
             QuestingAPI.getAPI(ApiReference.PACKET_SENDER).sendToAll(new QuestingPacket(ID_NAME, payload));

--- a/src/main/java/betterquesting/network/handlers/NetNameSync.java
+++ b/src/main/java/betterquesting/network/handlers/NetNameSync.java
@@ -68,7 +68,7 @@ public class NetNameSync {
         if (party == null) return;
 
         NBTTagCompound payload = new NBTTagCompound();
-        payload.setTag("data", NameCache.INSTANCE.writeToNBT(new NBTTagList(), party.getMembers()));
+        payload.setTag("data", NameCache.INSTANCE.writeToNBT(new NBTTagList(), party.getMembers(), true));
         payload.setBoolean("merge", true);
 
         if (player != null) {
@@ -96,7 +96,7 @@ public class NetNameSync {
         }
 
         NBTTagCompound payload = new NBTTagCompound();
-        payload.setTag("data", NameCache.INSTANCE.writeToNBT(new NBTTagList(), idList));
+        payload.setTag("data", NameCache.INSTANCE.writeToNBT(new NBTTagList(), idList, true));
         payload.setBoolean("merge", idList != null);
 
         if (players == null) {

--- a/src/main/java/betterquesting/network/handlers/NetPartySync.java
+++ b/src/main/java/betterquesting/network/handlers/NetPartySync.java
@@ -63,7 +63,7 @@ public class NetPartySync {
         for (DBEntry<IParty> party : partySubset) {
             NBTTagCompound entry = new NBTTagCompound();
             entry.setInteger("partyID", party.getID());
-            entry.setTag("config", party.getValue().writeToNBT(new NBTTagCompound()));
+            entry.setTag("config", party.getValue().writeToNBT(new NBTTagCompound(), true));
             dataList.appendTag(entry);
         }
 

--- a/src/main/java/betterquesting/network/handlers/NetQuestSync.java
+++ b/src/main/java/betterquesting/network/handlers/NetQuestSync.java
@@ -75,7 +75,7 @@ public class NetQuestSync {
             for (DBEntry<IQuest> entry : questSubset) {
                 NBTTagCompound tag = new NBTTagCompound();
 
-                if (config) tag.setTag("config", entry.getValue().writeToNBT(new NBTTagCompound()));
+                if (config) tag.setTag("config", entry.getValue().writeToNBT(new NBTTagCompound(), true));
                 if (progress)
                     tag.setTag("progress", entry.getValue().writeProgressToNBT(new NBTTagCompound(), pidList));
                 if (resetIDs != null) tag.setIntArray("resets", resetIDs);

--- a/src/main/java/betterquesting/network/handlers/NetScoreSync.java
+++ b/src/main/java/betterquesting/network/handlers/NetScoreSync.java
@@ -24,7 +24,7 @@ public class NetScoreSync {
 
     public static void sendScore(@Nullable EntityPlayerMP player) {
         NBTTagCompound payload = new NBTTagCompound();
-        payload.setTag("data", ScoreboardBQ.INSTANCE.writeToNBT(new NBTTagList(), player == null ? null : Collections.singletonList(QuestingAPI.getQuestingUUID(player))));
+        payload.setTag("data", ScoreboardBQ.INSTANCE.writeToNBT(new NBTTagList(), player == null ? null : Collections.singletonList(QuestingAPI.getQuestingUUID(player)), true));
         payload.setBoolean("merge", player != null);
 
         if (player == null) {

--- a/src/main/java/betterquesting/network/handlers/NetSettingSync.java
+++ b/src/main/java/betterquesting/network/handlers/NetSettingSync.java
@@ -34,13 +34,13 @@ public class NetSettingSync {
     @SideOnly(Side.CLIENT)
     public static void requestEdit() {
         NBTTagCompound payload = new NBTTagCompound();
-        payload.setTag("data", QuestSettings.INSTANCE.writeToNBT(new NBTTagCompound()));
+        payload.setTag("data", QuestSettings.INSTANCE.writeToNBT(new NBTTagCompound(), true));
         PacketSender.INSTANCE.sendToServer(new QuestingPacket(ID_NAME, payload));
     }
 
     public static void sendSync(@Nullable EntityPlayerMP player) {
         NBTTagCompound payload = new NBTTagCompound();
-        payload.setTag("data", QuestSettings.INSTANCE.writeToNBT(new NBTTagCompound()));
+        payload.setTag("data", QuestSettings.INSTANCE.writeToNBT(new NBTTagCompound(), true));
         if (player != null) {
             PacketSender.INSTANCE.sendToPlayers(new QuestingPacket(ID_NAME, payload), player);
         } else {

--- a/src/main/java/betterquesting/questing/QuestDatabase.java
+++ b/src/main/java/betterquesting/questing/QuestDatabase.java
@@ -55,10 +55,10 @@ public final class QuestDatabase extends SimpleDatabase<IQuest> implements IQues
     }
 
     @Override
-    public synchronized NBTTagList writeToNBT(NBTTagList json, @Nullable List<Integer> subset) {
+    public synchronized NBTTagList writeToNBT(NBTTagList json, @Nullable List<Integer> subset, boolean reduce) {
         for (DBEntry<IQuest> entry : this.getEntries()) {
             if (subset != null && !subset.contains(entry.getID())) continue;
-            NBTTagCompound jq = entry.getValue().writeToNBT(new NBTTagCompound());
+            NBTTagCompound jq = entry.getValue().writeToNBT(new NBTTagCompound(), reduce);
             if (subset != null && jq.isEmpty()) continue;
             jq.setInteger("questID", entry.getID());
             json.appendTag(jq);

--- a/src/main/java/betterquesting/questing/QuestDatabase.java
+++ b/src/main/java/betterquesting/questing/QuestDatabase.java
@@ -54,17 +54,23 @@ public final class QuestDatabase extends SimpleDatabase<IQuest> implements IQues
         if (hasRemoved) quest.setRequirements(rem);
     }
 
+    @Deprecated
     @Override
-    public synchronized NBTTagList writeToNBT(NBTTagList json, @Nullable List<Integer> subset, boolean reduce) {
+    public synchronized NBTTagList writeToNBT(NBTTagList nbt, @Nullable List<Integer> subset) {
+        return writeToNBT(nbt, subset, false);
+    }
+
+    @Override
+    public synchronized NBTTagList writeToNBT(NBTTagList nbt, @Nullable List<Integer> subset, boolean reduce) {
         for (DBEntry<IQuest> entry : this.getEntries()) {
             if (subset != null && !subset.contains(entry.getID())) continue;
             NBTTagCompound jq = entry.getValue().writeToNBT(new NBTTagCompound(), reduce);
             if (subset != null && jq.isEmpty()) continue;
             jq.setInteger("questID", entry.getID());
-            json.appendTag(jq);
+            nbt.appendTag(jq);
         }
 
-        return json;
+        return nbt;
     }
 
     @Override

--- a/src/main/java/betterquesting/questing/QuestInstance.java
+++ b/src/main/java/betterquesting/questing/QuestInstance.java
@@ -403,26 +403,32 @@ public class QuestInstance implements IQuest {
             prereqTypes.put(req, kind);
     }
 
+    @Deprecated
     @Override
-    public NBTTagCompound writeToNBT(NBTTagCompound jObj, boolean reduce) {
+    public NBTTagCompound writeToNBT(NBTTagCompound nbt) {
+        return writeToNBT(nbt, false);
+    }
+
+    @Override
+    public NBTTagCompound writeToNBT(NBTTagCompound nbt, boolean reduce) {
         NBTTagCompound nbtProperties = qInfo.writeToNBT(new NBTTagCompound(), reduce);
         if (!reduce || !nbtProperties.isEmpty())
-            jObj.setTag("properties", nbtProperties);
-        jObj.setTag("tasks", tasks.writeToNBT(new NBTTagList(), null, reduce));
+            nbt.setTag("properties", nbtProperties);
+        nbt.setTag("tasks", tasks.writeToNBT(new NBTTagList(), null, reduce));
         NBTTagList nbtRewards = rewards.writeToNBT(new NBTTagList(), null, reduce);
         if (!reduce || !nbtRewards.isEmpty())
-            jObj.setTag("rewards", nbtRewards);
+            nbt.setTag("rewards", nbtRewards);
         if (!reduce || getRequirements().length > 0)
-            jObj.setTag("preRequisites", new NBTTagIntArray(getRequirements()));
+            nbt.setTag("preRequisites", new NBTTagIntArray(getRequirements()));
         if (!prereqTypes.isEmpty()) {
             byte[] types = new byte[preRequisites.length];
             int[] req = this.preRequisites;
             for (int i = 0, requirementsLength = req.length; i < requirementsLength; i++)
                 types[i] = getRequirementType(req[i]).id();
-            jObj.setTag("preRequisiteTypes", new NBTTagByteArray(types));
+            nbt.setTag("preRequisiteTypes", new NBTTagByteArray(types));
         }
 
-        return jObj;
+        return nbt;
     }
 
     @Override

--- a/src/main/java/betterquesting/questing/QuestInstance.java
+++ b/src/main/java/betterquesting/questing/QuestInstance.java
@@ -404,11 +404,16 @@ public class QuestInstance implements IQuest {
     }
 
     @Override
-    public NBTTagCompound writeToNBT(NBTTagCompound jObj) {
-        jObj.setTag("properties", qInfo.writeToNBT(new NBTTagCompound()));
-        jObj.setTag("tasks", tasks.writeToNBT(new NBTTagList(), null));
-        jObj.setTag("rewards", rewards.writeToNBT(new NBTTagList(), null));
-        jObj.setTag("preRequisites", new NBTTagIntArray(getRequirements()));
+    public NBTTagCompound writeToNBT(NBTTagCompound jObj, boolean reduce) {
+        NBTTagCompound nbtProperties = qInfo.writeToNBT(new NBTTagCompound(), reduce);
+        if (!reduce || !nbtProperties.isEmpty())
+            jObj.setTag("properties", nbtProperties);
+        jObj.setTag("tasks", tasks.writeToNBT(new NBTTagList(), null, reduce));
+        NBTTagList nbtRewards = rewards.writeToNBT(new NBTTagList(), null, reduce);
+        if (!reduce || !nbtRewards.isEmpty())
+            jObj.setTag("rewards", nbtRewards);
+        if (!reduce || getRequirements().length > 0)
+            jObj.setTag("preRequisites", new NBTTagIntArray(getRequirements()));
         if (!prereqTypes.isEmpty()) {
             byte[] types = new byte[preRequisites.length];
             int[] req = this.preRequisites;

--- a/src/main/java/betterquesting/questing/QuestLine.java
+++ b/src/main/java/betterquesting/questing/QuestLine.java
@@ -87,14 +87,14 @@ public class QuestLine extends SimpleDatabase<IQuestLineEntry> implements IQuest
     }
 
     @Override
-    public NBTTagCompound writeToNBT(NBTTagCompound json, @Nullable List<Integer> subset) {
-        json.setTag("properties", info.writeToNBT(new NBTTagCompound()));
+    public NBTTagCompound writeToNBT(NBTTagCompound json, @Nullable List<Integer> subset, boolean reduce) {
+        json.setTag("properties", info.writeToNBT(new NBTTagCompound(), reduce));
 
         NBTTagList jArr = new NBTTagList();
 
         for (DBEntry<IQuestLineEntry> entry : getEntries()) {
             if (subset != null && !subset.contains(entry.getID())) continue;
-            NBTTagCompound qle = entry.getValue().writeToNBT(new NBTTagCompound());
+            NBTTagCompound qle = entry.getValue().writeToNBT(new NBTTagCompound(), reduce);
             qle.setInteger("id", entry.getID());
             jArr.appendTag(qle);
         }

--- a/src/main/java/betterquesting/questing/QuestLine.java
+++ b/src/main/java/betterquesting/questing/QuestLine.java
@@ -86,9 +86,15 @@ public class QuestLine extends SimpleDatabase<IQuestLineEntry> implements IQuest
         return null;
     }
 
+    @Deprecated
     @Override
-    public NBTTagCompound writeToNBT(NBTTagCompound json, @Nullable List<Integer> subset, boolean reduce) {
-        json.setTag("properties", info.writeToNBT(new NBTTagCompound(), reduce));
+    public NBTTagCompound writeToNBT(NBTTagCompound nbt, @Nullable List<Integer> subset) {
+        return writeToNBT(nbt, subset, false);
+    }
+
+    @Override
+    public NBTTagCompound writeToNBT(NBTTagCompound nbt, @Nullable List<Integer> subset, boolean reduce) {
+        nbt.setTag("properties", info.writeToNBT(new NBTTagCompound(), reduce));
 
         NBTTagList jArr = new NBTTagList();
 
@@ -99,8 +105,8 @@ public class QuestLine extends SimpleDatabase<IQuestLineEntry> implements IQuest
             jArr.appendTag(qle);
         }
 
-        json.setTag("quests", jArr);
-        return json;
+        nbt.setTag("quests", jArr);
+        return nbt;
     }
 
     @Override

--- a/src/main/java/betterquesting/questing/QuestLineDatabase.java
+++ b/src/main/java/betterquesting/questing/QuestLineDatabase.java
@@ -58,17 +58,23 @@ public final class QuestLineDatabase extends SimpleDatabase<IQuestLine> implemen
         }
     }
 
+    @Deprecated
     @Override
-    public synchronized NBTTagList writeToNBT(NBTTagList json, @Nullable List<Integer> subset, boolean reduce) {
+    public synchronized NBTTagList writeToNBT(NBTTagList nbt, @Nullable List<Integer> subset) {
+        return writeToNBT(nbt, subset, false);
+    }
+
+    @Override
+    public synchronized NBTTagList writeToNBT(NBTTagList nbt, @Nullable List<Integer> subset, boolean reduce) {
         for (DBEntry<IQuestLine> entry : getEntries()) {
             if (subset != null && !subset.contains(entry.getID())) continue;
             NBTTagCompound jObj = entry.getValue().writeToNBT(new NBTTagCompound(), null, reduce);
             jObj.setInteger("lineID", entry.getID());
             jObj.setInteger("order", getOrderIndex(entry.getID()));
-            json.appendTag(jObj);
+            nbt.appendTag(jObj);
         }
 
-        return json;
+        return nbt;
     }
 
     @Override

--- a/src/main/java/betterquesting/questing/QuestLineDatabase.java
+++ b/src/main/java/betterquesting/questing/QuestLineDatabase.java
@@ -59,10 +59,10 @@ public final class QuestLineDatabase extends SimpleDatabase<IQuestLine> implemen
     }
 
     @Override
-    public synchronized NBTTagList writeToNBT(NBTTagList json, @Nullable List<Integer> subset) {
+    public synchronized NBTTagList writeToNBT(NBTTagList json, @Nullable List<Integer> subset, boolean reduce) {
         for (DBEntry<IQuestLine> entry : getEntries()) {
             if (subset != null && !subset.contains(entry.getID())) continue;
-            NBTTagCompound jObj = entry.getValue().writeToNBT(new NBTTagCompound(), null);
+            NBTTagCompound jObj = entry.getValue().writeToNBT(new NBTTagCompound(), null, reduce);
             jObj.setInteger("lineID", entry.getID());
             jObj.setInteger("order", getOrderIndex(entry.getID()));
             json.appendTag(jObj);

--- a/src/main/java/betterquesting/questing/QuestLineEntry.java
+++ b/src/main/java/betterquesting/questing/QuestLineEntry.java
@@ -77,13 +77,19 @@ public class QuestLineEntry implements IQuestLineEntry {
         this.sizeY = sizeY;
     }
 
+    @Deprecated
     @Override
-    public NBTTagCompound writeToNBT(NBTTagCompound json, boolean reduce) {
-        json.setInteger("sizeX", sizeX);
-        json.setInteger("sizeY", sizeY);
-        json.setInteger("x", posX);
-        json.setInteger("y", posY);
-        return json;
+    public NBTTagCompound writeToNBT(NBTTagCompound nbt) {
+        return writeToNBT(nbt, false);
+    }
+
+    @Override
+    public NBTTagCompound writeToNBT(NBTTagCompound nbt, boolean reduce) {
+        nbt.setInteger("sizeX", sizeX);
+        nbt.setInteger("sizeY", sizeY);
+        nbt.setInteger("x", posX);
+        nbt.setInteger("y", posY);
+        return nbt;
     }
 
     @Override

--- a/src/main/java/betterquesting/questing/QuestLineEntry.java
+++ b/src/main/java/betterquesting/questing/QuestLineEntry.java
@@ -78,7 +78,7 @@ public class QuestLineEntry implements IQuestLineEntry {
     }
 
     @Override
-    public NBTTagCompound writeToNBT(NBTTagCompound json) {
+    public NBTTagCompound writeToNBT(NBTTagCompound json, boolean reduce) {
         json.setInteger("sizeX", sizeX);
         json.setInteger("sizeY", sizeY);
         json.setInteger("x", posX);

--- a/src/main/java/betterquesting/questing/party/PartyInstance.java
+++ b/src/main/java/betterquesting/questing/party/PartyInstance.java
@@ -137,7 +137,7 @@ public class PartyInstance implements IParty {
     }
 
     @Override
-    public NBTTagCompound writeToNBT(NBTTagCompound json) {
+    public NBTTagCompound writeToNBT(NBTTagCompound json, boolean reduce) {
         NBTTagList memJson = new NBTTagList();
         for (Entry<UUID, EnumPartyStatus> mem : members.entrySet()) {
             NBTTagCompound jm = new NBTTagCompound();
@@ -147,7 +147,7 @@ public class PartyInstance implements IParty {
         }
         json.setTag("members", memJson);
 
-        json.setTag("properties", pInfo.writeToNBT(new NBTTagCompound()));
+        json.setTag("properties", pInfo.writeToNBT(new NBTTagCompound(), reduce));
 
         return json;
     }
@@ -181,7 +181,7 @@ public class PartyInstance implements IParty {
 
     @Override
     public NBTTagCompound writeProperties(NBTTagCompound nbt) {
-        return pInfo.writeToNBT(nbt);
+        return pInfo.writeToNBT(nbt, true);
     }
 
     @Override

--- a/src/main/java/betterquesting/questing/party/PartyInstance.java
+++ b/src/main/java/betterquesting/questing/party/PartyInstance.java
@@ -136,8 +136,14 @@ public class PartyInstance implements IParty {
         }
     }
 
+    @Deprecated
     @Override
-    public NBTTagCompound writeToNBT(NBTTagCompound json, boolean reduce) {
+    public NBTTagCompound writeToNBT(NBTTagCompound nbt) {
+        return writeToNBT(nbt, false);
+    }
+
+    @Override
+    public NBTTagCompound writeToNBT(NBTTagCompound nbt, boolean reduce) {
         NBTTagList memJson = new NBTTagList();
         for (Entry<UUID, EnumPartyStatus> mem : members.entrySet()) {
             NBTTagCompound jm = new NBTTagCompound();
@@ -145,11 +151,11 @@ public class PartyInstance implements IParty {
             jm.setString("status", mem.getValue().toString());
             memJson.appendTag(jm);
         }
-        json.setTag("members", memJson);
+        nbt.setTag("members", memJson);
 
-        json.setTag("properties", pInfo.writeToNBT(new NBTTagCompound(), reduce));
+        nbt.setTag("properties", pInfo.writeToNBT(new NBTTagCompound(), reduce));
 
-        return json;
+        return nbt;
     }
 
     @Override

--- a/src/main/java/betterquesting/questing/party/PartyInvitations.java
+++ b/src/main/java/betterquesting/questing/party/PartyInvitations.java
@@ -102,6 +102,12 @@ public class PartyInvitations implements INBTPartial<NBTTagList, UUID> {
         invites.clear();
     }
 
+    @Deprecated
+    @Override
+    public synchronized NBTTagList writeToNBT(NBTTagList nbt, @Nullable List<UUID> subset) {
+        return writeToNBT(nbt, subset, false);
+    }
+
     @Override
     public synchronized NBTTagList writeToNBT(NBTTagList nbt, @Nullable List<UUID> subset, boolean reduce) // Don't bother saving this to disk. We do need to send packets though
     {

--- a/src/main/java/betterquesting/questing/party/PartyInvitations.java
+++ b/src/main/java/betterquesting/questing/party/PartyInvitations.java
@@ -103,7 +103,7 @@ public class PartyInvitations implements INBTPartial<NBTTagList, UUID> {
     }
 
     @Override
-    public synchronized NBTTagList writeToNBT(NBTTagList nbt, @Nullable List<UUID> subset) // Don't bother saving this to disk. We do need to send packets though
+    public synchronized NBTTagList writeToNBT(NBTTagList nbt, @Nullable List<UUID> subset, boolean reduce) // Don't bother saving this to disk. We do need to send packets though
     {
         if (subset != null) {
             subset.forEach((uuid) -> {

--- a/src/main/java/betterquesting/questing/party/PartyManager.java
+++ b/src/main/java/betterquesting/questing/party/PartyManager.java
@@ -61,10 +61,10 @@ public class PartyManager extends SimpleDatabase<IParty> implements IPartyDataba
     }
 
     @Override
-    public synchronized NBTTagList writeToNBT(NBTTagList json, List<Integer> subset) {
+    public synchronized NBTTagList writeToNBT(NBTTagList json, List<Integer> subset, boolean reduce) {
         for (DBEntry<IParty> entry : getEntries()) {
             if (subset != null && !subset.contains(entry.getID())) continue;
-            NBTTagCompound jp = entry.getValue().writeToNBT(new NBTTagCompound());
+            NBTTagCompound jp = entry.getValue().writeToNBT(new NBTTagCompound(), reduce);
             jp.setInteger("partyID", entry.getID());
             json.appendTag(jp);
         }

--- a/src/main/java/betterquesting/questing/party/PartyManager.java
+++ b/src/main/java/betterquesting/questing/party/PartyManager.java
@@ -60,16 +60,22 @@ public class PartyManager extends SimpleDatabase<IParty> implements IPartyDataba
         return null;
     }
 
+    @Deprecated
     @Override
-    public synchronized NBTTagList writeToNBT(NBTTagList json, List<Integer> subset, boolean reduce) {
+    public synchronized NBTTagList writeToNBT(NBTTagList nbt, List<Integer> subset) {
+        return writeToNBT(nbt, subset, false);
+    }
+
+    @Override
+    public synchronized NBTTagList writeToNBT(NBTTagList nbt, List<Integer> subset, boolean reduce) {
         for (DBEntry<IParty> entry : getEntries()) {
             if (subset != null && !subset.contains(entry.getID())) continue;
             NBTTagCompound jp = entry.getValue().writeToNBT(new NBTTagCompound(), reduce);
             jp.setInteger("partyID", entry.getID());
-            json.appendTag(jp);
+            nbt.appendTag(jp);
         }
 
-        return json;
+        return nbt;
     }
 
     @Override

--- a/src/main/java/betterquesting/questing/rewards/RewardChoice.java
+++ b/src/main/java/betterquesting/questing/rewards/RewardChoice.java
@@ -1,6 +1,6 @@
 package betterquesting.questing.rewards;
 
-import betterquesting.NBTReplaceUtil;
+import betterquesting.NBTUtil;
 import betterquesting.api.api.QuestingAPI;
 import betterquesting.api.questing.IQuest;
 import betterquesting.api.questing.rewards.IReward;
@@ -59,7 +59,8 @@ public class RewardChoice implements IReward {
 
     @Override
     public boolean canClaim(EntityPlayer player, DBEntry<IQuest> quest) {
-        if (!selected.containsKey(QuestingAPI.getQuestingUUID(player))) return false;
+        if (!selected.containsKey(QuestingAPI.getQuestingUUID(player)))
+            return false;
 
         int tmp = selected.get(QuestingAPI.getQuestingUUID(player));
         return choices.size() <= 0 || (tmp >= 0 && tmp < choices.size());
@@ -92,8 +93,8 @@ public class RewardChoice implements IReward {
 
         for (ItemStack s : stack.getCombinedStacks()) {
             if (s.getTagCompound() != null) {
-                s.setTagCompound(NBTReplaceUtil.replaceStrings(s.getTagCompound(), "VAR_NAME", player.getName()));
-                s.setTagCompound(NBTReplaceUtil.replaceStrings(s.getTagCompound(), "VAR_UUID", QuestingAPI.getQuestingUUID(player).toString()));
+                s.setTagCompound(NBTUtil.replaceStrings(s.getTagCompound(), "VAR_NAME", player.getName()));
+                s.setTagCompound(NBTUtil.replaceStrings(s.getTagCompound(), "VAR_UUID", QuestingAPI.getQuestingUUID(player).toString()));
             }
 
             if (!player.inventory.addItemStackToInventory(s)) {

--- a/src/main/java/betterquesting/questing/rewards/RewardChoice.java
+++ b/src/main/java/betterquesting/questing/rewards/RewardChoice.java
@@ -112,6 +112,12 @@ public class RewardChoice implements IReward {
         }
     }
 
+    @Deprecated
+    @Override
+    public NBTTagCompound writeToNBT(NBTTagCompound nbt) {
+        return writeToNBT(nbt, false);
+    }
+
     @Override
     public NBTTagCompound writeToNBT(NBTTagCompound nbt, boolean reduce) {
         NBTTagList rJson = new NBTTagList();

--- a/src/main/java/betterquesting/questing/rewards/RewardChoice.java
+++ b/src/main/java/betterquesting/questing/rewards/RewardChoice.java
@@ -113,10 +113,10 @@ public class RewardChoice implements IReward {
     }
 
     @Override
-    public NBTTagCompound writeToNBT(NBTTagCompound nbt) {
+    public NBTTagCompound writeToNBT(NBTTagCompound nbt, boolean reduce) {
         NBTTagList rJson = new NBTTagList();
         for (BigItemStack stack : choices) {
-            rJson.appendTag(JsonHelper.ItemStackToJson(stack, new NBTTagCompound()));
+            rJson.appendTag(JsonHelper.ItemStackToJson(stack, new NBTTagCompound(), reduce));
         }
         nbt.setTag("choices", rJson);
         return nbt;

--- a/src/main/java/betterquesting/questing/rewards/RewardCommand.java
+++ b/src/main/java/betterquesting/questing/rewards/RewardCommand.java
@@ -95,6 +95,12 @@ public class RewardCommand implements IReward {
         asScript = NBTUtil.getBoolean(nbt, "asScript", DEFAULT_AS_SCRIPT);
     }
 
+    @Deprecated
+    @Override
+    public NBTTagCompound writeToNBT(NBTTagCompound nbt) {
+        return writeToNBT(nbt, false);
+    }
+
     @Override
     public NBTTagCompound writeToNBT(NBTTagCompound nbt, boolean reduce) {
         nbt.setString("command", command);

--- a/src/main/java/betterquesting/questing/rewards/RewardCommand.java
+++ b/src/main/java/betterquesting/questing/rewards/RewardCommand.java
@@ -1,6 +1,7 @@
 package betterquesting.questing.rewards;
 
 import betterquesting.AdminExecute;
+import betterquesting.NBTUtil;
 import betterquesting.api.api.QuestingAPI;
 import betterquesting.api.questing.IQuest;
 import betterquesting.api.questing.rewards.IReward;
@@ -28,12 +29,18 @@ import java.util.Arrays;
 import java.util.UUID;
 
 public class RewardCommand implements IReward {
+
+    private static final String DEFAULT_TITLE = "bq_standard.reward.command";
+    private static final String DEFAULT_DESC = "Run a command script";
+    private static final boolean DEFAULT_VIA_PLAYER = false;
+    private static final boolean DEFAULT_HIDE_ICON = true;
+    private static final boolean DEFAULT_AS_SCRIPT = true;
     public String command = "#Script Comment\nsay Running reward script...\nsay @s Claimed a reward";
-    public String title = "bq_standard.reward.command";
-    public String desc = "Run a command script";
-    public boolean viaPlayer = false;
-    public boolean hideIcon = true;
-    public boolean asScript = true;
+    public String title = DEFAULT_TITLE;
+    public String desc = DEFAULT_DESC;
+    public boolean viaPlayer = DEFAULT_VIA_PLAYER;
+    public boolean hideIcon = DEFAULT_HIDE_ICON;
+    public boolean asScript = DEFAULT_AS_SCRIPT;
 
     @Override
     public ResourceLocation getFactoryID() {
@@ -81,21 +88,26 @@ public class RewardCommand implements IReward {
     @Override
     public void readFromNBT(NBTTagCompound nbt) {
         command = nbt.getString("command");
-        title = nbt.hasKey("title", 8) ? nbt.getString("title") : "bq_standard.reward.command";
-        desc = nbt.hasKey("description", 8) ? nbt.getString("description") : "Run a command script";
-        viaPlayer = nbt.getBoolean("viaPlayer");
-        hideIcon = !nbt.hasKey("hideBlockIcon", 1) || nbt.getBoolean("hideBlockIcon");
-        asScript = !nbt.hasKey("asScript", 1) || nbt.getBoolean("asScript");
+        title = NBTUtil.getString(nbt, "title", DEFAULT_TITLE);
+        desc = NBTUtil.getString(nbt, "description", DEFAULT_DESC);
+        viaPlayer = NBTUtil.getBoolean(nbt, "viaPlayer", DEFAULT_VIA_PLAYER);
+        hideIcon = NBTUtil.getBoolean(nbt, "hideBlockIcon", DEFAULT_HIDE_ICON);
+        asScript = NBTUtil.getBoolean(nbt, "asScript", DEFAULT_AS_SCRIPT);
     }
 
     @Override
-    public NBTTagCompound writeToNBT(NBTTagCompound nbt) {
+    public NBTTagCompound writeToNBT(NBTTagCompound nbt, boolean reduce) {
         nbt.setString("command", command);
-        nbt.setString("title", title);
-        nbt.setString("description", desc);
-        nbt.setBoolean("viaPlayer", viaPlayer);
-        nbt.setBoolean("hideBlockIcon", hideIcon);
-        nbt.setBoolean("asScript", asScript);
+        if (!reduce || !title.equals(DEFAULT_TITLE))
+            nbt.setString("title", title);
+        if (!reduce || !desc.equals(DEFAULT_TITLE))
+            nbt.setString("description", desc);
+        if (!reduce || viaPlayer != DEFAULT_VIA_PLAYER)
+            nbt.setBoolean("viaPlayer", viaPlayer);
+        if (!reduce || hideIcon != DEFAULT_HIDE_ICON)
+            nbt.setBoolean("hideBlockIcon", hideIcon);
+        if (!reduce || asScript != DEFAULT_AS_SCRIPT)
+            nbt.setBoolean("asScript", asScript);
         return nbt;
     }
 

--- a/src/main/java/betterquesting/questing/rewards/RewardItem.java
+++ b/src/main/java/betterquesting/questing/rewards/RewardItem.java
@@ -1,6 +1,6 @@
 package betterquesting.questing.rewards;
 
-import betterquesting.NBTReplaceUtil;
+import betterquesting.NBTUtil;
 import betterquesting.api.api.QuestingAPI;
 import betterquesting.api.questing.IQuest;
 import betterquesting.api.questing.rewards.IReward;
@@ -48,8 +48,8 @@ public class RewardItem implements IReward {
 
             for (ItemStack s : stack.getCombinedStacks()) {
                 if (s.getTagCompound() != null) {
-                    s.setTagCompound(NBTReplaceUtil.replaceStrings(s.getTagCompound(), "VAR_NAME", player.getName()));
-                    s.setTagCompound(NBTReplaceUtil.replaceStrings(s.getTagCompound(), "VAR_UUID", QuestingAPI.getQuestingUUID(player).toString()));
+                    s.setTagCompound(NBTUtil.replaceStrings(s.getTagCompound(), "VAR_NAME", player.getName()));
+                    s.setTagCompound(NBTUtil.replaceStrings(s.getTagCompound(), "VAR_UUID", QuestingAPI.getQuestingUUID(player).toString()));
                 }
 
                 if (!player.inventory.addItemStackToInventory(s)) {
@@ -66,7 +66,8 @@ public class RewardItem implements IReward {
         for (int i = 0; i < rList.tagCount(); i++) {
             try {
                 BigItemStack item = JsonHelper.JsonToItemStack(rList.getCompoundTagAt(i));
-                if (item != null) items.add(item);
+                if (item != null)
+                    items.add(item);
             } catch (Exception e) {
                 BetterQuesting.logger.log(Level.ERROR, "Unable to load reward item data", e);
             }

--- a/src/main/java/betterquesting/questing/rewards/RewardItem.java
+++ b/src/main/java/betterquesting/questing/rewards/RewardItem.java
@@ -75,10 +75,10 @@ public class RewardItem implements IReward {
     }
 
     @Override
-    public NBTTagCompound writeToNBT(NBTTagCompound nbt) {
+    public NBTTagCompound writeToNBT(NBTTagCompound nbt, boolean reduce) {
         NBTTagList rJson = new NBTTagList();
         for (BigItemStack stack : items) {
-            rJson.appendTag(JsonHelper.ItemStackToJson(stack, new NBTTagCompound()));
+            rJson.appendTag(JsonHelper.ItemStackToJson(stack, new NBTTagCompound(), reduce));
         }
         nbt.setTag("rewards", rJson);
         return nbt;

--- a/src/main/java/betterquesting/questing/rewards/RewardItem.java
+++ b/src/main/java/betterquesting/questing/rewards/RewardItem.java
@@ -74,6 +74,12 @@ public class RewardItem implements IReward {
         }
     }
 
+    @Deprecated
+    @Override
+    public NBTTagCompound writeToNBT(NBTTagCompound nbt) {
+        return writeToNBT(nbt, false);
+    }
+
     @Override
     public NBTTagCompound writeToNBT(NBTTagCompound nbt, boolean reduce) {
         NBTTagList rJson = new NBTTagList();

--- a/src/main/java/betterquesting/questing/rewards/RewardRecipe.java
+++ b/src/main/java/betterquesting/questing/rewards/RewardRecipe.java
@@ -58,6 +58,12 @@ public class RewardRecipe implements IReward {
         return null;
     }
 
+    @Deprecated
+    @Override
+    public NBTTagCompound writeToNBT(NBTTagCompound nbt) {
+        return writeToNBT(nbt, false);
+    }
+
     @Override
     public NBTTagCompound writeToNBT(NBTTagCompound nbt, boolean reduce) {
         nbt.setString("recipes", recipeNames);

--- a/src/main/java/betterquesting/questing/rewards/RewardRecipe.java
+++ b/src/main/java/betterquesting/questing/rewards/RewardRecipe.java
@@ -59,7 +59,7 @@ public class RewardRecipe implements IReward {
     }
 
     @Override
-    public NBTTagCompound writeToNBT(NBTTagCompound nbt) {
+    public NBTTagCompound writeToNBT(NBTTagCompound nbt, boolean reduce) {
         nbt.setString("recipes", recipeNames);
         return nbt;
     }

--- a/src/main/java/betterquesting/questing/rewards/RewardScoreboard.java
+++ b/src/main/java/betterquesting/questing/rewards/RewardScoreboard.java
@@ -1,5 +1,6 @@
 package betterquesting.questing.rewards;
 
+import betterquesting.NBTUtil;
 import betterquesting.api.questing.IQuest;
 import betterquesting.api.questing.rewards.IReward;
 import betterquesting.api2.client.gui.misc.IGuiRect;
@@ -18,9 +19,12 @@ import net.minecraftforge.fml.relauncher.SideOnly;
 import org.apache.logging.log4j.Level;
 
 public class RewardScoreboard implements IReward {
+
+    private static final String DEFAULT_TYPE = "dummy";
+    private static final boolean DEFAULT_RELATIVE = true;
     public String score = "Reputation";
-    public String type = "dummy";
-    public boolean relative = true;
+    public String type = DEFAULT_TYPE;
+    public boolean relative = DEFAULT_RELATIVE;
     public int value = 1;
 
     @Override
@@ -69,20 +73,22 @@ public class RewardScoreboard implements IReward {
     }
 
     @Override
-    public void readFromNBT(NBTTagCompound json) {
-        score = json.getString("score");
-        type = json.getString("type");
-        value = json.getInteger("value");
-        relative = json.getBoolean("relative");
+    public void readFromNBT(NBTTagCompound nbt) {
+        score = nbt.getString("score");
+        type = NBTUtil.getString(nbt, "type", DEFAULT_TYPE);
+        value = nbt.getInteger("value");
+        relative = NBTUtil.getBoolean(nbt, "relative", DEFAULT_RELATIVE);
     }
 
     @Override
-    public NBTTagCompound writeToNBT(NBTTagCompound json) {
-        json.setString("score", score);
-        json.setString("type", "dummy");
-        json.setInteger("value", value);
-        json.setBoolean("relative", relative);
-        return json;
+    public NBTTagCompound writeToNBT(NBTTagCompound nbt, boolean reduce) {
+        nbt.setString("score", score);
+        if (!reduce || !type.equals(DEFAULT_TYPE))
+            nbt.setString("type", "dummy");
+        nbt.setInteger("value", value);
+        if (!reduce || relative != DEFAULT_RELATIVE)
+            nbt.setBoolean("relative", relative);
+        return nbt;
     }
 
     @Override

--- a/src/main/java/betterquesting/questing/rewards/RewardScoreboard.java
+++ b/src/main/java/betterquesting/questing/rewards/RewardScoreboard.java
@@ -80,6 +80,12 @@ public class RewardScoreboard implements IReward {
         relative = NBTUtil.getBoolean(nbt, "relative", DEFAULT_RELATIVE);
     }
 
+    @Deprecated
+    @Override
+    public NBTTagCompound writeToNBT(NBTTagCompound nbt) {
+        return writeToNBT(nbt, false);
+    }
+
     @Override
     public NBTTagCompound writeToNBT(NBTTagCompound nbt, boolean reduce) {
         nbt.setString("score", score);

--- a/src/main/java/betterquesting/questing/rewards/RewardStorage.java
+++ b/src/main/java/betterquesting/questing/rewards/RewardStorage.java
@@ -16,11 +16,11 @@ import java.util.UUID;
 
 public class RewardStorage extends SimpleDatabase<IReward> implements IDatabaseNBT<IReward, NBTTagList, NBTTagList> {
     @Override
-    public NBTTagList writeToNBT(NBTTagList json, @Nullable List<Integer> subset) {
+    public NBTTagList writeToNBT(NBTTagList json, @Nullable List<Integer> subset, boolean reduce) {
         for (DBEntry<IReward> rew : getEntries()) {
             if (subset != null && !subset.contains(rew.getID())) continue;
             ResourceLocation rewardID = rew.getValue().getFactoryID();
-            NBTTagCompound rJson = rew.getValue().writeToNBT(new NBTTagCompound());
+            NBTTagCompound rJson = rew.getValue().writeToNBT(new NBTTagCompound(), reduce);
             rJson.setString("rewardID", rewardID.toString());
             rJson.setInteger("index", rew.getID());
             json.appendTag(rJson);

--- a/src/main/java/betterquesting/questing/rewards/RewardStorage.java
+++ b/src/main/java/betterquesting/questing/rewards/RewardStorage.java
@@ -15,18 +15,24 @@ import java.util.List;
 import java.util.UUID;
 
 public class RewardStorage extends SimpleDatabase<IReward> implements IDatabaseNBT<IReward, NBTTagList, NBTTagList> {
+    @Deprecated
     @Override
-    public NBTTagList writeToNBT(NBTTagList json, @Nullable List<Integer> subset, boolean reduce) {
+    public NBTTagList writeToNBT(NBTTagList nbt, @Nullable List<Integer> subset) {
+        return writeToNBT(nbt, subset, false);
+    }
+
+    @Override
+    public NBTTagList writeToNBT(NBTTagList nbt, @Nullable List<Integer> subset, boolean reduce) {
         for (DBEntry<IReward> rew : getEntries()) {
             if (subset != null && !subset.contains(rew.getID())) continue;
             ResourceLocation rewardID = rew.getValue().getFactoryID();
             NBTTagCompound rJson = rew.getValue().writeToNBT(new NBTTagCompound(), reduce);
             rJson.setString("rewardID", rewardID.toString());
             rJson.setInteger("index", rew.getID());
-            json.appendTag(rJson);
+            nbt.appendTag(rJson);
         }
 
-        return json;
+        return nbt;
     }
 
     @Override

--- a/src/main/java/betterquesting/questing/rewards/RewardXP.java
+++ b/src/main/java/betterquesting/questing/rewards/RewardXP.java
@@ -48,6 +48,12 @@ public class RewardXP implements IReward {
         levels = NBTUtil.getBoolean(nbt, "isLevels", DEFAULT_LEVELS);
     }
 
+    @Deprecated
+    @Override
+    public NBTTagCompound writeToNBT(NBTTagCompound nbt) {
+        return writeToNBT(nbt, false);
+    }
+
     @Override
     public NBTTagCompound writeToNBT(NBTTagCompound nbt, boolean reduce) {
         if (!reduce || amount != DEFAULT_AMOUNT)

--- a/src/main/java/betterquesting/questing/rewards/RewardXP.java
+++ b/src/main/java/betterquesting/questing/rewards/RewardXP.java
@@ -1,5 +1,6 @@
 package betterquesting.questing.rewards;
 
+import betterquesting.NBTUtil;
 import betterquesting.XPHelper;
 import betterquesting.api.questing.IQuest;
 import betterquesting.api.questing.rewards.IReward;
@@ -16,8 +17,10 @@ import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
 public class RewardXP implements IReward {
-    public int amount = 1;
-    public boolean levels = true;
+    private static final int DEFAULT_AMOUNT = 1;
+    private static final boolean DEFAULT_LEVELS = true;
+    public int amount = DEFAULT_AMOUNT;
+    public boolean levels = DEFAULT_LEVELS;
 
     @Override
     public ResourceLocation getFactoryID() {
@@ -41,14 +44,16 @@ public class RewardXP implements IReward {
 
     @Override
     public void readFromNBT(NBTTagCompound nbt) {
-        amount = nbt.getInteger("amount");
-        levels = nbt.getBoolean("isLevels");
+        amount = NBTUtil.getInteger(nbt, "amount", DEFAULT_AMOUNT);
+        levels = NBTUtil.getBoolean(nbt, "isLevels", DEFAULT_LEVELS);
     }
 
     @Override
-    public NBTTagCompound writeToNBT(NBTTagCompound nbt) {
-        nbt.setInteger("amount", amount);
-        nbt.setBoolean("isLevels", levels);
+    public NBTTagCompound writeToNBT(NBTTagCompound nbt, boolean reduce) {
+        if (!reduce || amount != DEFAULT_AMOUNT)
+            nbt.setInteger("amount", amount);
+        if (!reduce || levels != DEFAULT_LEVELS)
+            nbt.setBoolean("isLevels", levels);
         return nbt;
     }
 

--- a/src/main/java/betterquesting/questing/rewards/loot/LootGroup.java
+++ b/src/main/java/betterquesting/questing/rewards/loot/LootGroup.java
@@ -73,7 +73,7 @@ public class LootGroup extends SimpleDatabase<LootGroup.LootEntry> implements IN
     }
 
     @Override
-    public NBTTagCompound writeToNBT(NBTTagCompound tag) {
+    public NBTTagCompound writeToNBT(NBTTagCompound tag, boolean reduce) {
         tag.setString("name", name);
         tag.setInteger("weight", weight);
 
@@ -81,7 +81,7 @@ public class LootGroup extends SimpleDatabase<LootGroup.LootEntry> implements IN
         for (DBEntry<LootEntry> entry : getEntries()) {
             if (entry == null) continue;
 
-            NBTTagCompound jLoot = entry.getValue().writeToNBT(new NBTTagCompound());
+            NBTTagCompound jLoot = entry.getValue().writeToNBT(new NBTTagCompound(), reduce);
             jLoot.setInteger("ID", entry.getID());
             jRew.appendTag(jLoot);
         }
@@ -107,12 +107,12 @@ public class LootGroup extends SimpleDatabase<LootGroup.LootEntry> implements IN
         }
 
         @Override
-        public NBTTagCompound writeToNBT(NBTTagCompound tag) {
+        public NBTTagCompound writeToNBT(NBTTagCompound tag, boolean reduce) {
             tag.setInteger("weight", weight);
 
             NBTTagList jItm = new NBTTagList();
             for (BigItemStack stack : items) {
-                jItm.appendTag(JsonHelper.ItemStackToJson(stack, new NBTTagCompound()));
+                jItm.appendTag(JsonHelper.ItemStackToJson(stack, new NBTTagCompound(), reduce));
             }
             tag.setTag("items", jItm);
 

--- a/src/main/java/betterquesting/questing/rewards/loot/LootGroup.java
+++ b/src/main/java/betterquesting/questing/rewards/loot/LootGroup.java
@@ -72,10 +72,16 @@ public class LootGroup extends SimpleDatabase<LootGroup.LootEntry> implements IN
         }
     }
 
+    @Deprecated
     @Override
-    public NBTTagCompound writeToNBT(NBTTagCompound tag, boolean reduce) {
-        tag.setString("name", name);
-        tag.setInteger("weight", weight);
+    public NBTTagCompound writeToNBT(NBTTagCompound nbt) {
+        return writeToNBT(nbt, false);
+    }
+
+    @Override
+    public NBTTagCompound writeToNBT(NBTTagCompound nbt, boolean reduce) {
+        nbt.setString("name", name);
+        nbt.setInteger("weight", weight);
 
         NBTTagList jRew = new NBTTagList();
         for (DBEntry<LootEntry> entry : getEntries()) {
@@ -85,9 +91,9 @@ public class LootGroup extends SimpleDatabase<LootGroup.LootEntry> implements IN
             jLoot.setInteger("ID", entry.getID());
             jRew.appendTag(jLoot);
         }
-        tag.setTag("rewards", jRew);
+        nbt.setTag("rewards", jRew);
 
-        return tag;
+        return nbt;
     }
 
     public static class LootEntry implements INBTSaveLoad<NBTTagCompound> {
@@ -104,6 +110,12 @@ public class LootGroup extends SimpleDatabase<LootGroup.LootEntry> implements IN
             for (int i = 0; i < jItm.tagCount(); i++) {
                 items.add(JsonHelper.JsonToItemStack(jItm.getCompoundTagAt(i)));
             }
+        }
+
+        @Deprecated
+        @Override
+        public NBTTagCompound writeToNBT(NBTTagCompound nbt) {
+            return writeToNBT(nbt, false);
         }
 
         @Override

--- a/src/main/java/betterquesting/questing/rewards/loot/LootRegistry.java
+++ b/src/main/java/betterquesting/questing/rewards/loot/LootRegistry.java
@@ -62,8 +62,14 @@ public class LootRegistry extends SimpleDatabase<LootGroup> implements INBTParti
         return null;
     }
 
+    @Deprecated
     @Override
-    public synchronized NBTTagCompound writeToNBT(NBTTagCompound tag, @Nullable List<Integer> subset, boolean reduce) {
+    public synchronized NBTTagCompound writeToNBT(NBTTagCompound nbt, @Nullable List<Integer> subset) {
+        return writeToNBT(nbt, subset, false);
+    }
+
+    @Override
+    public synchronized NBTTagCompound writeToNBT(NBTTagCompound nbt, @Nullable List<Integer> subset, boolean reduce) {
         NBTTagList jRew = new NBTTagList();
         for (DBEntry<LootGroup> entry : getEntries()) {
             if (subset != null && !subset.contains(entry.getID())) continue;
@@ -71,9 +77,9 @@ public class LootRegistry extends SimpleDatabase<LootGroup> implements INBTParti
             jGrp.setInteger("ID", entry.getID());
             jRew.appendTag(jGrp);
         }
-        tag.setTag("groups", jRew);
+        nbt.setTag("groups", jRew);
 
-        return tag;
+        return nbt;
     }
 
     @Override

--- a/src/main/java/betterquesting/questing/rewards/loot/LootRegistry.java
+++ b/src/main/java/betterquesting/questing/rewards/loot/LootRegistry.java
@@ -63,11 +63,11 @@ public class LootRegistry extends SimpleDatabase<LootGroup> implements INBTParti
     }
 
     @Override
-    public synchronized NBTTagCompound writeToNBT(NBTTagCompound tag, @Nullable List<Integer> subset) {
+    public synchronized NBTTagCompound writeToNBT(NBTTagCompound tag, @Nullable List<Integer> subset, boolean reduce) {
         NBTTagList jRew = new NBTTagList();
         for (DBEntry<LootGroup> entry : getEntries()) {
             if (subset != null && !subset.contains(entry.getID())) continue;
-            NBTTagCompound jGrp = entry.getValue().writeToNBT(new NBTTagCompound());
+            NBTTagCompound jGrp = entry.getValue().writeToNBT(new NBTTagCompound(), reduce);
             jGrp.setInteger("ID", entry.getID());
             jRew.appendTag(jGrp);
         }

--- a/src/main/java/betterquesting/questing/tasks/TaskAdvancement.java
+++ b/src/main/java/betterquesting/questing/tasks/TaskAdvancement.java
@@ -117,7 +117,7 @@ public class TaskAdvancement implements ITask {
     }
 
     @Override
-    public NBTTagCompound writeToNBT(NBTTagCompound nbt) {
+    public NBTTagCompound writeToNBT(NBTTagCompound nbt, boolean reduce) {
         nbt.setString("advancement_id", advID == null ? "" : advID.toString());
         return nbt;
     }

--- a/src/main/java/betterquesting/questing/tasks/TaskAdvancement.java
+++ b/src/main/java/betterquesting/questing/tasks/TaskAdvancement.java
@@ -116,6 +116,12 @@ public class TaskAdvancement implements ITask {
         }
     }
 
+    @Deprecated
+    @Override
+    public NBTTagCompound writeToNBT(NBTTagCompound nbt) {
+        return writeToNBT(nbt, false);
+    }
+
     @Override
     public NBTTagCompound writeToNBT(NBTTagCompound nbt, boolean reduce) {
         nbt.setString("advancement_id", advID == null ? "" : advID.toString());

--- a/src/main/java/betterquesting/questing/tasks/TaskBlockBreak.java
+++ b/src/main/java/betterquesting/questing/tasks/TaskBlockBreak.java
@@ -108,6 +108,12 @@ public class TaskBlockBreak implements ITask {
         }
     }
 
+    @Deprecated
+    @Override
+    public NBTTagCompound writeToNBT(NBTTagCompound nbt) {
+        return writeToNBT(nbt, false);
+    }
+
     @Override
     public NBTTagCompound writeToNBT(NBTTagCompound nbt, boolean reduce) {
         NBTTagList bAry = new NBTTagList();

--- a/src/main/java/betterquesting/questing/tasks/TaskBlockBreak.java
+++ b/src/main/java/betterquesting/questing/tasks/TaskBlockBreak.java
@@ -109,10 +109,10 @@ public class TaskBlockBreak implements ITask {
     }
 
     @Override
-    public NBTTagCompound writeToNBT(NBTTagCompound nbt) {
+    public NBTTagCompound writeToNBT(NBTTagCompound nbt, boolean reduce) {
         NBTTagList bAry = new NBTTagList();
         for (NbtBlockType block : blockTypes) {
-            bAry.appendTag(block.writeToNBT(new NBTTagCompound()));
+            bAry.appendTag(block.writeToNBT(new NBTTagCompound(), reduce));
         }
         nbt.setTag("blocks", bAry);
 

--- a/src/main/java/betterquesting/questing/tasks/TaskCheckbox.java
+++ b/src/main/java/betterquesting/questing/tasks/TaskCheckbox.java
@@ -57,7 +57,7 @@ public class TaskCheckbox implements ITask {
     }
 
     @Override
-    public NBTTagCompound writeToNBT(NBTTagCompound nbt) {
+    public NBTTagCompound writeToNBT(NBTTagCompound nbt, boolean reduce) {
         return nbt;
     }
 

--- a/src/main/java/betterquesting/questing/tasks/TaskCheckbox.java
+++ b/src/main/java/betterquesting/questing/tasks/TaskCheckbox.java
@@ -56,6 +56,12 @@ public class TaskCheckbox implements ITask {
         }
     }
 
+    @Deprecated
+    @Override
+    public NBTTagCompound writeToNBT(NBTTagCompound nbt) {
+        return writeToNBT(nbt, false);
+    }
+
     @Override
     public NBTTagCompound writeToNBT(NBTTagCompound nbt, boolean reduce) {
         return nbt;

--- a/src/main/java/betterquesting/questing/tasks/TaskCrafting.java
+++ b/src/main/java/betterquesting/questing/tasks/TaskCrafting.java
@@ -122,6 +122,12 @@ public class TaskCrafting implements ITask {
         }
     }
 
+    @Deprecated
+    @Override
+    public NBTTagCompound writeToNBT(NBTTagCompound nbt) {
+        return writeToNBT(nbt, false);
+    }
+
     @Override
     public NBTTagCompound writeToNBT(NBTTagCompound nbt, boolean reduce) {
         if (!reduce || partialMatch != DEFAULT_PARTIAL_MATCH)

--- a/src/main/java/betterquesting/questing/tasks/TaskCrafting.java
+++ b/src/main/java/betterquesting/questing/tasks/TaskCrafting.java
@@ -1,5 +1,6 @@
 package betterquesting.questing.tasks;
 
+import betterquesting.NBTUtil;
 import betterquesting.api.questing.IQuest;
 import betterquesting.api.questing.tasks.ITask;
 import betterquesting.api.utils.BigItemStack;
@@ -30,14 +31,20 @@ import javax.annotation.Nullable;
 import java.util.*;
 
 public class TaskCrafting implements ITask {
+
+    private static final boolean DEFAULT_PARTIAL_MATCH = true;
+    private static final boolean DEFAULT_IGNORE_NBT = false;
+    private static final boolean DEFAULT_ALLOW_ANVIL = false;
+    private static final boolean DEFAULT_ALLOW_SMELT = true;
+    private static final boolean DEFAULT_ALLOW_CRAFT = true;
     private final Set<UUID> completeUsers = new TreeSet<>();
     public final NonNullList<BigItemStack> requiredItems = NonNullList.create();
     public final TreeMap<UUID, int[]> userProgress = new TreeMap<>();
-    public boolean partialMatch = true;
-    public boolean ignoreNBT = false;
-    public boolean allowAnvil = false;
-    public boolean allowSmelt = true;
-    public boolean allowCraft = true;
+    public boolean partialMatch = DEFAULT_PARTIAL_MATCH;
+    public boolean ignoreNBT = DEFAULT_IGNORE_NBT;
+    public boolean allowAnvil = DEFAULT_ALLOW_ANVIL;
+    public boolean allowSmelt = DEFAULT_ALLOW_SMELT;
+    public boolean allowCraft = DEFAULT_ALLOW_CRAFT;
 
     @Override
     public ResourceLocation getFactoryID() {
@@ -116,16 +123,21 @@ public class TaskCrafting implements ITask {
     }
 
     @Override
-    public NBTTagCompound writeToNBT(NBTTagCompound nbt) {
-        nbt.setBoolean("partialMatch", partialMatch);
-        nbt.setBoolean("ignoreNBT", ignoreNBT);
-        nbt.setBoolean("allowCraft", allowCraft);
-        nbt.setBoolean("allowSmelt", allowSmelt);
-        nbt.setBoolean("allowAnvil", allowAnvil);
+    public NBTTagCompound writeToNBT(NBTTagCompound nbt, boolean reduce) {
+        if (!reduce || partialMatch != DEFAULT_PARTIAL_MATCH)
+            nbt.setBoolean("partialMatch", partialMatch);
+        if (!reduce || ignoreNBT != DEFAULT_IGNORE_NBT)
+            nbt.setBoolean("ignoreNBT", ignoreNBT);
+        if (!reduce || allowCraft != DEFAULT_ALLOW_CRAFT)
+            nbt.setBoolean("allowCraft", allowCraft);
+        if (!reduce || allowSmelt != DEFAULT_ALLOW_SMELT)
+            nbt.setBoolean("allowSmelt", allowSmelt);
+        if (!reduce || allowAnvil != DEFAULT_ALLOW_ANVIL)
+            nbt.setBoolean("allowAnvil", allowAnvil);
 
         NBTTagList itemArray = new NBTTagList();
         for (BigItemStack stack : this.requiredItems) {
-            itemArray.appendTag(JsonHelper.ItemStackToJson(stack, new NBTTagCompound()));
+            itemArray.appendTag(JsonHelper.ItemStackToJson(stack, new NBTTagCompound(), reduce));
         }
         nbt.setTag("requiredItems", itemArray);
 
@@ -134,11 +146,11 @@ public class TaskCrafting implements ITask {
 
     @Override
     public void readFromNBT(NBTTagCompound nbt) {
-        partialMatch = nbt.getBoolean("partialMatch");
-        ignoreNBT = nbt.getBoolean("ignoreNBT");
-        if (nbt.hasKey("allowCraft")) allowCraft = nbt.getBoolean("allowCraft");
-        if (nbt.hasKey("allowSmelt")) allowSmelt = nbt.getBoolean("allowSmelt");
-        if (nbt.hasKey("allowAnvil")) allowAnvil = nbt.getBoolean("allowAnvil");
+        partialMatch = NBTUtil.getBoolean(nbt, "partialMatch", DEFAULT_PARTIAL_MATCH);
+        ignoreNBT = NBTUtil.getBoolean(nbt, "ignoreNBT", DEFAULT_IGNORE_NBT);
+        allowCraft = NBTUtil.getBoolean(nbt, "allowCraft", DEFAULT_ALLOW_CRAFT);
+        allowSmelt = NBTUtil.getBoolean(nbt, "allowSmelt", DEFAULT_ALLOW_SMELT);
+        allowAnvil = NBTUtil.getBoolean(nbt, "allowAnvil", DEFAULT_ALLOW_ANVIL);
 
         requiredItems.clear();
         NBTTagList iList = nbt.getTagList("requiredItems", 10);

--- a/src/main/java/betterquesting/questing/tasks/TaskFluid.java
+++ b/src/main/java/betterquesting/questing/tasks/TaskFluid.java
@@ -1,5 +1,6 @@
 package betterquesting.questing.tasks;
 
+import betterquesting.NBTUtil;
 import betterquesting.api.questing.IQuest;
 import betterquesting.api.questing.tasks.IFluidTask;
 import betterquesting.api.questing.tasks.IItemTask;
@@ -37,14 +38,19 @@ import javax.annotation.Nullable;
 import java.util.*;
 
 public class TaskFluid implements ITaskInventory, IFluidTask, IItemTask {
+
+    private static final boolean DEFAULT_IGNORE_NBT = false;
+    private static final boolean DEFAULT_CONSUME = true;
+    private static final boolean DEFAULT_GROUP_DETECT = false;
+    private static final boolean DEFAULT_AUTO_CONSUME = false;
     private final Set<UUID> completeUsers = new TreeSet<>();
     public final NonNullList<FluidStack> requiredFluids = NonNullList.create();
     public final TreeMap<UUID, int[]> userProgress = new TreeMap<>();
     //public boolean partialMatch = true; // Not many ideal ways of implementing this with fluid handlers
-    public boolean ignoreNbt = false;
-    public boolean consume = true;
-    public boolean groupDetect = false;
-    public boolean autoConsume = false;
+    public boolean ignoreNBT = DEFAULT_IGNORE_NBT;
+    public boolean consume = DEFAULT_CONSUME;
+    public boolean groupDetect = DEFAULT_GROUP_DETECT;
+    public boolean autoConsume = DEFAULT_AUTO_CONSUME;
 
     @Override
     public ResourceLocation getFactoryID() {
@@ -121,7 +127,8 @@ public class TaskFluid implements ITaskInventory, IFluidTask, IItemTask {
                 for (int j = 0; j < requiredFluids.size(); j++) {
                     final FluidStack rStack = requiredFluids.get(j);
                     FluidStack drainOG = rStack.copy();
-                    if (ignoreNbt) drainOG.tag = null;
+                    if (ignoreNBT)
+                        drainOG.tag = null;
 
                     // Pre-check
                     FluidStack sample = handler.drain(drainOG, false);
@@ -134,8 +141,10 @@ public class TaskFluid implements ITaskInventory, IFluidTask, IItemTask {
 
                         FluidStack drain = rStack.copy();
                         drain.amount = remaining / stack.getCount(); // Must be a multiple of the stack size
-                        if (ignoreNbt) drain.tag = null;
-                        if (drain.amount <= 0) continue;
+                        if (ignoreNBT)
+                            drain.tag = null;
+                        if (drain.amount <= 0)
+                            continue;
 
                         FluidStack fluid = handler.drain(drain, consume); // TODO: Look into reducing this to a single call if possible
                         if (fluid == null || fluid.amount <= 0) continue;
@@ -185,12 +194,16 @@ public class TaskFluid implements ITaskInventory, IFluidTask, IItemTask {
     }
 
     @Override
-    public NBTTagCompound writeToNBT(NBTTagCompound nbt) {
+    public NBTTagCompound writeToNBT(NBTTagCompound nbt, boolean reduce) {
         //json.setBoolean("partialMatch", partialMatch);
-        nbt.setBoolean("ignoreNBT", ignoreNbt);
-        nbt.setBoolean("consume", consume);
-        nbt.setBoolean("groupDetect", groupDetect);
-        nbt.setBoolean("autoConsume", autoConsume);
+        if (!reduce || ignoreNBT != DEFAULT_IGNORE_NBT)
+            nbt.setBoolean("ignoreNBT", ignoreNBT);
+        if (!reduce || consume != DEFAULT_CONSUME)
+            nbt.setBoolean("consume", consume);
+        if (!reduce || groupDetect != DEFAULT_GROUP_DETECT)
+            nbt.setBoolean("groupDetect", groupDetect);
+        if (!reduce || autoConsume != DEFAULT_AUTO_CONSUME)
+            nbt.setBoolean("autoConsume", autoConsume);
 
         NBTTagList itemArray = new NBTTagList();
         for (FluidStack stack : this.requiredFluids) {
@@ -204,10 +217,10 @@ public class TaskFluid implements ITaskInventory, IFluidTask, IItemTask {
     @Override
     public void readFromNBT(NBTTagCompound nbt) {
         //partialMatch = json.getBoolean("partialMatch");
-        ignoreNbt = nbt.getBoolean("ignoreNBT");
-        consume = nbt.getBoolean("consume");
-        groupDetect = nbt.getBoolean("groupDetect");
-        autoConsume = nbt.getBoolean("autoConsume");
+        ignoreNBT = NBTUtil.getBoolean(nbt, "ignoreNBT", DEFAULT_IGNORE_NBT);
+        consume = NBTUtil.getBoolean(nbt, "consume", DEFAULT_CONSUME);
+        groupDetect = NBTUtil.getBoolean(nbt, "groupDetect", DEFAULT_GROUP_DETECT);
+        autoConsume = NBTUtil.getBoolean(nbt, "autoConsume", DEFAULT_AUTO_CONSUME);
 
         requiredFluids.clear();
         NBTTagList fList = nbt.getTagList("requiredFluids", 10);
@@ -323,8 +336,10 @@ public class TaskFluid implements ITaskInventory, IFluidTask, IItemTask {
 
         for (int j = 0; j < requiredFluids.size(); j++) {
             FluidStack rStack = requiredFluids.get(j).copy();
-            if (ignoreNbt) rStack.tag = null;
-            if (progress[j] < rStack.amount && rStack.equals(fluid)) return true;
+            if (ignoreNBT)
+                rStack.tag = null;
+            if (progress[j] < rStack.amount && rStack.equals(fluid))
+                return true;
         }
 
         return false;

--- a/src/main/java/betterquesting/questing/tasks/TaskFluid.java
+++ b/src/main/java/betterquesting/questing/tasks/TaskFluid.java
@@ -193,6 +193,12 @@ public class TaskFluid implements ITaskInventory, IFluidTask, IItemTask {
         }
     }
 
+    @Deprecated
+    @Override
+    public NBTTagCompound writeToNBT(NBTTagCompound nbt) {
+        return writeToNBT(nbt, false);
+    }
+
     @Override
     public NBTTagCompound writeToNBT(NBTTagCompound nbt, boolean reduce) {
         //json.setBoolean("partialMatch", partialMatch);

--- a/src/main/java/betterquesting/questing/tasks/TaskHunt.java
+++ b/src/main/java/betterquesting/questing/tasks/TaskHunt.java
@@ -112,6 +112,12 @@ public class TaskHunt implements ITask {
         pInfo.markDirtyParty(Collections.singletonList(quest.getID()));
     }
 
+    @Deprecated
+    @Override
+    public NBTTagCompound writeToNBT(NBTTagCompound nbt) {
+        return writeToNBT(nbt, false);
+    }
+
     @Override
     public NBTTagCompound writeToNBT(NBTTagCompound nbt, boolean reduce) {
         nbt.setString("target", idName);

--- a/src/main/java/betterquesting/questing/tasks/TaskHunt.java
+++ b/src/main/java/betterquesting/questing/tasks/TaskHunt.java
@@ -1,5 +1,6 @@
 package betterquesting.questing.tasks;
 
+import betterquesting.NBTUtil;
 import betterquesting.api.questing.IQuest;
 import betterquesting.api.questing.tasks.ITask;
 import betterquesting.api.utils.ItemComparison;
@@ -30,13 +31,18 @@ import javax.annotation.Nullable;
 import java.util.*;
 
 public class TaskHunt implements ITask {
+
+    private static final String DEFAULT_DAMAGE_TYPE = "";
+    private static final int DEFAULT_REQUIRED = 1;
+    private static final boolean DEFAULT_IGNORE_NBT = true;
+    private static final boolean DEFAULT_SUBTYPES = true;
     private final Set<UUID> completeUsers = new TreeSet<>();
     private final TreeMap<UUID, Integer> userProgress = new TreeMap<>();
     public String idName = "minecraft:zombie";
-    public String damageType = "";
-    public int required = 1;
-    public boolean ignoreNBT = true;
-    public boolean subtypes = true;
+    public String damageType = DEFAULT_DAMAGE_TYPE;
+    public int required = DEFAULT_REQUIRED;
+    public boolean ignoreNBT = DEFAULT_IGNORE_NBT;
+    public boolean subtypes = DEFAULT_SUBTYPES;
 
     /**
      * NBT representation of the intended target. Used only for NBT comparison checks
@@ -107,13 +113,18 @@ public class TaskHunt implements ITask {
     }
 
     @Override
-    public NBTTagCompound writeToNBT(NBTTagCompound nbt) {
+    public NBTTagCompound writeToNBT(NBTTagCompound nbt, boolean reduce) {
         nbt.setString("target", idName);
-        nbt.setInteger("required", required);
-        nbt.setBoolean("subtypes", subtypes);
-        nbt.setBoolean("ignoreNBT", ignoreNBT);
-        nbt.setTag("targetNBT", targetTags);
-        nbt.setString("damageType", damageType);
+        if (!reduce || required != DEFAULT_REQUIRED)
+            nbt.setInteger("required", required);
+        if (!reduce || subtypes != DEFAULT_SUBTYPES)
+            nbt.setBoolean("subtypes", subtypes);
+        if (!reduce || ignoreNBT != DEFAULT_IGNORE_NBT)
+            nbt.setBoolean("ignoreNBT", ignoreNBT);
+        if (!reduce || !targetTags.isEmpty())
+            nbt.setTag("targetNBT", targetTags);
+        if (!reduce || !damageType.equals(DEFAULT_DAMAGE_TYPE))
+            nbt.setString("damageType", damageType);
 
         return nbt;
     }
@@ -121,11 +132,11 @@ public class TaskHunt implements ITask {
     @Override
     public void readFromNBT(NBTTagCompound nbt) {
         idName = nbt.getString("target");
-        required = nbt.getInteger("required");
-        subtypes = nbt.getBoolean("subtypes");
-        ignoreNBT = nbt.getBoolean("ignoreNBT");
+        required = NBTUtil.getInteger(nbt, "required", DEFAULT_REQUIRED);
+        subtypes = NBTUtil.getBoolean(nbt, "subtypes", DEFAULT_SUBTYPES);
+        ignoreNBT = NBTUtil.getBoolean(nbt, "ignoreNBT", DEFAULT_IGNORE_NBT);
         targetTags = nbt.getCompoundTag("targetNBT");
-        damageType = nbt.getString("damageType");
+        damageType = NBTUtil.getString(nbt, "damageType", DEFAULT_DAMAGE_TYPE);
     }
 
     @Override

--- a/src/main/java/betterquesting/questing/tasks/TaskInteractEntity.java
+++ b/src/main/java/betterquesting/questing/tasks/TaskInteractEntity.java
@@ -1,5 +1,6 @@
 package betterquesting.questing.tasks;
 
+import betterquesting.NBTUtil;
 import betterquesting.api.questing.IQuest;
 import betterquesting.api.questing.tasks.ITask;
 import betterquesting.api.utils.BigItemStack;
@@ -31,23 +32,33 @@ import javax.annotation.Nullable;
 import java.util.*;
 
 public class TaskInteractEntity implements ITask {
+
+    private static final boolean DEFAULT_IGNORE_ITEM_NBT = false;
+    private static final boolean DEFAULT_PARTIAL_ITEM_MATCH = true;
+    private static final boolean DEFAULT_USE_MAIN_HAND = true;
+    private static final boolean DEFAULT_USE_OFFHAND = true;
+    private static final boolean DEFAULT_ENTITY_SUBTYPES = true;
+    private static final boolean DEFAULT_IGNORE_ENTITY_NBT = true;
+    private static final boolean DEFAULT_ON_INTERACT = true;
+    private static final boolean DEFAULT_ON_HIT = false;
+    private static final int DEFAULT_REQUIRED = 1;
     private final Set<UUID> completeUsers = new TreeSet<>();
     private final TreeMap<UUID, Integer> userProgress = new TreeMap<>();
 
     public BigItemStack targetItem = new BigItemStack(Items.AIR);
-    public boolean ignoreItemNBT = false;
-    public boolean partialItemMatch = true;
-    public boolean useMainHand = true;
-    public boolean useOffHand = true;
+    public boolean ignoreItemNBT = DEFAULT_IGNORE_ITEM_NBT;
+    public boolean partialItemMatch = DEFAULT_PARTIAL_ITEM_MATCH;
+    public boolean useMainHand = DEFAULT_USE_MAIN_HAND;
+    public boolean useOffHand = DEFAULT_USE_OFFHAND;
 
     public String entityID = "minecraft:villager";
     public NBTTagCompound entityTags = new NBTTagCompound();
-    public boolean entitySubtypes = true;
-    public boolean ignoreEntityNBT = true;
+    public boolean entitySubtypes = DEFAULT_ENTITY_SUBTYPES;
+    public boolean ignoreEntityNBT = DEFAULT_IGNORE_ENTITY_NBT;
 
-    public boolean onInteract = true;
-    public boolean onHit = false;
-    public int required = 1;
+    public boolean onInteract = DEFAULT_ON_INTERACT;
+    public boolean onHit = DEFAULT_ON_HIT;
+    public int required = DEFAULT_REQUIRED;
 
     @Override
     public String getUnlocalisedName() {
@@ -207,40 +218,50 @@ public class TaskInteractEntity implements ITask {
     }
 
     @Override
-    public NBTTagCompound writeToNBT(NBTTagCompound nbt) {
-        nbt.setTag("item", targetItem.writeToNBT(new NBTTagCompound()));
-        nbt.setBoolean("ignoreItemNBT", ignoreItemNBT);
-        nbt.setBoolean("partialItemMatch", partialItemMatch);
+    public NBTTagCompound writeToNBT(NBTTagCompound nbt, boolean reduce) {
+        nbt.setTag("item", targetItem.writeToNBT(new NBTTagCompound(), reduce));
+        if (!reduce || ignoreItemNBT != DEFAULT_IGNORE_ITEM_NBT)
+            nbt.setBoolean("ignoreItemNBT", ignoreItemNBT);
+        if (!reduce || partialItemMatch != DEFAULT_PARTIAL_ITEM_MATCH)
+            nbt.setBoolean("partialItemMatch", partialItemMatch);
 
         nbt.setString("targetID", entityID);
-        nbt.setTag("targetNBT", entityTags);
-        nbt.setBoolean("ignoreTargetNBT", ignoreEntityNBT);
-        nbt.setBoolean("targetSubtypes", entitySubtypes);
+        if (!reduce || !entityTags.isEmpty())
+            nbt.setTag("targetNBT", entityTags);
+        if (!reduce || ignoreEntityNBT != DEFAULT_IGNORE_ENTITY_NBT)
+            nbt.setBoolean("ignoreTargetNBT", ignoreEntityNBT);
+        if (!reduce || entitySubtypes != DEFAULT_ENTITY_SUBTYPES)
+            nbt.setBoolean("targetSubtypes", entitySubtypes);
 
-        nbt.setBoolean("allowMainHand", useMainHand);
-        nbt.setBoolean("allowOffHand", useOffHand);
-        nbt.setInteger("requiredUses", required);
-        nbt.setBoolean("onInteract", onInteract);
-        nbt.setBoolean("onHit", onHit);
+        if (!reduce || useMainHand != DEFAULT_USE_MAIN_HAND)
+            nbt.setBoolean("allowMainHand", useMainHand);
+        if (!reduce || useOffHand != DEFAULT_USE_OFFHAND)
+            nbt.setBoolean("allowOffHand", useOffHand);
+        if (!reduce || required != DEFAULT_REQUIRED)
+            nbt.setInteger("requiredUses", required);
+        if (!reduce || onInteract != DEFAULT_ON_INTERACT)
+            nbt.setBoolean("onInteract", onInteract);
+        if (!reduce || onHit != DEFAULT_ON_HIT)
+            nbt.setBoolean("onHit", onHit);
         return nbt;
     }
 
     @Override
     public void readFromNBT(NBTTagCompound nbt) {
         targetItem = new BigItemStack(nbt.getCompoundTag("item"));
-        ignoreItemNBT = nbt.getBoolean("ignoreItemNBT");
-        partialItemMatch = nbt.getBoolean("partialItemMatch");
+        ignoreItemNBT = NBTUtil.getBoolean(nbt, "ignoreItemNBT", DEFAULT_IGNORE_ITEM_NBT);
+        partialItemMatch = NBTUtil.getBoolean(nbt, "partialItemMatch", DEFAULT_PARTIAL_ITEM_MATCH);
 
         entityID = nbt.getString("targetID");
         entityTags = nbt.getCompoundTag("targetNBT");
-        ignoreEntityNBT = nbt.getBoolean("ignoreTargetNBT");
-        entitySubtypes = nbt.getBoolean("targetSubtypes");
+        ignoreEntityNBT = NBTUtil.getBoolean(nbt, "ignoreTargetNBT", DEFAULT_IGNORE_ENTITY_NBT);
+        entitySubtypes = NBTUtil.getBoolean(nbt, "targetSubtypes", DEFAULT_ENTITY_SUBTYPES);
 
-        useMainHand = nbt.getBoolean("allowMainHand");
-        useOffHand = nbt.getBoolean("allowOffHand");
-        required = nbt.getInteger("requiredUses");
-        onInteract = nbt.getBoolean("onInteract");
-        onHit = nbt.getBoolean("onHit");
+        useMainHand = NBTUtil.getBoolean(nbt, "allowMainHand", DEFAULT_USE_MAIN_HAND);
+        useOffHand = NBTUtil.getBoolean(nbt, "allowOffHand", DEFAULT_USE_OFFHAND);
+        required = NBTUtil.getInteger(nbt, "requiredUses", DEFAULT_REQUIRED);
+        onInteract = NBTUtil.getBoolean(nbt, "onInteract", DEFAULT_ON_INTERACT);
+        onHit = NBTUtil.getBoolean(nbt, "onHit", DEFAULT_ON_HIT);
     }
 
     private void setUserProgress(UUID uuid, int progress) {

--- a/src/main/java/betterquesting/questing/tasks/TaskInteractEntity.java
+++ b/src/main/java/betterquesting/questing/tasks/TaskInteractEntity.java
@@ -217,6 +217,12 @@ public class TaskInteractEntity implements ITask {
         return nbt;
     }
 
+    @Deprecated
+    @Override
+    public NBTTagCompound writeToNBT(NBTTagCompound nbt) {
+        return writeToNBT(nbt, false);
+    }
+
     @Override
     public NBTTagCompound writeToNBT(NBTTagCompound nbt, boolean reduce) {
         nbt.setTag("item", targetItem.writeToNBT(new NBTTagCompound(), reduce));

--- a/src/main/java/betterquesting/questing/tasks/TaskInteractItem.java
+++ b/src/main/java/betterquesting/questing/tasks/TaskInteractItem.java
@@ -211,6 +211,12 @@ public class TaskInteractItem implements ITask {
         return nbt;
     }
 
+    @Deprecated
+    @Override
+    public synchronized NBTTagCompound writeToNBT(NBTTagCompound nbt) {
+        return writeToNBT(nbt, false);
+    }
+
     @Override
     public synchronized NBTTagCompound writeToNBT(NBTTagCompound nbt, boolean reduce) {
         nbt.setTag("item", targetItem.writeToNBT(new NBTTagCompound(), reduce));

--- a/src/main/java/betterquesting/questing/tasks/TaskInteractItem.java
+++ b/src/main/java/betterquesting/questing/tasks/TaskInteractItem.java
@@ -1,5 +1,6 @@
 package betterquesting.questing.tasks;
 
+import betterquesting.NBTUtil;
 import betterquesting.NbtBlockType;
 import betterquesting.api.questing.IQuest;
 import betterquesting.api.questing.tasks.ITask;
@@ -35,18 +36,26 @@ import javax.annotation.Nullable;
 import java.util.*;
 
 public class TaskInteractItem implements ITask {
+
+    private static final boolean DEFAULT_PARTIAL_MATCH = true;
+    private static final boolean DEFAULT_IGNORE_NBT = false;
+    private static final boolean DEFAULT_USE_MAIN_HAND = true;
+    private static final boolean DEFAULT_USE_OFFHAND = true;
+    private static final boolean DEFAULT_ON_INTERACT = true;
+    private static final boolean DEFAULT_ON_HIT = false;
+    private static final int DEFAULT_REQUIRED = 1;
     private final Set<UUID> completeUsers = new TreeSet<>();
     private final TreeMap<UUID, Integer> userProgress = new TreeMap<>();
 
     public BigItemStack targetItem = new BigItemStack(Items.AIR);
     public final NbtBlockType targetBlock = new NbtBlockType(Blocks.AIR);
-    public boolean partialMatch = true;
-    public boolean ignoreNBT = false;
-    public boolean useMainHand = true;
-    public boolean useOffHand = true;
-    public boolean onInteract = true;
-    public boolean onHit = false;
-    public int required = 1;
+    public boolean partialMatch = DEFAULT_PARTIAL_MATCH;
+    public boolean ignoreNBT = DEFAULT_IGNORE_NBT;
+    public boolean useMainHand = DEFAULT_USE_MAIN_HAND;
+    public boolean useOffHand = DEFAULT_USE_OFFHAND;
+    public boolean onInteract = DEFAULT_ON_INTERACT;
+    public boolean onHit = DEFAULT_ON_HIT;
+    public int required = DEFAULT_REQUIRED;
 
     @Override
     public String getUnlocalisedName() {
@@ -203,16 +212,23 @@ public class TaskInteractItem implements ITask {
     }
 
     @Override
-    public synchronized NBTTagCompound writeToNBT(NBTTagCompound nbt) {
-        nbt.setTag("item", targetItem.writeToNBT(new NBTTagCompound()));
-        nbt.setTag("block", targetBlock.writeToNBT(new NBTTagCompound()));
-        nbt.setBoolean("ignoreNbt", ignoreNBT);
-        nbt.setBoolean("partialMatch", partialMatch);
-        nbt.setBoolean("allowMainHand", useMainHand);
-        nbt.setBoolean("allowOffHand", useOffHand);
-        nbt.setInteger("requiredUses", required);
-        nbt.setBoolean("onInteract", onInteract);
-        nbt.setBoolean("onHit", onHit);
+    public synchronized NBTTagCompound writeToNBT(NBTTagCompound nbt, boolean reduce) {
+        nbt.setTag("item", targetItem.writeToNBT(new NBTTagCompound(), reduce));
+        nbt.setTag("block", targetBlock.writeToNBT(new NBTTagCompound(), reduce));
+        if (!reduce || ignoreNBT != DEFAULT_IGNORE_NBT)
+            nbt.setBoolean("ignoreNbt", ignoreNBT);// Not "ignoreNBT"!!
+        if (!reduce || partialMatch != DEFAULT_PARTIAL_MATCH)
+            nbt.setBoolean("partialMatch", partialMatch);
+        if (!reduce || useMainHand != DEFAULT_USE_MAIN_HAND)
+            nbt.setBoolean("allowMainHand", useMainHand);
+        if (!reduce || useOffHand != DEFAULT_USE_OFFHAND)
+            nbt.setBoolean("allowOffHand", useOffHand);
+        if (!reduce || required != DEFAULT_REQUIRED)
+            nbt.setInteger("requiredUses", required);
+        if (!reduce || onInteract != DEFAULT_ON_INTERACT)
+            nbt.setBoolean("onInteract", onInteract);
+        if (!reduce || onHit != DEFAULT_ON_HIT)
+            nbt.setBoolean("onHit", onHit);
         return nbt;
     }
 
@@ -220,13 +236,13 @@ public class TaskInteractItem implements ITask {
     public synchronized void readFromNBT(NBTTagCompound nbt) {
         targetItem = new BigItemStack(nbt.getCompoundTag("item"));
         targetBlock.readFromNBT(nbt.getCompoundTag("block"));
-        ignoreNBT = nbt.getBoolean("ignoreNbt");
-        partialMatch = nbt.getBoolean("partialMatch");
-        useMainHand = nbt.getBoolean("allowMainHand");
-        useOffHand = nbt.getBoolean("allowOffHand");
-        required = nbt.getInteger("requiredUses");
-        onInteract = nbt.getBoolean("onInteract");
-        onHit = nbt.getBoolean("onHit");
+        ignoreNBT = NBTUtil.getBoolean(nbt, "ignoreNbt", DEFAULT_IGNORE_NBT);
+        partialMatch = NBTUtil.getBoolean(nbt, "partialMatch", DEFAULT_PARTIAL_MATCH);
+        useMainHand = NBTUtil.getBoolean(nbt, "allowMainHand", DEFAULT_USE_MAIN_HAND);
+        useOffHand = NBTUtil.getBoolean(nbt, "allowOffHand", DEFAULT_USE_OFFHAND);
+        required = NBTUtil.getInteger(nbt, "requiredUses", DEFAULT_REQUIRED);
+        onInteract = NBTUtil.getBoolean(nbt, "onInteract", DEFAULT_ON_INTERACT);
+        onHit = NBTUtil.getBoolean(nbt, "onHit", DEFAULT_ON_HIT);
     }
 
     private void setUserProgress(UUID uuid, Integer progress) {

--- a/src/main/java/betterquesting/questing/tasks/TaskLocation.java
+++ b/src/main/java/betterquesting/questing/tasks/TaskLocation.java
@@ -1,5 +1,6 @@
 package betterquesting.questing.tasks;
 
+import betterquesting.NBTUtil;
 import betterquesting.api.questing.IQuest;
 import betterquesting.api2.client.gui.misc.IGuiRect;
 import betterquesting.api2.client.gui.panels.IGuiPanel;
@@ -26,19 +27,31 @@ import javax.annotation.Nullable;
 import java.util.*;
 
 public class TaskLocation implements ITaskTickable {
+
+    private static final String DEFAULT_STRUCTURE = "";
+    private static final String DEFAULT_BIOME = "";
+    private static final int DEFAULT_X = 0;
+    private static final int DEFAULT_Y = 0;
+    private static final int DEFAULT_Z = 0;
+    private static final int DEFAULT_DIM = 0;
+    private static final int DEFAULT_RANGE = -1;
+    private static final boolean DEFAULT_VISIBLE = false;
+    private static final boolean DEFAULT_HIDE_INFO = false;
+    private static final boolean DEFAULT_INVERT = false;
+    private static final boolean DEFAULT_TAXI_CAB = false;
     private final Set<UUID> completeUsers = new TreeSet<>();
     public String name = "New Location";
-    public String structure = "";
-    public String biome = "";
-    public int x = 0;
-    public int y = 0;
-    public int z = 0;
-    public int dim = 0;
-    public int range = -1;
-    public boolean visible = false;
-    public boolean hideInfo = false;
-    public boolean invert = false;
-    public boolean taxiCab = false;
+    public String structure = DEFAULT_STRUCTURE;
+    public String biome = DEFAULT_BIOME;
+    public int x = DEFAULT_X;
+    public int y = DEFAULT_Y;
+    public int z = DEFAULT_Z;
+    public int dim = DEFAULT_DIM;
+    public int range = DEFAULT_RANGE;
+    public boolean visible = DEFAULT_VISIBLE;
+    public boolean hideInfo = DEFAULT_HIDE_INFO;
+    public boolean invert = DEFAULT_INVERT;
+    public boolean taxiCab = DEFAULT_TAXI_CAB;
 
     @Override
     public ResourceLocation getFactoryID() {
@@ -123,19 +136,30 @@ public class TaskLocation implements ITaskTickable {
     }
 
     @Override
-    public NBTTagCompound writeToNBT(NBTTagCompound nbt) {
+    public NBTTagCompound writeToNBT(NBTTagCompound nbt, boolean reduce) {
         nbt.setString("name", name);
-        nbt.setInteger("posX", x);
-        nbt.setInteger("posY", y);
-        nbt.setInteger("posZ", z);
-        nbt.setInteger("dimension", dim);
-        nbt.setString("biome", biome);
-        nbt.setString("structure", structure);
-        nbt.setInteger("range", range);
-        nbt.setBoolean("visible", visible);
-        nbt.setBoolean("hideInfo", hideInfo);
-        nbt.setBoolean("invert", invert);
-        nbt.setBoolean("taxiCabDist", taxiCab);
+        if (!reduce || x != DEFAULT_X)
+            nbt.setInteger("posX", x);
+        if (!reduce || y != DEFAULT_Y)
+            nbt.setInteger("posY", y);
+        if (!reduce || z != DEFAULT_Z)
+            nbt.setInteger("posZ", z);
+        if (!reduce || dim != DEFAULT_DIM)
+            nbt.setInteger("dimension", dim);
+        if (!reduce || !biome.equals(DEFAULT_BIOME))
+            nbt.setString("biome", biome);
+        if (!reduce || !structure.equals(DEFAULT_STRUCTURE))
+            nbt.setString("structure", structure);
+        if (!reduce || range != DEFAULT_RANGE)
+            nbt.setInteger("range", range);
+        if (!reduce || visible != DEFAULT_VISIBLE)
+            nbt.setBoolean("visible", visible);
+        if (!reduce || hideInfo != DEFAULT_HIDE_INFO)
+            nbt.setBoolean("hideInfo", hideInfo);
+        if (!reduce || invert != DEFAULT_INVERT)
+            nbt.setBoolean("invert", invert);
+        if (!reduce || taxiCab != DEFAULT_TAXI_CAB)
+            nbt.setBoolean("taxiCabDist", taxiCab);
 
         return nbt;
     }
@@ -143,17 +167,17 @@ public class TaskLocation implements ITaskTickable {
     @Override
     public void readFromNBT(NBTTagCompound nbt) {
         name = nbt.getString("name");
-        x = nbt.getInteger("posX");
-        y = nbt.getInteger("posY");
-        z = nbt.getInteger("posZ");
-        dim = nbt.getInteger("dimension");
-        biome = nbt.getString("biome");
-        structure = nbt.getString("structure");
-        range = nbt.getInteger("range");
-        visible = nbt.getBoolean("visible");
-        hideInfo = nbt.getBoolean("hideInfo");
-        invert = nbt.getBoolean("invert") || nbt.getBoolean("invertDistance");
-        taxiCab = nbt.getBoolean("taxiCabDist");
+        x = NBTUtil.getInteger(nbt, "posX", DEFAULT_X);
+        y = NBTUtil.getInteger(nbt, "posY", DEFAULT_Y);
+        z = NBTUtil.getInteger(nbt, "posZ", DEFAULT_Z);
+        dim = NBTUtil.getInteger(nbt, "dimension", DEFAULT_DIM);
+        biome = NBTUtil.getString(nbt, "biome", DEFAULT_BIOME);
+        structure = NBTUtil.getString(nbt, "structure", DEFAULT_STRUCTURE);
+        range = NBTUtil.getInteger(nbt, "range", DEFAULT_RANGE);
+        visible = NBTUtil.getBoolean(nbt, "visible", DEFAULT_VISIBLE);
+        hideInfo = NBTUtil.getBoolean(nbt, "hideInfo", DEFAULT_HIDE_INFO);
+        invert = NBTUtil.getBoolean(nbt, "invert", DEFAULT_INVERT) || nbt.getBoolean("invertDistance");
+        taxiCab = NBTUtil.getBoolean(nbt, "taxiCabDist", DEFAULT_TAXI_CAB);
     }
 
     @Override

--- a/src/main/java/betterquesting/questing/tasks/TaskLocation.java
+++ b/src/main/java/betterquesting/questing/tasks/TaskLocation.java
@@ -135,6 +135,12 @@ public class TaskLocation implements ITaskTickable {
         }
     }
 
+    @Deprecated
+    @Override
+    public NBTTagCompound writeToNBT(NBTTagCompound nbt) {
+        return writeToNBT(nbt, false);
+    }
+
     @Override
     public NBTTagCompound writeToNBT(NBTTagCompound nbt, boolean reduce) {
         nbt.setString("name", name);

--- a/src/main/java/betterquesting/questing/tasks/TaskMeeting.java
+++ b/src/main/java/betterquesting/questing/tasks/TaskMeeting.java
@@ -1,5 +1,6 @@
 package betterquesting.questing.tasks;
 
+import betterquesting.NBTUtil;
 import betterquesting.api.questing.IQuest;
 import betterquesting.api.utils.ItemComparison;
 import betterquesting.api2.client.gui.misc.IGuiRect;
@@ -26,13 +27,18 @@ import javax.annotation.Nullable;
 import java.util.*;
 
 public class TaskMeeting implements ITaskTickable {
+
+    private static final int DEFAULT_RANGE = 4;
+    private static final int DEFAULT_AMOUNT = 1;
+    private static final boolean DEFAULT_IGNORE_NBT = true;
+    private static final boolean DEFAULT_SUBTYPES = true;
     private final Set<UUID> completeUsers = new TreeSet<>();
 
     public String idName = "minecraft:villager";
-    public int range = 4;
-    public int amount = 1;
-    public boolean ignoreNBT = true;
-    public boolean subtypes = true;
+    public int range = DEFAULT_RANGE;
+    public int amount = DEFAULT_AMOUNT;
+    public boolean ignoreNBT = DEFAULT_IGNORE_NBT;
+    public boolean subtypes = DEFAULT_SUBTYPES;
 
     /**
      * NBT representation of the intended target. Used only for NBT comparison checks
@@ -114,25 +120,30 @@ public class TaskMeeting implements ITaskTickable {
     }
 
     @Override
-    public NBTTagCompound writeToNBT(NBTTagCompound json) {
-        json.setString("target", idName);
-        json.setInteger("range", range);
-        json.setInteger("amount", amount);
-        json.setBoolean("subtypes", subtypes);
-        json.setBoolean("ignoreNBT", ignoreNBT);
-        json.setTag("targetNBT", targetTags);
+    public NBTTagCompound writeToNBT(NBTTagCompound nbt, boolean reduce) {
+        nbt.setString("target", idName);
+        if (!reduce || range != DEFAULT_RANGE)
+            nbt.setInteger("range", range);
+        if (!reduce || amount != DEFAULT_AMOUNT)
+            nbt.setInteger("amount", amount);
+        if (!reduce || subtypes != DEFAULT_SUBTYPES)
+            nbt.setBoolean("subtypes", subtypes);
+        if (!reduce || ignoreNBT != DEFAULT_IGNORE_NBT)
+            nbt.setBoolean("ignoreNBT", ignoreNBT);
+        if (!reduce || !targetTags.isEmpty())
+            nbt.setTag("targetNBT", targetTags);
 
-        return json;
+        return nbt;
     }
 
     @Override
-    public void readFromNBT(NBTTagCompound json) {
-        idName = json.hasKey("target", 8) ? json.getString("target") : "minecraft:villager";
-        range = json.getInteger("range");
-        amount = json.getInteger("amount");
-        subtypes = json.getBoolean("subtypes");
-        ignoreNBT = json.getBoolean("ignoreNBT");
-        targetTags = json.getCompoundTag("targetNBT");
+    public void readFromNBT(NBTTagCompound nbt) {
+        idName = nbt.hasKey("target", 8) ? nbt.getString("target") : "minecraft:villager";
+        range = NBTUtil.getInteger(nbt, "range", DEFAULT_RANGE);
+        amount = NBTUtil.getInteger(nbt, "amount", DEFAULT_AMOUNT);
+        subtypes = NBTUtil.getBoolean(nbt, "subtypes", DEFAULT_SUBTYPES);
+        ignoreNBT = NBTUtil.getBoolean(nbt, "ignoreNBT", DEFAULT_IGNORE_NBT);
+        targetTags = nbt.getCompoundTag("targetNBT");
     }
 
     @Override

--- a/src/main/java/betterquesting/questing/tasks/TaskMeeting.java
+++ b/src/main/java/betterquesting/questing/tasks/TaskMeeting.java
@@ -119,6 +119,12 @@ public class TaskMeeting implements ITaskTickable {
         }
     }
 
+    @Deprecated
+    @Override
+    public NBTTagCompound writeToNBT(NBTTagCompound nbt) {
+        return writeToNBT(nbt, false);
+    }
+
     @Override
     public NBTTagCompound writeToNBT(NBTTagCompound nbt, boolean reduce) {
         nbt.setString("target", idName);

--- a/src/main/java/betterquesting/questing/tasks/TaskRetrieval.java
+++ b/src/main/java/betterquesting/questing/tasks/TaskRetrieval.java
@@ -196,6 +196,12 @@ public class TaskRetrieval implements ITaskInventory, IItemTask {
         }
     }
 
+    @Deprecated
+    @Override
+    public NBTTagCompound writeToNBT(NBTTagCompound nbt) {
+        return writeToNBT(nbt, false);
+    }
+
     @Override
     public NBTTagCompound writeToNBT(NBTTagCompound nbt, boolean reduce) {
         if (!reduce || partialMatch != DEFAULT_PARTIAL_MATCH)

--- a/src/main/java/betterquesting/questing/tasks/TaskRetrieval.java
+++ b/src/main/java/betterquesting/questing/tasks/TaskRetrieval.java
@@ -1,5 +1,6 @@
 package betterquesting.questing.tasks;
 
+import betterquesting.NBTUtil;
 import betterquesting.api.enums.EnumLogic;
 import betterquesting.api.questing.IQuest;
 import betterquesting.api.questing.tasks.IItemTask;
@@ -36,15 +37,22 @@ import java.util.*;
 import java.util.stream.IntStream;
 
 public class TaskRetrieval implements ITaskInventory, IItemTask {
+
+    private static final boolean DEFAULT_PARTIAL_MATCH = true;
+    private static final boolean DEFAULT_IGNORE_NBT = false;
+    private static final boolean DEFAULT_CONSUME = false;
+    private static final boolean DEFAULT_GROUP_DETECT = false;
+    private static final boolean DEFAULT_AUTO_CONSUME = false;
+    private static final EnumLogic DEFAULT_ENTRY_LOGIC = EnumLogic.AND;
     private final Set<UUID> completeUsers = new TreeSet<>();
     public final NonNullList<BigItemStack> requiredItems = NonNullList.create();
     private final TreeMap<UUID, int[]> userProgress = new TreeMap<>();
-    public boolean partialMatch = true;
-    public boolean ignoreNBT = false;
-    public boolean consume = false;
-    public boolean groupDetect = false;
-    public boolean autoConsume = false;
-    public EnumLogic entryLogic = EnumLogic.AND;
+    public boolean partialMatch = DEFAULT_PARTIAL_MATCH;
+    public boolean ignoreNBT = DEFAULT_IGNORE_NBT;
+    public boolean consume = DEFAULT_CONSUME;
+    public boolean groupDetect = DEFAULT_GROUP_DETECT;
+    public boolean autoConsume = DEFAULT_AUTO_CONSUME;
+    public EnumLogic entryLogic = DEFAULT_ENTRY_LOGIC;
 
     @Override
     public String getUnlocalisedName() {
@@ -189,38 +197,37 @@ public class TaskRetrieval implements ITaskInventory, IItemTask {
     }
 
     @Override
-    public NBTTagCompound writeToNBT(NBTTagCompound json) {
-        json.setBoolean("partialMatch", partialMatch);
-        json.setBoolean("ignoreNBT", ignoreNBT);
-        json.setBoolean("consume", consume);
-        json.setBoolean("groupDetect", groupDetect);
-        json.setBoolean("autoConsume", autoConsume);
-        json.setString("entryLogic", entryLogic.name());
+    public NBTTagCompound writeToNBT(NBTTagCompound nbt, boolean reduce) {
+        if (!reduce || partialMatch != DEFAULT_PARTIAL_MATCH)
+            nbt.setBoolean("partialMatch", partialMatch);
+        if (!reduce || ignoreNBT != DEFAULT_IGNORE_NBT)
+            nbt.setBoolean("ignoreNBT", ignoreNBT);
+        if (!reduce || consume != DEFAULT_CONSUME)
+            nbt.setBoolean("consume", consume);
+        if (!reduce || groupDetect != DEFAULT_GROUP_DETECT)
+            nbt.setBoolean("groupDetect", groupDetect);
+        if (!reduce || autoConsume != DEFAULT_AUTO_CONSUME)
+            nbt.setBoolean("autoConsume", autoConsume);
+        if (!reduce || entryLogic != DEFAULT_ENTRY_LOGIC)
+            nbt.setString("entryLogic", entryLogic.name());
 
         NBTTagList itemArray = new NBTTagList();
         for (BigItemStack stack : this.requiredItems) {
-            itemArray.appendTag(JsonHelper.ItemStackToJson(stack, new NBTTagCompound()));
+            itemArray.appendTag(JsonHelper.ItemStackToJson(stack, new NBTTagCompound(), reduce));
         }
-        json.setTag("requiredItems", itemArray);
+        nbt.setTag("requiredItems", itemArray);
 
-        return json;
+        return nbt;
     }
 
     @Override
     public void readFromNBT(NBTTagCompound nbt) {
-        partialMatch = nbt.getBoolean("partialMatch");
-        ignoreNBT = nbt.getBoolean("ignoreNBT");
-        consume = nbt.getBoolean("consume");
-        groupDetect = nbt.getBoolean("groupDetect");
-        autoConsume = nbt.getBoolean("autoConsume");
-        if (nbt.hasKey("entryLogic", 8)) {
-            for (EnumLogic value : EnumLogic.values()) {
-                if (value.name().equalsIgnoreCase(nbt.getString("entryLogic"))) {
-                    entryLogic = value;
-                    break;
-                }
-            }
-        }
+        partialMatch = NBTUtil.getBoolean(nbt, "partialMatch", DEFAULT_PARTIAL_MATCH);
+        ignoreNBT = NBTUtil.getBoolean(nbt, "ignoreNBT", DEFAULT_IGNORE_NBT);
+        consume = NBTUtil.getBoolean(nbt, "consume", DEFAULT_CONSUME);
+        groupDetect = NBTUtil.getBoolean(nbt, "groupDetect", DEFAULT_GROUP_DETECT);
+        autoConsume = NBTUtil.getBoolean(nbt, "autoConsume", DEFAULT_AUTO_CONSUME);
+        entryLogic = NBTUtil.getEnum(nbt, "entryLogic", EnumLogic.class, true, DEFAULT_ENTRY_LOGIC);
 
         requiredItems.clear();
         NBTTagList iList = nbt.getTagList("requiredItems", 10);

--- a/src/main/java/betterquesting/questing/tasks/TaskScoreboard.java
+++ b/src/main/java/betterquesting/questing/tasks/TaskScoreboard.java
@@ -109,6 +109,12 @@ public class TaskScoreboard implements ITaskTickable {
         }
     }
 
+    @Deprecated
+    @Override
+    public NBTTagCompound writeToNBT(NBTTagCompound nbt) {
+        return writeToNBT(nbt, false);
+    }
+
     @Override
     public NBTTagCompound writeToNBT(NBTTagCompound nbt, boolean reduce) {
         nbt.setString("scoreName", scoreName);

--- a/src/main/java/betterquesting/questing/tasks/TaskScoreboard.java
+++ b/src/main/java/betterquesting/questing/tasks/TaskScoreboard.java
@@ -1,5 +1,6 @@
 package betterquesting.questing.tasks;
 
+import betterquesting.NBTUtil;
 import betterquesting.ScoreboardBQ;
 import betterquesting.api.questing.IQuest;
 import betterquesting.api2.client.gui.misc.IGuiRect;
@@ -30,14 +31,19 @@ import javax.annotation.Nullable;
 import java.util.*;
 
 public class TaskScoreboard implements ITaskTickable {
+
+    private static final String DEFAULT_TYPE = "dummy";
+    private static final float DEFAULT_CONVERSION = 1F;
+    private static final String DEFAULT_SUFFIX = "";
+    private static final ScoreOperation DEFAULT_OPERATION = ScoreOperation.MORE_OR_EQUAL;
     private final Set<UUID> completeUsers = new TreeSet<>();
     public String scoreName = "Score";
     public String scoreDisp = "Score";
-    public String type = "dummy";
+    public String type = DEFAULT_TYPE;
     public int target = 1;
-    public float conversion = 1F;
-    public String suffix = "";
-    public ScoreOperation operation = ScoreOperation.MORE_OR_EQUAL;
+    public float conversion = DEFAULT_CONVERSION;
+    public String suffix = DEFAULT_SUFFIX;
+    public ScoreOperation operation = DEFAULT_OPERATION;
 
     @Override
     public ResourceLocation getFactoryID() {
@@ -104,32 +110,32 @@ public class TaskScoreboard implements ITaskTickable {
     }
 
     @Override
-    public NBTTagCompound writeToNBT(NBTTagCompound nbt) {
+    public NBTTagCompound writeToNBT(NBTTagCompound nbt, boolean reduce) {
         nbt.setString("scoreName", scoreName);
-        nbt.setString("scoreDisp", scoreDisp);
-        nbt.setString("type", type);
+        if (!reduce || !scoreDisp.equals(scoreName))
+            nbt.setString("scoreDisp", scoreDisp);
+        if (!reduce || !type.equals(DEFAULT_TYPE))
+            nbt.setString("type", type);
         nbt.setInteger("target", target);
-        nbt.setFloat("unitConversion", conversion);
-        nbt.setString("unitSuffix", suffix);
-        nbt.setString("operation", operation.name());
+        if (!reduce || conversion != DEFAULT_CONVERSION)
+            nbt.setFloat("unitConversion", conversion);
+        if (!reduce || !suffix.equals(DEFAULT_SUFFIX))
+            nbt.setString("unitSuffix", suffix);
+        if (!reduce || operation != DEFAULT_OPERATION)
+            nbt.setString("operation", operation.name());
 
         return nbt;
     }
 
     @Override
     public void readFromNBT(NBTTagCompound nbt) {
-        scoreName = nbt.getString("scoreName");
-        scoreName = scoreName.replaceAll(" ", "_");
-        scoreDisp = nbt.getString("scoreDisp");
-        type = nbt.hasKey("type", 8) ? nbt.getString("type") : "dummy";
+        scoreName = nbt.getString("scoreName").replaceAll(" ", "_");
+        scoreDisp = NBTUtil.getString(nbt, "scoreDisp", scoreName);
+        type = NBTUtil.getString(nbt, "type", DEFAULT_TYPE);
         target = nbt.getInteger("target");
-        conversion = nbt.getFloat("unitConversion");
-        suffix = nbt.getString("unitSuffix");
-        try {
-            operation = ScoreOperation.valueOf(nbt.hasKey("operation", 8) ? nbt.getString("operation") : "MORE_OR_EQUAL");
-        } catch (Exception e) {
-            operation = ScoreOperation.MORE_OR_EQUAL;
-        }
+        conversion = NBTUtil.getFloat(nbt, "unitConversion", DEFAULT_CONVERSION);
+        suffix = NBTUtil.getString(nbt, "unitSuffix", DEFAULT_SUFFIX);
+        operation = NBTUtil.getEnum(nbt, "operation", ScoreOperation.class, true, DEFAULT_OPERATION);
     }
 
     @Override

--- a/src/main/java/betterquesting/questing/tasks/TaskStorage.java
+++ b/src/main/java/betterquesting/questing/tasks/TaskStorage.java
@@ -16,17 +16,23 @@ import java.util.List;
 import java.util.UUID;
 
 public class TaskStorage extends SimpleDatabase<ITask> implements IDatabaseNBT<ITask, NBTTagList, NBTTagList> {
+    @Deprecated
     @Override
-    public NBTTagList writeToNBT(NBTTagList json, @Nullable List<Integer> subset, boolean reduce) {
+    public NBTTagList writeToNBT(NBTTagList nbt, @Nullable List<Integer> subset) {
+        return writeToNBT(nbt, subset, false);
+    }
+
+    @Override
+    public NBTTagList writeToNBT(NBTTagList nbt, @Nullable List<Integer> subset, boolean reduce) {
         for (DBEntry<ITask> entry : getEntries()) {
             if (subset != null && !subset.contains(entry.getID())) continue;
             ResourceLocation taskID = entry.getValue().getFactoryID();
             NBTTagCompound qJson = entry.getValue().writeToNBT(new NBTTagCompound(), reduce);
             qJson.setString("taskID", taskID.toString());
             qJson.setInteger("index", entry.getID());
-            json.appendTag(qJson);
+            nbt.appendTag(qJson);
         }
-        return json;
+        return nbt;
     }
 
     @Override

--- a/src/main/java/betterquesting/questing/tasks/TaskStorage.java
+++ b/src/main/java/betterquesting/questing/tasks/TaskStorage.java
@@ -17,11 +17,11 @@ import java.util.UUID;
 
 public class TaskStorage extends SimpleDatabase<ITask> implements IDatabaseNBT<ITask, NBTTagList, NBTTagList> {
     @Override
-    public NBTTagList writeToNBT(NBTTagList json, @Nullable List<Integer> subset) {
+    public NBTTagList writeToNBT(NBTTagList json, @Nullable List<Integer> subset, boolean reduce) {
         for (DBEntry<ITask> entry : getEntries()) {
             if (subset != null && !subset.contains(entry.getID())) continue;
             ResourceLocation taskID = entry.getValue().getFactoryID();
-            NBTTagCompound qJson = entry.getValue().writeToNBT(new NBTTagCompound());
+            NBTTagCompound qJson = entry.getValue().writeToNBT(new NBTTagCompound(), reduce);
             qJson.setString("taskID", taskID.toString());
             qJson.setInteger("index", entry.getID());
             json.appendTag(qJson);

--- a/src/main/java/betterquesting/questing/tasks/TaskTame.java
+++ b/src/main/java/betterquesting/questing/tasks/TaskTame.java
@@ -1,5 +1,6 @@
 package betterquesting.questing.tasks;
 
+import betterquesting.NBTUtil;
 import betterquesting.api.questing.IQuest;
 import betterquesting.api.questing.tasks.ITask;
 import betterquesting.api.utils.ItemComparison;
@@ -29,12 +30,16 @@ import javax.annotation.Nullable;
 import java.util.*;
 
 public class TaskTame implements ITask {
+
+    private static final int DEFAULT_REQUIRED = 1;
+    private static final boolean DEFAULT_IGNORE_NBT = true;
+    private static final boolean DEFAULT_SUBTYPES = true;
     private final Set<UUID> completeUsers = new TreeSet<>();
     public final HashMap<UUID, Integer> userProgress = new HashMap<>();
     public String idName = "minecraft:wolf";
-    public int required = 1;
-    public boolean ignoreNBT = true;
-    public boolean subtypes = true;
+    public int required = DEFAULT_REQUIRED;
+    public boolean ignoreNBT = DEFAULT_IGNORE_NBT;
+    public boolean subtypes = DEFAULT_SUBTYPES;
 
     /**
      * NBT representation of the intended target. Used only for NBT comparison checks
@@ -129,23 +134,27 @@ public class TaskTame implements ITask {
     }
 
     @Override
-    public NBTTagCompound writeToNBT(NBTTagCompound json) {
-        json.setString("target", idName);
-        json.setInteger("required", required);
-        json.setBoolean("subtypes", subtypes);
-        json.setBoolean("ignoreNBT", ignoreNBT);
-        json.setTag("targetNBT", targetTags);
+    public NBTTagCompound writeToNBT(NBTTagCompound nbt, boolean reduce) {
+        nbt.setString("target", idName);
+        if (!reduce || required != DEFAULT_REQUIRED)
+            nbt.setInteger("required", required);
+        if (!reduce || subtypes != DEFAULT_SUBTYPES)
+            nbt.setBoolean("subtypes", subtypes);
+        if (!reduce || ignoreNBT != DEFAULT_IGNORE_NBT)
+            nbt.setBoolean("ignoreNBT", ignoreNBT);
+        if (!reduce || !targetTags.isEmpty())
+            nbt.setTag("targetNBT", targetTags);
 
-        return json;
+        return nbt;
     }
 
     @Override
-    public void readFromNBT(NBTTagCompound json) {
-        idName = json.getString("target");
-        required = json.getInteger("required");
-        subtypes = json.getBoolean("subtypes");
-        ignoreNBT = json.getBoolean("ignoreNBT");
-        targetTags = json.getCompoundTag("targetNBT");
+    public void readFromNBT(NBTTagCompound nbt) {
+        idName = nbt.getString("target");
+        required = NBTUtil.getInteger(nbt, "required", DEFAULT_REQUIRED);
+        subtypes = NBTUtil.getBoolean(nbt, "subtypes", DEFAULT_SUBTYPES);
+        ignoreNBT = NBTUtil.getBoolean(nbt, "ignoreNBT", DEFAULT_IGNORE_NBT);
+        targetTags = nbt.getCompoundTag("targetNBT");
     }
 
     @Override

--- a/src/main/java/betterquesting/questing/tasks/TaskTame.java
+++ b/src/main/java/betterquesting/questing/tasks/TaskTame.java
@@ -133,6 +133,12 @@ public class TaskTame implements ITask {
         return new GuiEditTaskTame(parent, quest, this);
     }
 
+    @Deprecated
+    @Override
+    public NBTTagCompound writeToNBT(NBTTagCompound nbt) {
+        return writeToNBT(nbt, false);
+    }
+
     @Override
     public NBTTagCompound writeToNBT(NBTTagCompound nbt, boolean reduce) {
         nbt.setString("target", idName);

--- a/src/main/java/betterquesting/questing/tasks/TaskTrigger.java
+++ b/src/main/java/betterquesting/questing/tasks/TaskTrigger.java
@@ -184,6 +184,12 @@ public class TaskTrigger implements ITask {
         }
     }
 
+    @Deprecated
+    @Override
+    public NBTTagCompound writeToNBT(NBTTagCompound nbt) {
+        return writeToNBT(nbt, false);
+    }
+
     @Override
     public NBTTagCompound writeToNBT(NBTTagCompound nbt, boolean reduce) {
         nbt.setString("description", desc);

--- a/src/main/java/betterquesting/questing/tasks/TaskTrigger.java
+++ b/src/main/java/betterquesting/questing/tasks/TaskTrigger.java
@@ -185,7 +185,7 @@ public class TaskTrigger implements ITask {
     }
 
     @Override
-    public NBTTagCompound writeToNBT(NBTTagCompound nbt) {
+    public NBTTagCompound writeToNBT(NBTTagCompound nbt, boolean reduce) {
         nbt.setString("description", desc);
         nbt.setString("trigger", triggerID);
         nbt.setString("conditions", critJson);

--- a/src/main/java/betterquesting/questing/tasks/TaskXP.java
+++ b/src/main/java/betterquesting/questing/tasks/TaskXP.java
@@ -105,6 +105,12 @@ public class TaskXP implements ITaskTickable {
         return "bq_standard.task.xp";
     }
 
+    @Deprecated
+    @Override
+    public NBTTagCompound writeToNBT(NBTTagCompound nbt) {
+        return writeToNBT(nbt, false);
+    }
+
     @Override
     public NBTTagCompound writeToNBT(NBTTagCompound nbt, boolean reduce) {
         if (!reduce || amount != DEFAULT_AMOUNT)

--- a/src/main/java/betterquesting/questing/tasks/TaskXP.java
+++ b/src/main/java/betterquesting/questing/tasks/TaskXP.java
@@ -1,5 +1,6 @@
 package betterquesting.questing.tasks;
 
+import betterquesting.NBTUtil;
 import betterquesting.XPHelper;
 import betterquesting.api.questing.IQuest;
 import betterquesting.api2.client.gui.misc.IGuiRect;
@@ -21,11 +22,15 @@ import javax.annotation.Nullable;
 import java.util.*;
 
 public class TaskXP implements ITaskTickable {
+
+    private static final boolean DEFAULT_LEVELS = true;
+    private static final int DEFAULT_AMOUNT = 30;
+    private static final boolean DEFAULT_CONSUME = true;
     private final Set<UUID> completeUsers = new TreeSet<>();
     private final HashMap<UUID, Long> userProgress = new HashMap<>();
-    public boolean levels = true;
-    public int amount = 30;
-    public boolean consume = true;
+    public boolean levels = DEFAULT_LEVELS;
+    public int amount = DEFAULT_AMOUNT;
+    public boolean consume = DEFAULT_CONSUME;
 
     @Override
     public ResourceLocation getFactoryID() {
@@ -101,18 +106,21 @@ public class TaskXP implements ITaskTickable {
     }
 
     @Override
-    public NBTTagCompound writeToNBT(NBTTagCompound json) {
-        json.setInteger("amount", amount);
-        json.setBoolean("isLevels", levels);
-        json.setBoolean("consume", consume);
-        return json;
+    public NBTTagCompound writeToNBT(NBTTagCompound nbt, boolean reduce) {
+        if (!reduce || amount != DEFAULT_AMOUNT)
+            nbt.setInteger("amount", amount);
+        if (!reduce || levels != DEFAULT_LEVELS)
+            nbt.setBoolean("isLevels", levels);
+        if (!reduce || consume != DEFAULT_CONSUME)
+            nbt.setBoolean("consume", consume);
+        return nbt;
     }
 
     @Override
-    public void readFromNBT(NBTTagCompound json) {
-        amount = json.hasKey("amount", 99) ? json.getInteger("amount") : 30;
-        levels = json.getBoolean("isLevels");
-        consume = json.getBoolean("consume");
+    public void readFromNBT(NBTTagCompound nbt) {
+        amount = NBTUtil.getInteger(nbt, "amount", DEFAULT_AMOUNT);
+        levels = NBTUtil.getBoolean(nbt, "isLevels", DEFAULT_LEVELS);
+        consume = NBTUtil.getBoolean(nbt, "consume", DEFAULT_CONSUME);
     }
 
     @Override

--- a/src/main/java/betterquesting/storage/LifeDatabase.java
+++ b/src/main/java/betterquesting/storage/LifeDatabase.java
@@ -28,6 +28,12 @@ public final class LifeDatabase implements ILifeDatabase {
         playerLives.put(uuid, MathHelper.clamp(value, 0, QuestSettings.INSTANCE.getProperty(NativeProps.LIVES_MAX)));
     }
 
+    @Deprecated
+    @Override
+    public synchronized NBTTagCompound writeToNBT(NBTTagCompound nbt, @Nullable List<UUID> users) {
+        return writeToNBT(nbt, users, false);
+    }
+
     @Override
     public synchronized NBTTagCompound writeToNBT(NBTTagCompound nbt, @Nullable List<UUID> users, boolean reduce) {
         NBTTagList jul = new NBTTagList();

--- a/src/main/java/betterquesting/storage/LifeDatabase.java
+++ b/src/main/java/betterquesting/storage/LifeDatabase.java
@@ -29,7 +29,7 @@ public final class LifeDatabase implements ILifeDatabase {
     }
 
     @Override
-    public synchronized NBTTagCompound writeToNBT(NBTTagCompound nbt, @Nullable List<UUID> users) {
+    public synchronized NBTTagCompound writeToNBT(NBTTagCompound nbt, @Nullable List<UUID> users, boolean reduce) {
         NBTTagList jul = new NBTTagList();
         for (Entry<UUID, Integer> entry : playerLives.entrySet()) {
             if (users != null && !users.contains(entry.getKey())) continue;

--- a/src/main/java/betterquesting/storage/NameCache.java
+++ b/src/main/java/betterquesting/storage/NameCache.java
@@ -63,6 +63,12 @@ public final class NameCache implements INameCache {
         return cache.size();
     }
 
+    @Deprecated
+    @Override
+    public synchronized NBTTagList writeToNBT(NBTTagList nbt, @Nullable List<UUID> users) {
+        return writeToNBT(nbt, users, false);
+    }
+
     @Override
     public synchronized NBTTagList writeToNBT(NBTTagList nbt, @Nullable List<UUID> users, boolean reduce) {
         for (Entry<UUID, NBTTagCompound> entry : cache.entrySet()) {

--- a/src/main/java/betterquesting/storage/NameCache.java
+++ b/src/main/java/betterquesting/storage/NameCache.java
@@ -64,7 +64,7 @@ public final class NameCache implements INameCache {
     }
 
     @Override
-    public synchronized NBTTagList writeToNBT(NBTTagList nbt, @Nullable List<UUID> users) {
+    public synchronized NBTTagList writeToNBT(NBTTagList nbt, @Nullable List<UUID> users, boolean reduce) {
         for (Entry<UUID, NBTTagCompound> entry : cache.entrySet()) {
             if (users != null && !users.contains(entry.getKey())) continue;
             NBTTagCompound jn = new NBTTagCompound();

--- a/src/main/java/betterquesting/storage/PropertyContainer.java
+++ b/src/main/java/betterquesting/storage/PropertyContainer.java
@@ -74,7 +74,9 @@ public class PropertyContainer implements IPropertyContainer, INBTSaveLoad<NBTTa
 
     @Override
     public synchronized void removeAllProps() {
-        nbtInfo.getKeySet().clear();
+        List<String> keys = new ArrayList<>(nbtInfo.getKeySet());
+        for (String key : keys)
+            nbtInfo.removeTag(key);
     }
 
     @Deprecated
@@ -111,7 +113,7 @@ public class PropertyContainer implements IPropertyContainer, INBTSaveLoad<NBTTa
 
     @Override
     public synchronized void readFromNBT(NBTTagCompound nbt) {
-        nbtInfo.getKeySet().clear();
+        removeAllProps();
         nbtInfo.merge(nbt);
 
         // TODO: FIX CASING <- ???

--- a/src/main/java/betterquesting/storage/PropertyContainer.java
+++ b/src/main/java/betterquesting/storage/PropertyContainer.java
@@ -77,6 +77,12 @@ public class PropertyContainer implements IPropertyContainer, INBTSaveLoad<NBTTa
         nbtInfo.getKeySet().clear();
     }
 
+    @Deprecated
+    @Override
+    public synchronized NBTTagCompound writeToNBT(NBTTagCompound nbt) {
+        return writeToNBT(nbt, false);
+    }
+
     @Override
     public synchronized NBTTagCompound writeToNBT(NBTTagCompound nbt, boolean reduce) {
         if (reduce) {


### PR DESCRIPTION
To reduce the quest file size, omit default values.

- Renamed NBTReplaceUtil -> NBTUtil
- Added "reduce" flag parameter to writeToNBT()s to specify whether to reduce or not. (Don't reduce on nbt editor.)
- Added IPropertyReducible to omit default values.