### PR TITLE
Random quest ID

### DIFF
--- a/src/main/java/betterquesting/api2/storage/AbstractDatabase.java
+++ b/src/main/java/betterquesting/api2/storage/AbstractDatabase.java
@@ -1,0 +1,127 @@
+package betterquesting.api2.storage;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.TreeMap;
+
+public abstract class AbstractDatabase<T> implements IDatabase<T> {
+
+    /**
+     * If the cache size would somehow exceed 24MB (on 64bit machines) we stop.
+     */
+    public static int CACHE_MAX_SIZE = 24 * 1024 * 1024 / 8;
+
+    /**
+     * If {@code mapDB.size < SPARSE_RATIO * (mapDB.lastKey() - mapDB.firstKey())} the database will be considered
+     * sparse and an cache array won't be built to save memory.
+     * <p>
+     * Under this sparsity a 10k element database will roughly result in a 0.5MB cache which is more than enough reasonable.
+     */
+    public static double SPARSE_RATIO = 0.15d;
+
+    final TreeMap<Integer, T> mapDB = new TreeMap<>();
+
+    private LookupLogicType type = null;
+    private LookupLogic<T> logic = null;
+
+    private LookupLogic<T> getLookupLogic() {
+        if (type != null)
+            return logic;
+        LookupLogicType newType = LookupLogicType.determine(this);
+        type = newType;
+        logic = newType.get(this);
+        return logic;
+    }
+
+    private void updateLookupLogic() {
+        if (type == null)
+            return;
+        LookupLogicType newType = LookupLogicType.determine(this);
+        if (newType != type) {
+            type = null;
+            logic = null;
+        } else {
+            logic.onDataChange();
+        }
+    }
+
+    @Override
+    public synchronized DBEntry<T> add(int id, T value) {
+        if (value == null) {
+            throw new NullPointerException("Value cannot be null");
+        } else if (id < 0) {
+            throw new IllegalArgumentException("ID cannot be negative");
+        } else {
+            if (mapDB.putIfAbsent(id, value) == null) {
+                updateLookupLogic();
+                return new DBEntry<>(id, value);
+            } else {
+                throw new IllegalArgumentException("ID or value is already contained within database");
+            }
+        }
+    }
+
+    @Override
+    public synchronized boolean removeID(int key) {
+        if (key < 0)
+            return false;
+
+        if (mapDB.remove(key) != null) {
+            updateLookupLogic();
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public synchronized boolean removeValue(T value) {
+        return value != null && removeID(getID(value));
+    }
+
+    @Override
+    public synchronized int getID(T value) {
+        if (value == null)
+            return -1;
+
+        for (DBEntry<T> entry : getEntries()) {
+            if (entry.getValue() == value)
+                return entry.getID();
+        }
+
+        return -1;
+    }
+
+    @Override
+    public synchronized T getValue(int id) {
+        if (id < 0 || mapDB.size() <= 0)
+            return null;
+        return mapDB.get(id);
+    }
+
+    @Override
+    public synchronized int size() {
+        return mapDB.size();
+    }
+
+    @Override
+    public synchronized void reset() {
+        mapDB.clear();
+        type = null;
+        logic = null;
+    }
+
+    @Override
+    public synchronized List<DBEntry<T>> getEntries() {
+        return mapDB.isEmpty() ? Collections.emptyList() : getLookupLogic().getRefCache();
+    }
+
+    /**
+     * First try to use array cache.
+     * If memory usage would be too high try use sort merge join if keys is large.
+     * Otherwise look up each key separately via {@link TreeMap#get(Object)}.
+     */
+    @Override
+    public synchronized List<DBEntry<T>> bulkLookup(int... keys) {
+        return mapDB.isEmpty() || keys.length == 0 ? Collections.emptyList() : getLookupLogic().bulkLookup(keys);
+    }
+}

--- a/src/main/java/betterquesting/api2/storage/ArrayCacheLookupLogic.java
+++ b/src/main/java/betterquesting/api2/storage/ArrayCacheLookupLogic.java
@@ -8,8 +8,8 @@ class ArrayCacheLookupLogic<T> extends LookupLogic<T> {
     private DBEntry<T>[] cache = null;
     private int offset = -1;
 
-    public ArrayCacheLookupLogic(SimpleDatabase<T> simpleDatabase) {
-        super(simpleDatabase);
+    public ArrayCacheLookupLogic(AbstractDatabase<T> abstractDatabase) {
+        super(abstractDatabase);
     }
 
     @Override
@@ -21,7 +21,8 @@ class ArrayCacheLookupLogic<T> extends LookupLogic<T> {
 
     @Override
     public List<DBEntry<T>> getRefCache() {
-        if (refCache != null) return refCache;
+        if (refCache != null)
+            return refCache;
         if (cache == null) {
             return super.getRefCache();
         } else {
@@ -35,7 +36,8 @@ class ArrayCacheLookupLogic<T> extends LookupLogic<T> {
         computeCache();
         List<DBEntry<T>> list = new ArrayList<>(keys.length);
         for (int k : keys) {
-            if (k - offset >= cache.length) continue;
+            if (k - offset >= cache.length)
+                continue;
             final DBEntry<T> element = cache[k - offset];
             if (element != null) {
                 // it shouldn't place too much allocation/gc pressure since there aren't too many keys to look up anyway
@@ -47,11 +49,12 @@ class ArrayCacheLookupLogic<T> extends LookupLogic<T> {
 
     @SuppressWarnings("unchecked")
     private void computeCache() {
-        if (cache != null) return;
-        cache = new DBEntry[simpleDatabase.mapDB.lastKey() - simpleDatabase.mapDB.firstKey() + 1];
-        offset = simpleDatabase.mapDB.firstKey();
+        if (cache != null)
+            return;
+        cache = new DBEntry[abstractDatabase.mapDB.lastKey() - abstractDatabase.mapDB.firstKey() + 1];
+        offset = abstractDatabase.mapDB.firstKey();
         if (refCache == null) {
-            for (Map.Entry<Integer, T> entry : simpleDatabase.mapDB.entrySet()) {
+            for (Map.Entry<Integer, T> entry : abstractDatabase.mapDB.entrySet()) {
                 cache[entry.getKey() - offset] = new DBEntry<>(entry.getKey(), entry.getValue());
             }
         } else {

--- a/src/main/java/betterquesting/api2/storage/EmptyLookupLogic.java
+++ b/src/main/java/betterquesting/api2/storage/EmptyLookupLogic.java
@@ -5,8 +5,8 @@ import java.util.List;
 
 public class EmptyLookupLogic<T> extends LookupLogic<T> {
 
-    public EmptyLookupLogic(SimpleDatabase<T> simpleDatabase) {
-        super(simpleDatabase);
+    public EmptyLookupLogic(AbstractDatabase<T> abstractDatabase) {
+        super(abstractDatabase);
     }
 
     @Override

--- a/src/main/java/betterquesting/api2/storage/LookupLogic.java
+++ b/src/main/java/betterquesting/api2/storage/LookupLogic.java
@@ -7,11 +7,11 @@ import java.util.Map;
 
 abstract class LookupLogic<T> {
 
-    protected final SimpleDatabase<T> simpleDatabase;
+    protected final AbstractDatabase<T> abstractDatabase;
     protected List<DBEntry<T>> refCache = null;
 
-    public LookupLogic(SimpleDatabase<T> simpleDatabase) {
-        this.simpleDatabase = simpleDatabase;
+    public LookupLogic(AbstractDatabase<T> abstractDatabase) {
+        this.abstractDatabase = abstractDatabase;
     }
 
     public void onDataChange() {
@@ -19,7 +19,8 @@ abstract class LookupLogic<T> {
     }
 
     public List<DBEntry<T>> getRefCache() {
-        if (refCache != null) return refCache;
+        if (refCache != null)
+            return refCache;
         computeRefCache();
         return refCache;
     }
@@ -28,7 +29,7 @@ abstract class LookupLogic<T> {
 
     protected void computeRefCache() {
         List<DBEntry<T>> temp = new ArrayList<>();
-        for (Map.Entry<Integer, T> entry : simpleDatabase.mapDB.entrySet()) {
+        for (Map.Entry<Integer, T> entry : abstractDatabase.mapDB.entrySet()) {
             temp.add(new DBEntry<>(entry.getKey(), entry.getValue()));
         }
         refCache = Collections.unmodifiableList(temp);

--- a/src/main/java/betterquesting/api2/storage/LookupLogicType.java
+++ b/src/main/java/betterquesting/api2/storage/LookupLogicType.java
@@ -11,15 +11,15 @@ enum LookupLogicType {
     Empty(db -> db.mapDB.isEmpty(), EmptyLookupLogic::new),
     ArrayCache(db -> db.mapDB.size() < CACHE_MAX_SIZE && db.mapDB.size() > SPARSE_RATIO * (db.mapDB.lastKey() - db.mapDB.firstKey()), ArrayCacheLookupLogic::new),
     Naive(db -> true, NaiveLookupLogic::new);
-    private final Predicate<SimpleDatabase<?>> shouldUse;
-    private final Function<SimpleDatabase<?>, LookupLogic<?>> factory;
+    private final Predicate<AbstractDatabase<?>> shouldUse;
+    private final Function<AbstractDatabase<?>, LookupLogic<?>> factory;
 
-    LookupLogicType(Predicate<SimpleDatabase<?>> shouldUse, Function<SimpleDatabase<?>, LookupLogic<?>> factory) {
+    LookupLogicType(Predicate<AbstractDatabase<?>> shouldUse, Function<AbstractDatabase<?>, LookupLogic<?>> factory) {
         this.shouldUse = shouldUse;
         this.factory = factory;
     }
 
-    static LookupLogicType determine(SimpleDatabase<?> db) {
+    static LookupLogicType determine(AbstractDatabase<?> db) {
         for (LookupLogicType type : values()) {
             if (type.shouldUse.test(db))
                 return type;
@@ -28,7 +28,7 @@ enum LookupLogicType {
     }
 
     @SuppressWarnings("unchecked")
-    <T> LookupLogic<T> get(SimpleDatabase<T> db) {
+    <T> LookupLogic<T> get(AbstractDatabase<T> db) {
         return (LookupLogic<T>) factory.apply(db);
     }
 }

--- a/src/main/java/betterquesting/api2/storage/NaiveLookupLogic.java
+++ b/src/main/java/betterquesting/api2/storage/NaiveLookupLogic.java
@@ -10,8 +10,8 @@ class NaiveLookupLogic<T> extends LookupLogic<T> {
 
     private TIntObjectMap<DBEntry<T>> backingMap;
 
-    public NaiveLookupLogic(SimpleDatabase<T> simpleDatabase) {
-        super(simpleDatabase);
+    public NaiveLookupLogic(AbstractDatabase<T> abstractDatabase) {
+        super(abstractDatabase);
     }
 
     @Override
@@ -23,7 +23,7 @@ class NaiveLookupLogic<T> extends LookupLogic<T> {
     @Override
     public List<DBEntry<T>> bulkLookup(int[] keys) {
         if (backingMap == null) {
-            backingMap = new TIntObjectHashMap<>(simpleDatabase.mapDB.size());
+            backingMap = new TIntObjectHashMap<>(abstractDatabase.mapDB.size());
             for (DBEntry<T> entry : getRefCache()) {
                 backingMap.put(entry.getID(), entry);
             }

--- a/src/main/java/betterquesting/api2/storage/RandomIndexDatabase.java
+++ b/src/main/java/betterquesting/api2/storage/RandomIndexDatabase.java
@@ -1,0 +1,22 @@
+package betterquesting.api2.storage;
+
+import java.util.Random;
+
+public class RandomIndexDatabase<T> extends AbstractDatabase<T> {
+
+    private final Random random = new Random();
+
+    @Override
+    public synchronized int nextID() {
+        int id;
+        do {
+            // id >= 0
+            id = random.nextInt() & 0x7fff_ffff;
+        }
+        // The new id doesn't conflict with existing ones.
+        // However, new ids created by different players could conflict with each other.
+        while (mapDB.containsKey(id));
+        return id;
+    }
+
+}

--- a/src/main/java/betterquesting/api2/storage/SimpleDatabase.java
+++ b/src/main/java/betterquesting/api2/storage/SimpleDatabase.java
@@ -5,45 +5,9 @@ import java.util.Collections;
 import java.util.List;
 import java.util.TreeMap;
 
-public class SimpleDatabase<T> implements IDatabase<T> {
-
-    /**
-     * If the cache size would somehow exceed 24MB (on 64bit machines) we stop.
-     */
-    public static int CACHE_MAX_SIZE = 24 * 1024 * 1024 / 8;
-
-    /**
-     * If {@code mapDB.size < SPARSE_RATIO * (mapDB.lastKey() - mapDB.firstKey())} the database will be considered
-     * sparse and an cache array won't be built to save memory.
-     * <p>
-     * Under this sparsity a 10k element database will roughly result in a 0.5MB cache which is more than enough reasonable.
-     */
-    public static double SPARSE_RATIO = 0.15d;
-
-    final TreeMap<Integer, T> mapDB = new TreeMap<>();
+public class SimpleDatabase<T> extends AbstractDatabase<T> {
 
     private final BitSet idMap = new BitSet();
-    private LookupLogicType type = null;
-    private LookupLogic<T> logic = null;
-
-    private LookupLogic<T> getLookupLogic() {
-        if (type != null) return logic;
-        LookupLogicType newType = LookupLogicType.determine(this);
-        type = newType;
-        logic = newType.get(this);
-        return logic;
-    }
-
-    private void updateLookupLogic() {
-        if (type == null) return;
-        LookupLogicType newType = LookupLogicType.determine(this);
-        if (newType != type) {
-            type = null;
-            logic = null;
-        } else {
-            logic.onDataChange();
-        }
-    }
 
     @Override
     public synchronized int nextID() {
@@ -52,80 +16,24 @@ public class SimpleDatabase<T> implements IDatabase<T> {
 
     @Override
     public synchronized DBEntry<T> add(int id, T value) {
-        if (value == null) {
-            throw new NullPointerException("Value cannot be null");
-        } else if (id < 0) {
-            throw new IllegalArgumentException("ID cannot be negative");
-        } else {
-            if (mapDB.putIfAbsent(id, value) == null) {
-                idMap.set(id);
-                updateLookupLogic();
-                return new DBEntry<>(id, value);
-            } else {
-                throw new IllegalArgumentException("ID or value is already contained within database");
-            }
-        }
+        DBEntry<T> result = super.add(id, value);
+        // Don't add when an exception is thrown
+        idMap.set(id);
+        return result;
     }
 
     @Override
     public synchronized boolean removeID(int key) {
-        if (key < 0) return false;
-
-        if (mapDB.remove(key) != null) {
+        boolean result = super.removeID(key);
+        if (result)
             idMap.clear(key);
-            updateLookupLogic();
-            return true;
-        }
-        return false;
-    }
-
-    @Override
-    public synchronized boolean removeValue(T value) {
-        return value != null && removeID(getID(value));
-    }
-
-    @Override
-    public synchronized int getID(T value) {
-        if (value == null) return -1;
-
-        for (DBEntry<T> entry : getEntries()) {
-            if (entry.getValue() == value) return entry.getID();
-        }
-
-        return -1;
-    }
-
-    @Override
-    public synchronized T getValue(int id) {
-        if (id < 0 || mapDB.size() <= 0) return null;
-        return mapDB.get(id);
-    }
-
-    @Override
-    public synchronized int size() {
-        return mapDB.size();
+        return result;
     }
 
     @Override
     public synchronized void reset() {
-        mapDB.clear();
+        super.reset();
         idMap.clear();
-        type = null;
-        logic = null;
     }
 
-    @Override
-    public synchronized List<DBEntry<T>> getEntries() {
-        return mapDB.isEmpty() ? Collections.emptyList() : getLookupLogic().getRefCache();
-    }
-
-    /**
-     * First try to use array cache.
-     * If memory usage would be too high try use sort merge join if keys is large.
-     * Otherwise look up each key separately via {@link TreeMap#get(Object)}.
-     */
-    @Override
-    public synchronized List<DBEntry<T>> bulkLookup(int... keys) {
-        return mapDB.isEmpty() || keys.length == 0 ? Collections.emptyList() : getLookupLogic().bulkLookup(keys);
-    }
 }

--- a/src/main/java/betterquesting/client/toolbox/tools/ToolboxToolCopy.java
+++ b/src/main/java/betterquesting/client/toolbox/tools/ToolboxToolCopy.java
@@ -177,25 +177,10 @@ public class ToolboxToolCopy implements IToolboxTool {
     }
 
     private int[] getNextIDs(int num) {
-        List<DBEntry<IQuest>> listDB = QuestDatabase.INSTANCE.getEntries();
         int[] nxtIDs = new int[num];
-
-        if (listDB.size() <= 0 || listDB.get(listDB.size() - 1).getID() == listDB.size() - 1) {
-            for (int i = 0; i < num; i++) nxtIDs[i] = listDB.size() + i;
-            return nxtIDs;
-        }
-
-        int n1 = 0;
-        int n2 = 0;
         for (int i = 0; i < num; i++) {
-            while (n2 < listDB.size() && listDB.get(n2).getID() == n1) {
-                n1++;
-                n2++;
-            }
-
-            nxtIDs[i] = n1++;
+            nxtIDs[i] = QuestDatabase.INSTANCE.nextID();
         }
-
         return nxtIDs;
     }
 

--- a/src/main/java/betterquesting/importers/ftbq/FTBQQuestImporter.java
+++ b/src/main/java/betterquesting/importers/ftbq/FTBQQuestImporter.java
@@ -165,7 +165,14 @@ public class FTBQQuestImporter implements IImporter {
                 // === QUEST DATA ===
 
                 String hexID = questFile.getName().substring(0, questFile.getName().length() - (isSnbt ? ".snbt".length() : ".nbt".length()));
-                int questID = questDB.nextID();
+                int questID;
+                try {
+                    questID = Integer.parseInt(hexID, 16) & 0x7fff_ffff;
+                    if (lineDB.getValue(questID) != null)
+                        questID = questDB.nextID();
+                } catch (Exception e) {
+                    questID = questDB.nextID();
+                }
                 IQuest quest = questDB.createNew(questID);
                 IQuestLineEntry qle = questLine.createNew(questID);
                 ID_MAP.put(hexID, new FTBEntry(questID, quest, FTBEntryType.QUEST)); // Add this to the weird ass ID mapping
@@ -253,21 +260,21 @@ public class FTBQQuestImporter implements IImporter {
                     }
 
                     if (qTag.hasKey("dependency_requirement")) {
-                        switch (qTag.getString("dependency_requirement")){
-                            case "all_completed":{
+                        switch (qTag.getString("dependency_requirement")) {
+                            case "all_completed": {
                                 quest.setProperty(NativeProps.LOGIC_QUEST, EnumLogic.AND);
                                 break;
                             }
-                            case "one_completed":{
+                            case "one_completed": {
                                 quest.setProperty(NativeProps.LOGIC_QUEST, EnumLogic.OR);
                                 break;
                             }
                             // BetterQuesting has no "started" options.
-                            case "all_started":{
+                            case "all_started": {
                                 quest.setProperty(NativeProps.LOGIC_QUEST, EnumLogic.AND);
                                 break;
                             }
-                            case "one_started":{
+                            case "one_started": {
                                 quest.setProperty(NativeProps.LOGIC_QUEST, EnumLogic.OR);
                                 break;
                             }

--- a/src/main/java/betterquesting/importers/hqm/HQMQuestImporter.java
+++ b/src/main/java/betterquesting/importers/hqm/HQMQuestImporter.java
@@ -19,6 +19,7 @@ import betterquesting.importers.hqm.converters.rewards.HQMRewardReputation;
 import betterquesting.importers.hqm.converters.rewards.HQMRewardStandard;
 import betterquesting.importers.hqm.converters.tasks.*;
 import com.google.gson.*;
+import java.util.UUID;
 import net.minecraft.init.Items;
 import net.minecraft.nbt.NBTTagList;
 import org.apache.logging.log4j.Level;
@@ -122,41 +123,53 @@ public class HQMQuestImporter implements IImporter {
     }
 
     private void LoadReputations(JsonArray jsonRoot) {
-        if (jsonRoot == null || jsonRoot.size() <= 0) return;
+        if (jsonRoot == null || jsonRoot.size() <= 0)
+            return;
 
         int i = -1;
 
         for (JsonElement e : jsonRoot) {
-            if (!(e instanceof JsonObject)) continue;
+            if (!(e instanceof JsonObject))
+                continue;
             JsonObject jRep = e.getAsJsonObject();
 
             String repName = "Reputation(" + i + ")";
-            if (jRep.has("Name")) repName = JsonHelper.GetString(jRep, "Name", repName);
-            if (jRep.has("name")) repName = JsonHelper.GetString(jRep, "name", repName);
+            if (jRep.has("Name"))
+                repName = JsonHelper.GetString(jRep, "Name", repName);
+            if (jRep.has("name"))
+                repName = JsonHelper.GetString(jRep, "name", repName);
 
             String repId = "" + (++i);
-            if (jRep.has("Id")) repId = JsonHelper.GetNumber(jRep, "Id", i).toString();
-            if (jRep.has("id")) repId = JsonHelper.GetString(jRep, "id", repId);
+            if (jRep.has("Id"))
+                repId = JsonHelper.GetNumber(jRep, "Id", i).toString();
+            if (jRep.has("id"))
+                repId = JsonHelper.GetString(jRep, "id", repId);
 
 
             HQMRep repObj = new HQMRep(repName);
 
             JsonArray mrkAry = null;
-            if (jRep.has("Markers")) mrkAry = JsonHelper.GetArray(jRep, "Markers");
-            if (mrkAry == null) mrkAry = JsonHelper.GetArray(jRep, "markers");
+            if (jRep.has("Markers"))
+                mrkAry = JsonHelper.GetArray(jRep, "Markers");
+            if (mrkAry == null)
+                mrkAry = JsonHelper.GetArray(jRep, "markers");
 
             for (int m = 0; m < mrkAry.size(); m++) {
                 JsonElement e2 = mrkAry.get(m);
-                if (!(e2 instanceof JsonObject)) continue;
+                if (!(e2 instanceof JsonObject))
+                    continue;
 
                 JsonObject jMark = e2.getAsJsonObject();
 
                 int mId = m;
-                if (jMark.has("Id")) mId = JsonHelper.GetNumber(jMark, "Id", mId).intValue();
+                if (jMark.has("Id"))
+                    mId = JsonHelper.GetNumber(jMark, "Id", mId).intValue();
 
                 int mVal = 0;
-                if (jMark.has("Value")) mVal = JsonHelper.GetNumber(jMark, "Value", mVal).intValue();
-                if (jMark.has("value")) mVal = JsonHelper.GetNumber(jMark, "value", mVal).intValue();
+                if (jMark.has("Value"))
+                    mVal = JsonHelper.GetNumber(jMark, "Value", mVal).intValue();
+                if (jMark.has("value"))
+                    mVal = JsonHelper.GetNumber(jMark, "value", mVal).intValue();
 
                 repObj.addMarker(mId, mVal);
             }
@@ -169,7 +182,15 @@ public class HQMQuestImporter implements IImporter {
         if (idMap.containsKey(oldID)) {
             return idMap.get(oldID);
         } else {
-            IQuest quest = qdb.createNew(qdb.nextID());
+            int newID;
+            try {
+                newID = (int) (UUID.fromString(oldID).getMostSignificantBits() & 0x7fff_ffff);
+                if (qdb.getValue(newID) != null)
+                    newID = qdb.nextID();
+            } catch (Exception e) {
+                newID = qdb.nextID();
+            }
+            IQuest quest = qdb.createNew(newID);
             idMap.put(oldID, quest);
             return quest;
         }
@@ -286,7 +307,9 @@ public class HQMQuestImporter implements IImporter {
 
                 if (tsks != null && tsks.length > 0) {
                     IDatabaseNBT<ITask, NBTTagList, NBTTagList> taskReg = quest.getTasks();
-                    for (ITask t : tsks) taskReg.add(taskReg.nextID(), t);
+                    for (ITask t : tsks) {
+                        taskReg.add(taskReg.nextID(), t);
+                    }
                 }
             }
 
@@ -321,12 +344,16 @@ public class HQMQuestImporter implements IImporter {
     }
 
     private boolean containsReq(IQuest quest, int id) {
-        for (int reqID : quest.getRequirements()) if (id == reqID) return true;
+        for (int reqID : quest.getRequirements()) {
+            if (id == reqID)
+                return true;
+        }
         return false;
     }
 
     private void addReq(IQuest quest, int id) {
-        if (containsReq(quest, id)) return;
+        if (containsReq(quest, id))
+            return;
         int[] orig = quest.getRequirements();
         int[] added = Arrays.copyOf(orig, orig.length + 1);
         added[orig.length] = id;

--- a/src/main/java/betterquesting/questing/QuestDatabase.java
+++ b/src/main/java/betterquesting/questing/QuestDatabase.java
@@ -3,7 +3,7 @@ package betterquesting.questing;
 import betterquesting.api.questing.IQuest;
 import betterquesting.api.questing.IQuestDatabase;
 import betterquesting.api2.storage.DBEntry;
-import betterquesting.api2.storage.SimpleDatabase;
+import betterquesting.api2.storage.RandomIndexDatabase;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
 
@@ -11,55 +11,68 @@ import javax.annotation.Nullable;
 import java.util.List;
 import java.util.UUID;
 
-public final class QuestDatabase extends SimpleDatabase<IQuest> implements IQuestDatabase {
+public final class QuestDatabase extends RandomIndexDatabase<IQuest> implements IQuestDatabase {
     public static final QuestDatabase INSTANCE = new QuestDatabase();
 
     @Override
     public synchronized IQuest createNew(int id) {
         IQuest quest = new QuestInstance();
-        if (id >= 0) this.add(id, quest);
+        if (id >= 0)
+            this.add(id, quest);
         return quest;
     }
 
     @Override
     public synchronized boolean removeID(int id) {
         boolean success = super.removeID(id);
-        if (success) for (DBEntry<IQuest> entry : getEntries()) removeReq(entry.getValue(), id);
+        if (success)
+            for (DBEntry<IQuest> entry : getEntries()) {
+                removeReq(entry.getValue(), id);
+            }
         return success;
     }
 
     @Override
     public synchronized boolean removeValue(IQuest value) {
         int id = this.getID(value);
-        if (id < 0) return false;
+        if (id < 0)
+            return false;
         boolean success = this.removeValue(value);
-        if (success) for (DBEntry<IQuest> entry : getEntries()) removeReq(entry.getValue(), id);
+        if (success)
+            for (DBEntry<IQuest> entry : getEntries()) {
+                removeReq(entry.getValue(), id);
+            }
         return success;
     }
 
     private void removeReq(IQuest quest, int id) {
         int[] orig = quest.getRequirements();
-        if (orig.length <= 0) return;
+        if (orig.length <= 0)
+            return;
         boolean hasRemoved = false;
         int[] rem = new int[orig.length - 1];
         for (int i = 0; i < orig.length; i++) {
             if (!hasRemoved && orig[i] == id) {
                 hasRemoved = true;
                 continue;
-            } else if (!hasRemoved && i >= rem.length) break;
+            } else if (!hasRemoved && i >= rem.length)
+                break;
 
             rem[!hasRemoved ? i : (i - 1)] = orig[i];
         }
 
-        if (hasRemoved) quest.setRequirements(rem);
+        if (hasRemoved)
+            quest.setRequirements(rem);
     }
 
     @Override
     public synchronized NBTTagList writeToNBT(NBTTagList json, @Nullable List<Integer> subset) {
         for (DBEntry<IQuest> entry : this.getEntries()) {
-            if (subset != null && !subset.contains(entry.getID())) continue;
+            if (subset != null && !subset.contains(entry.getID()))
+                continue;
             NBTTagCompound jq = entry.getValue().writeToNBT(new NBTTagCompound());
-            if (subset != null && jq.isEmpty()) continue;
+            if (subset != null && jq.isEmpty())
+                continue;
             jq.setInteger("questID", entry.getID());
             json.appendTag(jq);
         }
@@ -69,16 +82,19 @@ public final class QuestDatabase extends SimpleDatabase<IQuest> implements IQues
 
     @Override
     public synchronized void readFromNBT(NBTTagList nbt, boolean merge) {
-        if (!merge) this.reset();
+        if (!merge)
+            this.reset();
 
         for (int i = 0; i < nbt.tagCount(); i++) {
             NBTTagCompound qTag = nbt.getCompoundTagAt(i);
 
             int qID = qTag.hasKey("questID", 99) ? qTag.getInteger("questID") : -1;
-            if (qID < 0) continue;
+            if (qID < 0)
+                continue;
 
             IQuest quest = getValue(qID);
-            if (quest == null) quest = this.createNew(qID);
+            if (quest == null)
+                quest = this.createNew(qID);
             quest.readFromNBT(qTag);
         }
     }
@@ -100,10 +116,12 @@ public final class QuestDatabase extends SimpleDatabase<IQuest> implements IQues
             NBTTagCompound qTag = json.getCompoundTagAt(i);
 
             int qID = qTag.hasKey("questID", 99) ? qTag.getInteger("questID") : -1;
-            if (qID < 0) continue;
+            if (qID < 0)
+                continue;
 
             IQuest quest = getValue(qID);
-            if (quest != null) quest.readProgressFromNBT(qTag, merge);
+            if (quest != null)
+                quest.readProgressFromNBT(qTag, merge);
         }
     }
 }


### PR DESCRIPTION
Now newly created quest ID will be random.
This prevents merge conflicts when multiple people try to add or remove quests simultaneously.

Changing the type of quest ID from int to UUID is pending for compatibility.

I won't apply this change to quest-line ID and other IDs until https://github.com/CleanroomMC/BetterQuesting/pull/103 is merged.