### PR TITLE
Reduce default values of the quest file redux

### DIFF
--- a/src/main/java/betterquesting/NBTReplaceUtil.java
+++ b/src/main/java/betterquesting/NBTReplaceUtil.java
@@ -1,34 +1,10 @@
 package betterquesting;
 
 import net.minecraft.nbt.NBTBase;
-import net.minecraft.nbt.NBTTagCompound;
-import net.minecraft.nbt.NBTTagList;
-import net.minecraft.nbt.NBTTagString;
 
+@Deprecated
 public class NBTReplaceUtil {
-    @SuppressWarnings("unchecked")
     public static <T extends NBTBase> T replaceStrings(T baseTag, String key, String replace) {
-        if (baseTag == null) {
-            return null;
-        }
-
-        if (baseTag instanceof NBTTagCompound) {
-            NBTTagCompound compound = (NBTTagCompound) baseTag;
-
-            for (String k : compound.getKeySet()) {
-                compound.setTag(k, replaceStrings(compound.getTag(k), key, replace));
-            }
-        } else if (baseTag instanceof NBTTagList) {
-            NBTTagList list = (NBTTagList) baseTag;
-
-            for (int i = 0; i < list.tagCount(); i++) {
-                list.set(i, replaceStrings(list.get(i), key, replace));
-            }
-        } else if (baseTag instanceof NBTTagString) {
-            NBTTagString tString = (NBTTagString) baseTag;
-            return (T) new NBTTagString(tString.getString().replaceAll(key, replace));
-        }
-
-        return baseTag; // Either isn't a string or doesn't contain one
+        return NBTUtil.replaceStrings(baseTag, key, replace);
     }
 }

--- a/src/main/java/betterquesting/NBTUtil.java
+++ b/src/main/java/betterquesting/NBTUtil.java
@@ -1,0 +1,34 @@
+package betterquesting;
+
+import net.minecraft.nbt.NBTBase;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.nbt.NBTTagList;
+import net.minecraft.nbt.NBTTagString;
+
+public class NBTUtil {
+    @SuppressWarnings("unchecked")
+    public static <T extends NBTBase> T replaceStrings(T baseTag, String key, String replace) {
+        if (baseTag == null) {
+            return null;
+        }
+
+        if (baseTag instanceof NBTTagCompound) {
+            NBTTagCompound compound = (NBTTagCompound) baseTag;
+
+            for (String k : compound.getKeySet()) {
+                compound.setTag(k, replaceStrings(compound.getTag(k), key, replace));
+            }
+        } else if (baseTag instanceof NBTTagList) {
+            NBTTagList list = (NBTTagList) baseTag;
+
+            for (int i = 0; i < list.tagCount(); i++) {
+                list.set(i, replaceStrings(list.get(i), key, replace));
+            }
+        } else if (baseTag instanceof NBTTagString) {
+            NBTTagString tString = (NBTTagString) baseTag;
+            return (T) new NBTTagString(tString.getString().replaceAll(key, replace));
+        }
+
+        return baseTag; // Either isn't a string or doesn't contain one
+    }
+}

--- a/src/main/java/betterquesting/NBTUtil.java
+++ b/src/main/java/betterquesting/NBTUtil.java
@@ -4,6 +4,7 @@ import net.minecraft.nbt.NBTBase;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
 import net.minecraft.nbt.NBTTagString;
+import net.minecraftforge.common.util.Constants;
 
 import javax.annotation.Nullable;
 
@@ -40,7 +41,7 @@ public class NBTUtil {
     }
 
     public static boolean getBoolean(NBTTagCompound tag, String key, boolean defaultValue) {
-        return tag.hasKey(key, 99) ? tag.getBoolean(key) : defaultValue;
+        return tag.hasKey(key, Constants.NBT.TAG_ANY_NUMERIC) ? tag.getBoolean(key) : defaultValue;
     }
 
     public static void setBoolean(NBTTagCompound tag, String key, boolean value, boolean defaultValue, boolean reduce) {
@@ -49,7 +50,7 @@ public class NBTUtil {
     }
 
     public static int getInteger(NBTTagCompound tag, String key, int defaultValue) {
-        return tag.hasKey(key, 99) ? tag.getInteger(key) : defaultValue;
+        return tag.hasKey(key, Constants.NBT.TAG_ANY_NUMERIC) ? tag.getInteger(key) : defaultValue;
     }
 
     public static void setInteger(NBTTagCompound tag, String key, int value, int defaultValue, boolean reduce) {
@@ -58,7 +59,7 @@ public class NBTUtil {
     }
 
     public static float getFloat(NBTTagCompound tag, String key, float defaultValue) {
-        return tag.hasKey(key, 99) ? tag.getFloat(key) : defaultValue;
+        return tag.hasKey(key, Constants.NBT.TAG_ANY_NUMERIC) ? tag.getFloat(key) : defaultValue;
     }
 
     public static void setFloat(NBTTagCompound tag, String key, float value, float defaultValue, boolean reduce) {
@@ -67,7 +68,7 @@ public class NBTUtil {
     }
 
     public static String getString(NBTTagCompound tag, String key, String defaultValue) {
-        return tag.hasKey(key, 8) ? tag.getString(key) : defaultValue;
+        return tag.hasKey(key, Constants.NBT.TAG_STRING) ? tag.getString(key) : defaultValue;
     }
 
     public static void setString(NBTTagCompound tag, String key, String value, String defaultValue, boolean reduce) {
@@ -76,7 +77,7 @@ public class NBTUtil {
     }
 
     public static <E extends Enum<E>> E getEnum(NBTTagCompound tag, String key, Class<E> enumClass, boolean ignoreCases, @Nullable E defaultValue) {
-        if (tag.hasKey(key, 8)) {
+        if (tag.hasKey(key, Constants.NBT.TAG_STRING)) {
             String valueStr = tag.getString(key);
             for (E value : enumClass.getEnumConstants()) {
                 boolean equals = ignoreCases ? value.name().equalsIgnoreCase(valueStr) : value.name().equals(valueStr);

--- a/src/main/java/betterquesting/NBTUtil.java
+++ b/src/main/java/betterquesting/NBTUtil.java
@@ -5,6 +5,8 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
 import net.minecraft.nbt.NBTTagString;
 
+import javax.annotation.Nullable;
+
 public class NBTUtil {
     @SuppressWarnings("unchecked")
     public static <T extends NBTBase> T replaceStrings(T baseTag, String key, String replace) {
@@ -31,4 +33,59 @@ public class NBTUtil {
 
         return baseTag; // Either isn't a string or doesn't contain one
     }
+
+    public static void setTag(NBTTagCompound tag, String key, NBTBase value, boolean reduce) {
+        if (reduce && value.isEmpty()) return;
+        tag.setTag(key, value);
+    }
+
+    public static boolean getBoolean(NBTTagCompound tag, String key, boolean defaultValue) {
+        return tag.hasKey(key, 99) ? tag.getBoolean(key) : defaultValue;
+    }
+
+    public static void setBoolean(NBTTagCompound tag, String key, boolean value, boolean defaultValue, boolean reduce) {
+        if (reduce && value == defaultValue) return;
+        tag.setBoolean(key, value);
+    }
+
+    public static int getInteger(NBTTagCompound tag, String key, int defaultValue) {
+        return tag.hasKey(key, 99) ? tag.getInteger(key) : defaultValue;
+    }
+
+    public static void setInteger(NBTTagCompound tag, String key, int value, int defaultValue, boolean reduce) {
+        if (reduce && value == defaultValue) return;
+        tag.setInteger(key, value);
+    }
+
+    public static float getFloat(NBTTagCompound tag, String key, float defaultValue) {
+        return tag.hasKey(key, 99) ? tag.getFloat(key) : defaultValue;
+    }
+
+    public static void setFloat(NBTTagCompound tag, String key, float value, float defaultValue, boolean reduce) {
+        if (reduce && value == defaultValue) return;
+        tag.setFloat(key, value);
+    }
+
+    public static String getString(NBTTagCompound tag, String key, String defaultValue) {
+        return tag.hasKey(key, 8) ? tag.getString(key) : defaultValue;
+    }
+
+    public static void setString(NBTTagCompound tag, String key, String value, String defaultValue, boolean reduce) {
+        if (reduce && value.equals(defaultValue)) return;
+        tag.setString(key, value);
+    }
+
+    public static <E extends Enum<E>> E getEnum(NBTTagCompound tag, String key, Class<E> enumClass, boolean ignoreCases, @Nullable E defaultValue) {
+        if (tag.hasKey(key, 8)) {
+            String valueStr = tag.getString(key);
+            for (E value : enumClass.getEnumConstants()) {
+                boolean equals = ignoreCases ? value.name().equalsIgnoreCase(valueStr) : value.name().equals(valueStr);
+                if (equals) {
+                    return value;
+                }
+            }
+        }
+        return defaultValue;
+    }
+
 }

--- a/src/main/java/betterquesting/NbtBlockType.java
+++ b/src/main/java/betterquesting/NbtBlockType.java
@@ -32,21 +32,27 @@ public class NbtBlockType // TODO: Make a version of this for the base mod and g
         this.tags = new NBTTagCompound();
     }
 
-    public NBTTagCompound writeToNBT(NBTTagCompound json) {
-        json.setString("blockID", b.getRegistryName().toString());
-        json.setInteger("meta", m);
-        json.setTag("nbt", tags);
-        json.setInteger("amount", n);
-        json.setString("oreDict", oreDict);
-        return json;
+    @Deprecated
+    public NBTTagCompound writeToNBT(NBTTagCompound nbt) {
+        return writeToNBT(nbt, false);
     }
 
-    public void readFromNBT(NBTTagCompound json) {
-        b = Block.REGISTRY.getObject(new ResourceLocation(json.getString("blockID")));
-        m = json.getInteger("meta");
-        tags = json.getCompoundTag("nbt");
-        n = json.getInteger("amount");
-        oreDict = json.getString("oreDict");
+    public NBTTagCompound writeToNBT(NBTTagCompound nbt, boolean reduce) {
+        nbt.setString("blockID", b.getRegistryName().toString());
+        NBTUtil.setInteger(nbt, "meta", m, -1, reduce);
+        NBTUtil.setTag(nbt, "nbt", tags, reduce);
+        NBTUtil.setInteger(nbt, "amount", n, 1, reduce);
+        NBTUtil.setString(nbt, "oreDict", oreDict, "", reduce);
+        return nbt;
+    }
+
+    public void readFromNBT(NBTTagCompound nbt) {
+        Block targetBlock = Block.REGISTRY.getObject(new ResourceLocation(nbt.getString("blockID")));
+        b = targetBlock != Blocks.AIR ? targetBlock : Blocks.LOG;
+        m = NBTUtil.getInteger(nbt, "meta", -1);
+        tags = nbt.getCompoundTag("nbt");
+        n = NBTUtil.getInteger(nbt, "amount", 1);
+        oreDict = NBTUtil.getString(nbt, "oreDict", "");
     }
 
     public BigItemStack getItemStack() {

--- a/src/main/java/betterquesting/ScoreBQ.java
+++ b/src/main/java/betterquesting/ScoreBQ.java
@@ -27,8 +27,14 @@ public class ScoreBQ implements INBTPartial<NBTTagList, UUID> {
         return playerScores.containsKey(uuid);
     }
 
+    @Deprecated
     @Override
     public synchronized NBTTagList writeToNBT(NBTTagList nbt, @Nullable List<UUID> subset) {
+        return writeToNBT(nbt, subset, false);
+    }
+
+    @Override
+    public synchronized NBTTagList writeToNBT(NBTTagList nbt, @Nullable List<UUID> subset, boolean reduce) {
         for (Entry<UUID, Integer> entry : playerScores.entrySet()) {
             if (subset != null && !subset.contains(entry.getKey())) continue;
             NBTTagCompound jObj = new NBTTagCompound();

--- a/src/main/java/betterquesting/ScoreboardBQ.java
+++ b/src/main/java/betterquesting/ScoreboardBQ.java
@@ -36,12 +36,18 @@ public class ScoreboardBQ implements INBTPartial<NBTTagList, UUID> {
         }
     }
 
+    @Deprecated
     @Override
     public synchronized NBTTagList writeToNBT(NBTTagList nbt, @Nullable List<UUID> users) {
+        return writeToNBT(nbt, users, false);
+    }
+
+    @Override
+    public synchronized NBTTagList writeToNBT(NBTTagList nbt, @Nullable List<UUID> users, boolean reduce) {
         for (Entry<String, ScoreBQ> entry : objectives.entrySet()) {
             NBTTagCompound jObj = new NBTTagCompound();
             jObj.setString("name", entry.getKey());
-            jObj.setTag("scores", entry.getValue().writeToNBT(new NBTTagList(), users));
+            jObj.setTag("scores", entry.getValue().writeToNBT(new NBTTagList(), users, reduce));
             nbt.appendTag(jObj);
         }
 

--- a/src/main/java/betterquesting/api/placeholders/rewards/RewardPlaceholder.java
+++ b/src/main/java/betterquesting/api/placeholders/rewards/RewardPlaceholder.java
@@ -21,8 +21,14 @@ public class RewardPlaceholder implements IReward {
         return nbtSaved;
     }
 
+    @Deprecated
     @Override
     public NBTTagCompound writeToNBT(NBTTagCompound nbt) {
+        return writeToNBT(nbt, false);
+    }
+
+    @Override
+    public NBTTagCompound writeToNBT(NBTTagCompound nbt, boolean reduce) {
         nbt.setTag("orig_data", nbtSaved);
 
         return nbt;

--- a/src/main/java/betterquesting/api/placeholders/tasks/TaskPlaceholder.java
+++ b/src/main/java/betterquesting/api/placeholders/tasks/TaskPlaceholder.java
@@ -33,8 +33,14 @@ public class TaskPlaceholder implements ITask {
         return nbtData.getCompoundTag("orig_prog");
     }
 
+    @Deprecated
     @Override
     public NBTTagCompound writeToNBT(NBTTagCompound nbt) {
+        return writeToNBT(nbt, false);
+    }
+
+    @Override
+    public NBTTagCompound writeToNBT(NBTTagCompound nbt, boolean reduce) {
         nbt.setTag("orig_data", nbtData.getCompoundTag("orig_data"));
         return nbt;
     }

--- a/src/main/java/betterquesting/api/properties/IPropertyReducible.java
+++ b/src/main/java/betterquesting/api/properties/IPropertyReducible.java
@@ -1,0 +1,9 @@
+package betterquesting.api.properties;
+
+import net.minecraft.nbt.NBTBase;
+
+public interface IPropertyReducible<T> extends IPropertyType<T> {
+
+    NBTBase reduceNBT(NBTBase nbt);
+
+}

--- a/src/main/java/betterquesting/api/properties/basic/PropertyTypeItemStack.java
+++ b/src/main/java/betterquesting/api/properties/basic/PropertyTypeItemStack.java
@@ -1,12 +1,14 @@
 package betterquesting.api.properties.basic;
 
+import betterquesting.api.properties.IPropertyReducible;
 import betterquesting.api.utils.BigItemStack;
 import betterquesting.api.utils.JsonHelper;
 import net.minecraft.nbt.NBTBase;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.ResourceLocation;
 
-public class PropertyTypeItemStack extends PropertyTypeBase<BigItemStack> {
+public class PropertyTypeItemStack extends PropertyTypeBase<BigItemStack> implements IPropertyReducible<BigItemStack> {
+
     public PropertyTypeItemStack(ResourceLocation key, BigItemStack def) {
         super(key, def);
     }
@@ -25,11 +27,23 @@ public class PropertyTypeItemStack extends PropertyTypeBase<BigItemStack> {
         NBTTagCompound nbt = new NBTTagCompound();
 
         if (value == null || value.getBaseStack() == null) {
-            getDefault().writeToNBT(nbt);
+            getDefault().writeToNBT(nbt, false);
         } else {
-            value.writeToNBT(nbt);
+            value.writeToNBT(nbt, false);
         }
 
         return nbt;
     }
+
+    @Override
+    public NBTBase reduceNBT(NBTBase nbt) {
+        BigItemStack value;
+        if (nbt == null || nbt.getId() != 10) {
+            value = this.getDefault();
+        } else {
+            value = JsonHelper.JsonToItemStack((NBTTagCompound) nbt);
+        }
+        return value.writeToNBT(new NBTTagCompound(), true);
+    }
+
 }

--- a/src/main/java/betterquesting/api/properties/basic/PropertyTypeItemStack.java
+++ b/src/main/java/betterquesting/api/properties/basic/PropertyTypeItemStack.java
@@ -6,6 +6,7 @@ import betterquesting.api.utils.JsonHelper;
 import net.minecraft.nbt.NBTBase;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.common.util.Constants;
 
 public class PropertyTypeItemStack extends PropertyTypeBase<BigItemStack> implements IPropertyReducible<BigItemStack> {
 
@@ -38,7 +39,7 @@ public class PropertyTypeItemStack extends PropertyTypeBase<BigItemStack> implem
     @Override
     public NBTBase reduceNBT(NBTBase nbt) {
         BigItemStack value;
-        if (nbt == null || nbt.getId() != 10) {
+        if (nbt == null || nbt.getId() != Constants.NBT.TAG_COMPOUND) {
             value = this.getDefault();
         } else {
             value = JsonHelper.JsonToItemStack((NBTTagCompound) nbt);

--- a/src/main/java/betterquesting/api/utils/BigItemStack.java
+++ b/src/main/java/betterquesting/api/utils/BigItemStack.java
@@ -1,5 +1,6 @@
 package betterquesting.api.utils;
 
+import betterquesting.NBTUtil;
 import net.minecraft.block.Block;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
@@ -17,10 +18,14 @@ import java.util.List;
  * <b>For storage purposes only!
  */
 public class BigItemStack {
-    private static final OreIngredient NO_ORE = new OreIngredient("");
+
+    private static final short DEFAULT_DAMAGE = 0;
+    private static final String DEFAULT_OREDICT = "";
+    private static final OreIngredient NO_ORE = new OreIngredient(DEFAULT_OREDICT);
+
     private final ItemStack baseStack;
     public int stackSize;
-    private String oreDict = "";
+    private String oreDict = DEFAULT_OREDICT;
     private OreIngredient oreIng = NO_ORE;
 
     public BigItemStack(ItemStack stack) {
@@ -34,7 +39,7 @@ public class BigItemStack {
     }
 
     public BigItemStack(@Nonnull Block block, int amount) {
-        this(block, amount, 0);
+        this(block, amount, DEFAULT_DAMAGE);
     }
 
     public BigItemStack(@Nonnull Block block, int amount, int damage) {
@@ -46,7 +51,7 @@ public class BigItemStack {
     }
 
     public BigItemStack(@Nonnull Item item, int amount) {
-        this(item, amount, 0);
+        this(item, amount, DEFAULT_DAMAGE);
     }
 
     public BigItemStack(@Nonnull Item item, int amount, int damage) {
@@ -142,18 +147,24 @@ public class BigItemStack {
         NBTTagCompound itemNBT = tags.copy();
         itemNBT.setInteger("Count", 1);
         if (tags.hasKey("id", 99)) {
-            itemNBT.setString("id", "" + tags.getShort("id"));
+            itemNBT.setString("id", String.valueOf(tags.getShort("id")));
         }
-        this.stackSize = tags.getInteger("Count");
+        this.stackSize = NBTUtil.getInteger(tags, "Count", 1);
         this.setOreDict(tags.getString("OreDict"));
         this.baseStack = new ItemStack(itemNBT); // Minecraft does the ID conversions for me
         if (tags.getShort("Damage") < 0) this.baseStack.setItemDamage(OreDictionary.WILDCARD_VALUE);
     }
 
+    @Deprecated
     public NBTTagCompound writeToNBT(NBTTagCompound tags) {
+        return writeToNBT(tags, false);
+    }
+
+    public NBTTagCompound writeToNBT(NBTTagCompound tags, boolean reduce) {
         baseStack.writeToNBT(tags);
         tags.setInteger("Count", stackSize);
-        tags.setString("OreDict", oreDict);
+        if (reduce && baseStack.getItemDamage() == DEFAULT_DAMAGE) tags.removeTag("Damage");
+        NBTUtil.setString(tags, "OreDict", oreDict, "", reduce);
         return tags;
     }
 }

--- a/src/main/java/betterquesting/api/utils/JsonHelper.java
+++ b/src/main/java/betterquesting/api/utils/JsonHelper.java
@@ -1,5 +1,6 @@
 package betterquesting.api.utils;
 
+import betterquesting.NBTUtil;
 import betterquesting.api.api.QuestingAPI;
 import betterquesting.api.placeholders.ItemPlaceholder;
 import betterquesting.api.placeholders.PlaceholderConverter;
@@ -279,14 +280,19 @@ public class JsonHelper {
     public static BigItemStack JsonToItemStack(NBTTagCompound nbt) {
         Item preCheck = Item.getByNameOrId(nbt.hasKey("id", 99) ? "" + nbt.getShort("id") : nbt.getString("id"));
         if (preCheck != null && preCheck != ItemPlaceholder.placeholder) return new BigItemStack(nbt);
-        return PlaceholderConverter.convertItem(preCheck, nbt.getString("id"), nbt.getInteger("Count"), nbt.getShort("Damage"), nbt.getString("OreDict"), !nbt.hasKey("tag", 10) ? null : nbt.getCompoundTag("tag"));
+        return PlaceholderConverter.convertItem(preCheck, nbt.getString("id"), NBTUtil.getInteger(nbt, "Count", 1), nbt.getShort("Damage"), nbt.getString("OreDict"), !nbt.hasKey("tag", 10) ? null : nbt.getCompoundTag("tag"));
     }
 
     /**
      * Use this for quests instead of converter NBT because this doesn't use ID numbers
      */
     public static NBTTagCompound ItemStackToJson(BigItemStack stack, NBTTagCompound nbt) {
-        if (stack != null) stack.writeToNBT(nbt);
+        return ItemStackToJson(stack, nbt, false);
+    }
+
+    public static NBTTagCompound ItemStackToJson(BigItemStack stack, NBTTagCompound nbt, boolean reduce) {
+        if (stack != null)
+            stack.writeToNBT(nbt, reduce);
         return nbt;
     }
 

--- a/src/main/java/betterquesting/api2/storage/INBTPartial.java
+++ b/src/main/java/betterquesting/api2/storage/INBTPartial.java
@@ -7,7 +7,12 @@ import java.util.List;
 
 // Used when the base data set can safely be split. Can be used in place of INBTSaveLoad
 public interface INBTPartial<T extends NBTBase, K> {
+    @Deprecated
     T writeToNBT(T nbt, @Nullable List<K> subset);
+
+    default T writeToNBT(T nbt, @Nullable List<K> subset, boolean reduce) {
+        return writeToNBT(nbt, subset);
+    }
 
     void readFromNBT(T nbt, boolean merge);
 }

--- a/src/main/java/betterquesting/api2/storage/INBTSaveLoad.java
+++ b/src/main/java/betterquesting/api2/storage/INBTSaveLoad.java
@@ -6,5 +6,10 @@ import net.minecraft.nbt.NBTBase;
 public interface INBTSaveLoad<T extends NBTBase> {
     T writeToNBT(T nbt);
 
+    default T writeToNBT(T nbt, boolean reduce) {
+        return writeToNBT(nbt);
+    }
+
     void readFromNBT(T nbt);
+
 }

--- a/src/main/java/betterquesting/client/gui2/GuiHome.java
+++ b/src/main/java/betterquesting/client/gui2/GuiHome.java
@@ -172,7 +172,7 @@ public class GuiHome extends GuiScreenCanvas {
             mc.displayGuiScreen(new GuiThemes(this));
         } else if (btn.getButtonID() == 4) // Editor
         {
-            mc.displayGuiScreen(new GuiNbtEditor(this, QuestSettings.INSTANCE.writeToNBT(new NBTTagCompound()), (value) ->
+            mc.displayGuiScreen(new GuiNbtEditor(this, QuestSettings.INSTANCE.writeToNBT(new NBTTagCompound(), false), (value) ->
             {
                 QuestSettings.INSTANCE.readFromNBT(value);
                 NetSettingSync.requestEdit();

--- a/src/main/java/betterquesting/client/gui2/editors/GuiEditLootEntry.java
+++ b/src/main/java/betterquesting/client/gui2/editors/GuiEditLootEntry.java
@@ -113,7 +113,7 @@ public class GuiEditLootEntry extends GuiScreenCanvas {
             @Override
             public void onButtonClick() {
                 if (selEntry != null) {
-                    final NBTTagCompound eTag = selEntry.writeToNBT(new NBTTagCompound());
+                    final NBTTagCompound eTag = selEntry.writeToNBT(new NBTTagCompound(), false);
                     mc.displayGuiScreen(QuestingAPI.getAPI(ApiReference.THEME_REG).getGui(PresetGUIs.EDIT_NBT, new GArgsNBT<>(screenRef, eTag.getTagList("items", 10), value -> {
                         LootGroup lg = LootRegistry.INSTANCE.getValue(groupID);
                         LootGroup.LootEntry le = lg == null ? null : lg.getValue(selectedID);
@@ -211,6 +211,6 @@ public class GuiEditLootEntry extends GuiScreenCanvas {
     }
 
     private void sendChanges() {
-        NetLootImport.importLoot(LootRegistry.INSTANCE.writeToNBT(new NBTTagCompound(), null));
+        NetLootImport.importLoot(LootRegistry.INSTANCE.writeToNBT(new NBTTagCompound(), null, true));
     }
 }

--- a/src/main/java/betterquesting/client/gui2/editors/GuiEditLootGroup.java
+++ b/src/main/java/betterquesting/client/gui2/editors/GuiEditLootGroup.java
@@ -205,6 +205,6 @@ public class GuiEditLootGroup extends GuiScreenCanvas implements IVolatileScreen
     }
 
     private void SendChanges() {
-        NetLootImport.importLoot(LootRegistry.INSTANCE.writeToNBT(new NBTTagCompound(), null));
+        NetLootImport.importLoot(LootRegistry.INSTANCE.writeToNBT(new NBTTagCompound(), null, true));
     }
 }

--- a/src/main/java/betterquesting/client/gui2/editors/GuiPrerequisiteEditor.java
+++ b/src/main/java/betterquesting/client/gui2/editors/GuiPrerequisiteEditor.java
@@ -308,7 +308,7 @@ public class GuiPrerequisiteEditor extends GuiScreenCanvas implements IPEventLis
         NBTTagList dataList = new NBTTagList();
         NBTTagCompound entry = new NBTTagCompound();
         entry.setInteger("questID", questID);
-        entry.setTag("config", quest.writeToNBT(new NBTTagCompound()));
+        entry.setTag("config", quest.writeToNBT(new NBTTagCompound(), true));
         dataList.appendTag(entry);
         payload.setTag("data", dataList);
         payload.setInteger("action", 0);

--- a/src/main/java/betterquesting/client/gui2/editors/GuiQuestEditor.java
+++ b/src/main/java/betterquesting/client/gui2/editors/GuiQuestEditor.java
@@ -195,7 +195,7 @@ public class GuiQuestEditor extends GuiScreenCanvas implements IPEventListener, 
             }
             case 4: // Advanced
             {
-                mc.displayGuiScreen(new GuiNbtEditor(this, quest.writeToNBT(new NBTTagCompound()), value -> {
+                mc.displayGuiScreen(new GuiNbtEditor(this, quest.writeToNBT(new NBTTagCompound(), false), value -> {
                     quest.readFromNBT(value);
                     sendChanges(questID);
                 }));
@@ -241,7 +241,7 @@ public class GuiQuestEditor extends GuiScreenCanvas implements IPEventListener, 
         NBTTagList dataList = new NBTTagList();
         NBTTagCompound entry = new NBTTagCompound();
         entry.setInteger("questID", questID);
-        entry.setTag("config", quest.writeToNBT(new NBTTagCompound()));
+        entry.setTag("config", quest.writeToNBT(new NBTTagCompound(), true));
         dataList.appendTag(entry);
         payload.setTag("data", dataList);
         payload.setInteger("action", 0);

--- a/src/main/java/betterquesting/client/gui2/editors/GuiQuestLineAddRemove.java
+++ b/src/main/java/betterquesting/client/gui2/editors/GuiQuestLineAddRemove.java
@@ -283,7 +283,7 @@ public class GuiQuestLineAddRemove extends GuiScreenCanvas implements IPEventLis
         NBTTagList dataList = new NBTTagList();
         NBTTagCompound entry = new NBTTagCompound();
         entry.setInteger("chapterID", lineID);
-        entry.setTag("config", questLine.writeToNBT(new NBTTagCompound(), null));
+        entry.setTag("config", questLine.writeToNBT(new NBTTagCompound(), null, true));
         dataList.appendTag(entry);
         payload.setTag("data", dataList);
         payload.setInteger("action", 0);

--- a/src/main/java/betterquesting/client/gui2/editors/GuiQuestLinesEditor.java
+++ b/src/main/java/betterquesting/client/gui2/editors/GuiQuestLinesEditor.java
@@ -320,7 +320,7 @@ public class GuiQuestLinesEditor extends GuiScreenCanvas implements IPEventListe
         NBTTagList dataList = new NBTTagList();
         NBTTagCompound entry = new NBTTagCompound();
         entry.setInteger("chapterID", chapter.getID());
-        entry.setTag("config", chapter.getValue().writeToNBT(new NBTTagCompound(), null));
+        entry.setTag("config", chapter.getValue().writeToNBT(new NBTTagCompound(), null, true));
         dataList.appendTag(entry);
         payload.setTag("data", dataList);
         payload.setInteger("action", 0);

--- a/src/main/java/betterquesting/client/gui2/editors/GuiRewardEditor.java
+++ b/src/main/java/betterquesting/client/gui2/editors/GuiRewardEditor.java
@@ -172,7 +172,7 @@ public class GuiRewardEditor extends GuiScreenCanvas implements IPEventListener,
             if (editor != null) {
                 mc.displayGuiScreen(editor);
             } else {
-                mc.displayGuiScreen(new GuiNbtEditor(this, reward.writeToNBT(new NBTTagCompound()), value -> {
+                mc.displayGuiScreen(new GuiNbtEditor(this, reward.writeToNBT(new NBTTagCompound(), false), value -> {
                     reward.readFromNBT(value);
                     SendChanges();
                 }));
@@ -198,7 +198,7 @@ public class GuiRewardEditor extends GuiScreenCanvas implements IPEventListener,
         NBTTagList dataList = new NBTTagList();
         NBTTagCompound entry = new NBTTagCompound();
         entry.setInteger("questID", qID);
-        entry.setTag("config", quest.writeToNBT(new NBTTagCompound()));
+        entry.setTag("config", quest.writeToNBT(new NBTTagCompound(), true));
         dataList.appendTag(entry);
         payload.setTag("data", dataList);
         payload.setInteger("action", 0);

--- a/src/main/java/betterquesting/client/gui2/editors/GuiTaskEditor.java
+++ b/src/main/java/betterquesting/client/gui2/editors/GuiTaskEditor.java
@@ -172,7 +172,7 @@ public class GuiTaskEditor extends GuiScreenCanvas implements IPEventListener, I
             if (editor != null) {
                 mc.displayGuiScreen(editor);
             } else {
-                mc.displayGuiScreen(new GuiNbtEditor(this, task.writeToNBT(new NBTTagCompound()), value -> {
+                mc.displayGuiScreen(new GuiNbtEditor(this, task.writeToNBT(new NBTTagCompound(), false), value -> {
                     task.readFromNBT(value);
                     SendChanges();
                 }));
@@ -198,7 +198,7 @@ public class GuiTaskEditor extends GuiScreenCanvas implements IPEventListener, I
         NBTTagList dataList = new NBTTagList();
         NBTTagCompound entry = new NBTTagCompound();
         entry.setInteger("questID", qID);
-        entry.setTag("config", quest.writeToNBT(new NBTTagCompound()));
+        entry.setTag("config", quest.writeToNBT(new NBTTagCompound(), true));
         dataList.appendTag(entry);
         payload.setTag("data", dataList);
         payload.setInteger("action", 0);

--- a/src/main/java/betterquesting/client/gui2/editors/tasks/GuiEditTaskAdvancement.java
+++ b/src/main/java/betterquesting/client/gui2/editors/tasks/GuiEditTaskAdvancement.java
@@ -121,7 +121,7 @@ public class GuiEditTaskAdvancement extends GuiScreenCanvas implements IVolatile
         NBTTagList dataList = new NBTTagList();
         NBTTagCompound entry = new NBTTagCompound();
         entry.setInteger("questID", quest.getID());
-        entry.setTag("config", quest.getValue().writeToNBT(new NBTTagCompound()));
+        entry.setTag("config", quest.getValue().writeToNBT(new NBTTagCompound(), true));
         dataList.appendTag(entry);
         payload.setTag("data", dataList);
         payload.setInteger("action", 0); // Action: Update data

--- a/src/main/java/betterquesting/client/gui2/editors/tasks/GuiEditTaskHunt.java
+++ b/src/main/java/betterquesting/client/gui2/editors/tasks/GuiEditTaskHunt.java
@@ -89,7 +89,7 @@ public class GuiEditTaskHunt extends GuiScreenCanvas implements IVolatileScreen 
         cvBackground.addPanel(new PanelButton(new GuiTransform(GuiAlign.MID_CENTER, -100, 32, 200, 16, 0), -1, QuestTranslation.translate("betterquesting.btn.advanced")) {
             @Override
             public void onButtonClick() {
-                mc.displayGuiScreen(QuestingAPI.getAPI(ApiReference.THEME_REG).getGui(PresetGUIs.EDIT_NBT, new GArgsNBT<>(screenRef, task.writeToNBT(new NBTTagCompound()), task::readFromNBT, null)));
+                mc.displayGuiScreen(QuestingAPI.getAPI(ApiReference.THEME_REG).getGui(PresetGUIs.EDIT_NBT, new GArgsNBT<>(screenRef, task.writeToNBT(new NBTTagCompound(), false), task::readFromNBT, null)));
             }
         });
 
@@ -109,7 +109,7 @@ public class GuiEditTaskHunt extends GuiScreenCanvas implements IVolatileScreen 
         NBTTagList dataList = new NBTTagList();
         NBTTagCompound entry = new NBTTagCompound();
         entry.setInteger("questID", quest.getID());
-        entry.setTag("config", quest.getValue().writeToNBT(new NBTTagCompound()));
+        entry.setTag("config", quest.getValue().writeToNBT(new NBTTagCompound(), true));
         dataList.appendTag(entry);
         payload.setTag("data", dataList);
         payload.setInteger("action", 0); // Action: Update data

--- a/src/main/java/betterquesting/client/gui2/editors/tasks/GuiEditTaskMeeting.java
+++ b/src/main/java/betterquesting/client/gui2/editors/tasks/GuiEditTaskMeeting.java
@@ -87,7 +87,7 @@ public class GuiEditTaskMeeting extends GuiScreenCanvas implements IVolatileScre
         cvBackground.addPanel(new PanelButton(new GuiTransform(GuiAlign.MID_CENTER, -100, 32, 200, 16, 0), -1, QuestTranslation.translate("betterquesting.btn.advanced")) {
             @Override
             public void onButtonClick() {
-                mc.displayGuiScreen(QuestingAPI.getAPI(ApiReference.THEME_REG).getGui(PresetGUIs.EDIT_NBT, new GArgsNBT<>(screenRef, task.writeToNBT(new NBTTagCompound()), task::readFromNBT, null)));
+                mc.displayGuiScreen(QuestingAPI.getAPI(ApiReference.THEME_REG).getGui(PresetGUIs.EDIT_NBT, new GArgsNBT<>(screenRef, task.writeToNBT(new NBTTagCompound(), false), task::readFromNBT, null)));
             }
         });
 
@@ -107,7 +107,7 @@ public class GuiEditTaskMeeting extends GuiScreenCanvas implements IVolatileScre
         NBTTagList dataList = new NBTTagList();
         NBTTagCompound entry = new NBTTagCompound();
         entry.setInteger("questID", quest.getID());
-        entry.setTag("config", quest.getValue().writeToNBT(new NBTTagCompound()));
+        entry.setTag("config", quest.getValue().writeToNBT(new NBTTagCompound(), true));
         dataList.appendTag(entry);
         payload.setTag("data", dataList);
         payload.setInteger("action", 0); // Action: Update data

--- a/src/main/java/betterquesting/client/gui2/editors/tasks/GuiEditTaskScoreboard.java
+++ b/src/main/java/betterquesting/client/gui2/editors/tasks/GuiEditTaskScoreboard.java
@@ -75,7 +75,7 @@ public class GuiEditTaskScoreboard extends GuiScreenCanvas {
         cvBackground.addPanel(new PanelButton(new GuiTransform(GuiAlign.MID_CENTER, -100, 16, 200, 16, 0), -1, QuestTranslation.translate("betterquesting.btn.advanced")) {
             @Override
             public void onButtonClick() {
-                mc.displayGuiScreen(QuestingAPI.getAPI(ApiReference.THEME_REG).getGui(PresetGUIs.EDIT_NBT, new GArgsNBT<>(screenRef, task.writeToNBT(new NBTTagCompound()), task::readFromNBT, null)));
+                mc.displayGuiScreen(QuestingAPI.getAPI(ApiReference.THEME_REG).getGui(PresetGUIs.EDIT_NBT, new GArgsNBT<>(screenRef, task.writeToNBT(new NBTTagCompound(), false), task::readFromNBT, null)));
             }
         });
 
@@ -95,7 +95,7 @@ public class GuiEditTaskScoreboard extends GuiScreenCanvas {
         NBTTagList dataList = new NBTTagList();
         NBTTagCompound entry = new NBTTagCompound();
         entry.setInteger("questID", quest.getID());
-        entry.setTag("config", quest.getValue().writeToNBT(new NBTTagCompound()));
+        entry.setTag("config", quest.getValue().writeToNBT(new NBTTagCompound(), true));
         dataList.appendTag(entry);
         payload.setTag("data", dataList);
         payload.setInteger("action", 0); // Action: Update data

--- a/src/main/java/betterquesting/client/gui2/editors/tasks/GuiEditTaskTame.java
+++ b/src/main/java/betterquesting/client/gui2/editors/tasks/GuiEditTaskTame.java
@@ -89,7 +89,7 @@ public class GuiEditTaskTame extends GuiScreenCanvas implements IVolatileScreen 
         cvBackground.addPanel(new PanelButton(new GuiTransform(GuiAlign.MID_CENTER, -100, 32, 200, 16, 0), -1, QuestTranslation.translate("betterquesting.btn.advanced")) {
             @Override
             public void onButtonClick() {
-                mc.displayGuiScreen(QuestingAPI.getAPI(ApiReference.THEME_REG).getGui(PresetGUIs.EDIT_NBT, new GArgsNBT<>(screenRef, task.writeToNBT(new NBTTagCompound()), task::readFromNBT, null)));
+                mc.displayGuiScreen(QuestingAPI.getAPI(ApiReference.THEME_REG).getGui(PresetGUIs.EDIT_NBT, new GArgsNBT<>(screenRef, task.writeToNBT(new NBTTagCompound(), false), task::readFromNBT, null)));
             }
         });
 
@@ -109,7 +109,7 @@ public class GuiEditTaskTame extends GuiScreenCanvas implements IVolatileScreen 
         NBTTagList dataList = new NBTTagList();
         NBTTagCompound entry = new NBTTagCompound();
         entry.setInteger("questID", quest.getID());
-        entry.setTag("config", quest.getValue().writeToNBT(new NBTTagCompound()));
+        entry.setTag("config", quest.getValue().writeToNBT(new NBTTagCompound(), true));
         dataList.appendTag(entry);
         payload.setTag("data", dataList);
         payload.setInteger("action", 0); // Action: Update data

--- a/src/main/java/betterquesting/client/importers/ImportedQuestLines.java
+++ b/src/main/java/betterquesting/client/importers/ImportedQuestLines.java
@@ -46,17 +46,23 @@ public class ImportedQuestLines extends SimpleDatabase<IQuestLine> implements IQ
         return ary;
     }
 
+    @Deprecated
     @Override
-    public NBTTagList writeToNBT(NBTTagList json, List<Integer> subset) {
+    public NBTTagList writeToNBT(NBTTagList nbt, List<Integer> subset) {
+        return writeToNBT(nbt, subset, false);
+    }
+
+    @Override
+    public NBTTagList writeToNBT(NBTTagList nbt, List<Integer> subset, boolean reduce) {
         for (DBEntry<IQuestLine> entry : getEntries()) {
             if (subset != null && !subset.contains(entry.getID())) continue;
-            NBTTagCompound jObj = entry.getValue().writeToNBT(new NBTTagCompound(), null);
+            NBTTagCompound jObj = entry.getValue().writeToNBT(new NBTTagCompound(), null, reduce);
             jObj.setInteger("lineID", entry.getID());
             jObj.setInteger("order", getOrderIndex(entry.getID()));
-            json.appendTag(jObj);
+            nbt.appendTag(jObj);
         }
 
-        return json;
+        return nbt;
     }
 
     @Override

--- a/src/main/java/betterquesting/client/importers/ImportedQuests.java
+++ b/src/main/java/betterquesting/client/importers/ImportedQuests.java
@@ -36,12 +36,18 @@ public class ImportedQuests extends SimpleDatabase<IQuest> implements IQuestData
         return values;
     }
 
+    @Deprecated
     @Override
     public NBTTagList writeToNBT(NBTTagList nbt, List<Integer> subset) {
+        return writeToNBT(nbt, subset, false);
+    }
+
+    @Override
+    public NBTTagList writeToNBT(NBTTagList nbt, List<Integer> subset, boolean reduce) {
         for (DBEntry<IQuest> entry : this.getEntries()) {
             if (subset != null && !subset.contains(entry.getID())) continue;
             NBTTagCompound jq = new NBTTagCompound();
-            entry.getValue().writeToNBT(jq);
+            entry.getValue().writeToNBT(jq, reduce);
             jq.setInteger("questID", entry.getID());
             nbt.appendTag(jq);
         }

--- a/src/main/java/betterquesting/client/toolbox/PanelTabMain.java
+++ b/src/main/java/betterquesting/client/toolbox/PanelTabMain.java
@@ -59,7 +59,7 @@ public class PanelTabMain extends CanvasEmpty {
             @Override
             public void onButtonClick() {
                 Minecraft mc = Minecraft.getMinecraft();
-                mc.displayGuiScreen(new GuiNbtEditor(mc.currentScreen, cvQuestLine.getQuestLine().writeToNBT(new NBTTagCompound(), null), value -> {
+                mc.displayGuiScreen(new GuiNbtEditor(mc.currentScreen, cvQuestLine.getQuestLine().writeToNBT(new NBTTagCompound(), null, false), value -> {
                     NBTTagCompound payload = new NBTTagCompound();
                     NBTTagList dataList = new NBTTagList();
                     NBTTagCompound entry = new NBTTagCompound();

--- a/src/main/java/betterquesting/client/toolbox/tools/ToolboxToolCopy.java
+++ b/src/main/java/betterquesting/client/toolbox/tools/ToolboxToolCopy.java
@@ -135,7 +135,7 @@ public class ToolboxToolCopy implements IToolboxTool {
             if (qLine.getValue(qID) == null)
                 qLine.add(qID, new QuestLineEntry(grab.btn.rect.x, grab.btn.rect.y, grab.btn.rect.w, grab.btn.rect.h));
 
-            NBTTagCompound questTags = quest.writeToNBT(new NBTTagCompound());
+            NBTTagCompound questTags = quest.writeToNBT(new NBTTagCompound(), true);
 
             int[] oldIDs = Arrays.copyOf(quest.getRequirements(), quest.getRequirements().length);
 
@@ -167,7 +167,7 @@ public class ToolboxToolCopy implements IToolboxTool {
         NBTTagList cdList = new NBTTagList();
         NBTTagCompound tagEntry = new NBTTagCompound();
         tagEntry.setInteger("chapterID", lID);
-        tagEntry.setTag("config", qLine.writeToNBT(new NBTTagCompound(), null));
+        tagEntry.setTag("config", qLine.writeToNBT(new NBTTagCompound(), null, true));
         cdList.appendTag(tagEntry);
         chPayload.setTag("data", cdList);
         chPayload.setInteger("action", 0);

--- a/src/main/java/betterquesting/client/toolbox/tools/ToolboxToolGrab.java
+++ b/src/main/java/betterquesting/client/toolbox/tools/ToolboxToolGrab.java
@@ -138,7 +138,7 @@ public class ToolboxToolGrab implements IToolboxTool {
             NBTTagList cdList = new NBTTagList();
             NBTTagCompound tagEntry = new NBTTagCompound();
             tagEntry.setInteger("chapterID", lID);
-            tagEntry.setTag("config", qLine.writeToNBT(new NBTTagCompound(), null));
+            tagEntry.setTag("config", qLine.writeToNBT(new NBTTagCompound(), null, true));
             cdList.appendTag(tagEntry);
             chPayload.setTag("data", cdList);
             chPayload.setInteger("action", 0);

--- a/src/main/java/betterquesting/client/toolbox/tools/ToolboxToolIcon.java
+++ b/src/main/java/betterquesting/client/toolbox/tools/ToolboxToolIcon.java
@@ -56,7 +56,7 @@ public class ToolboxToolIcon implements IToolboxTool {
 
                 NBTTagCompound entry = new NBTTagCompound();
                 entry.setInteger("questID", b.getStoredValue().getID());
-                entry.setTag("config", b.getStoredValue().getValue().writeToNBT(new NBTTagCompound()));
+                entry.setTag("config", b.getStoredValue().getValue().writeToNBT(new NBTTagCompound(), true));
                 dataList.appendTag(entry);
             }
 

--- a/src/main/java/betterquesting/client/toolbox/tools/ToolboxToolLink.java
+++ b/src/main/java/betterquesting/client/toolbox/tools/ToolboxToolLink.java
@@ -117,7 +117,7 @@ public class ToolboxToolLink implements IToolboxTool {
                     if (mod1) {
                         NBTTagCompound entry = new NBTTagCompound();
                         entry.setInteger("questID", b1.getStoredValue().getID());
-                        entry.setTag("config", b1.getStoredValue().getValue().writeToNBT(new NBTTagCompound()));
+                        entry.setTag("config", b1.getStoredValue().getValue().writeToNBT(new NBTTagCompound(), true));
                         dataList.appendTag(entry);
                     }
                 }
@@ -125,7 +125,7 @@ public class ToolboxToolLink implements IToolboxTool {
                 if (mod2) {
                     NBTTagCompound entry = new NBTTagCompound();
                     entry.setInteger("questID", b2.getStoredValue().getID());
-                    entry.setTag("config", q2.writeToNBT(new NBTTagCompound()));
+                    entry.setTag("config", q2.writeToNBT(new NBTTagCompound(), true));
                     dataList.appendTag(entry);
                 }
 

--- a/src/main/java/betterquesting/client/toolbox/tools/ToolboxToolNew.java
+++ b/src/main/java/betterquesting/client/toolbox/tools/ToolboxToolNew.java
@@ -102,7 +102,7 @@ public class ToolboxToolNew implements IToolboxTool {
         NBTTagList cdList = new NBTTagList();
         NBTTagCompound cTag = new NBTTagCompound();
         cTag.setInteger("chapterID", lID);
-        cTag.setTag("config", qLine.writeToNBT(new NBTTagCompound(), null));
+        cTag.setTag("config", qLine.writeToNBT(new NBTTagCompound(), null, true));
         cdList.appendTag(cTag);
         chPayload.setTag("data", cdList);
         chPayload.setInteger("action", 0);

--- a/src/main/java/betterquesting/client/toolbox/tools/ToolboxToolRemove.java
+++ b/src/main/java/betterquesting/client/toolbox/tools/ToolboxToolRemove.java
@@ -53,7 +53,7 @@ public class ToolboxToolRemove implements IToolboxTool {
             NBTTagList cdList = new NBTTagList();
             NBTTagCompound cTag = new NBTTagCompound();
             cTag.setInteger("chapterID", QuestLineDatabase.INSTANCE.getID(line));
-            cTag.setTag("config", line.writeToNBT(new NBTTagCompound(), null));
+            cTag.setTag("config", line.writeToNBT(new NBTTagCompound(), null, true));
             cdList.appendTag(cTag);
             chPayload.setTag("data", cdList);
             chPayload.setInteger("action", 0);
@@ -98,7 +98,7 @@ public class ToolboxToolRemove implements IToolboxTool {
             NBTTagList cdList = new NBTTagList();
             NBTTagCompound cTag = new NBTTagCompound();
             cTag.setInteger("chapterID", QuestLineDatabase.INSTANCE.getID(line));
-            cTag.setTag("config", line.writeToNBT(new NBTTagCompound(), null));
+            cTag.setTag("config", line.writeToNBT(new NBTTagCompound(), null, true));
             cdList.appendTag(cTag);
             chPayload.setTag("data", cdList);
             chPayload.setInteger("action", 0);

--- a/src/main/java/betterquesting/client/toolbox/tools/ToolboxToolScale.java
+++ b/src/main/java/betterquesting/client/toolbox/tools/ToolboxToolScale.java
@@ -154,7 +154,7 @@ public class ToolboxToolScale implements IToolboxTool {
             NBTTagList cdList = new NBTTagList();
             NBTTagCompound tagEntry = new NBTTagCompound();
             tagEntry.setInteger("chapterID", lID);
-            tagEntry.setTag("config", qLine.writeToNBT(new NBTTagCompound(), null));
+            tagEntry.setTag("config", qLine.writeToNBT(new NBTTagCompound(), null, true));
             cdList.appendTag(tagEntry);
             chPayload.setTag("data", cdList);
             chPayload.setInteger("action", 0);

--- a/src/main/java/betterquesting/client/ui_builder/ComponentPanel.java
+++ b/src/main/java/betterquesting/client/ui_builder/ComponentPanel.java
@@ -78,8 +78,14 @@ public class ComponentPanel implements INBTSaveLoad<NBTTagCompound> {
         return ComponentRegistry.INSTANCE.createNew(res, transform, panelData);
     }
 
+    @Deprecated
     @Override
     public NBTTagCompound writeToNBT(NBTTagCompound nbt) {
+        return writeToNBT(nbt, false);
+    }
+
+    @Override
+    public NBTTagCompound writeToNBT(NBTTagCompound nbt, boolean reduce) {
         nbt.setString("ref_name", refName);
         nbt.setString("panel_type", panelType);
 

--- a/src/main/java/betterquesting/client/ui_builder/GuiBuilderMain.java
+++ b/src/main/java/betterquesting/client/ui_builder/GuiBuilderMain.java
@@ -94,7 +94,7 @@ public class GuiBuilderMain extends GuiScreenCanvas implements IVolatileScreen {
             } else if (selectedID >= 0 && !(toolMode == 0 || toolMode == 2)) {
                 ComponentPanel com = COM_DB.getValue(selectedID);
                 // TODO: Add a callback here so the component can read in changes
-                if (com != null) openTrayNBT(com.writeToNBT(new NBTTagCompound()));
+                if (com != null) openTrayNBT(com.writeToNBT(new NBTTagCompound(), false));
             } else if (toolMode == 3) {
                 openTrayPalette();
             }

--- a/src/main/java/betterquesting/commands/admin/QuestCommandDefaults.java
+++ b/src/main/java/betterquesting/commands/admin/QuestCommandDefaults.java
@@ -189,6 +189,8 @@ public class QuestCommandDefaults extends QuestCommandBase {
 
             File questLineFile = new File(questLineDir, buildFileName.apply(questLineNameTranslated, questLineId) + ".json");
             NBTTagCompound questLineTag = questLine.writeToNBT(new NBTTagCompound(), null, true);
+            questLineTag.setInteger("lineID", questLineId);
+            questLineTag.setInteger("order", QuestLineDatabase.INSTANCE.getOrderIndex(entry.getID()));
             JsonHelper.WriteToFile(questLineFile, NBTConverter.NBTtoJSON_Compound(questLineTag, new JsonObject(), true));
         }
         ;
@@ -228,6 +230,7 @@ public class QuestCommandDefaults extends QuestCommandBase {
             }
 
             NBTTagCompound questTag = quest.writeToNBT(new NBTTagCompound(), true);
+            questTag.setInteger("questID", questId);
             JsonHelper.WriteToFile(questFile, NBTConverter.NBTtoJSON_Compound(questTag, new JsonObject(), true));
         }
 
@@ -316,7 +319,11 @@ public class QuestCommandDefaults extends QuestCommandBase {
                     path -> {
                         File questFile = path.toFile();
                         NBTTagCompound questTag = readNbt.apply(questFile);
-                        int questId = Integer.parseInt(questFile.getName().replaceAll("[^0-9]+", ""));
+                        int questId = questTag.hasKey("questID", 99) ? questTag.getInteger("questID") : -1;
+
+                        if (questId < 0) {
+                            questId = Integer.parseInt(questFile.getName().replaceAll("[^0-9]+", ""));
+                        }
 
                         if (questId < 0) {
                             return;

--- a/src/main/java/betterquesting/commands/admin/QuestCommandDefaults.java
+++ b/src/main/java/betterquesting/commands/admin/QuestCommandDefaults.java
@@ -20,12 +20,9 @@ import betterquesting.network.handlers.NetQuestSync;
 import betterquesting.network.handlers.NetSettingSync;
 import betterquesting.questing.QuestDatabase;
 import betterquesting.questing.QuestInstance;
-import betterquesting.questing.QuestLine;
 import betterquesting.questing.QuestLineDatabase;
 import betterquesting.storage.QuestSettings;
-import com.google.common.base.Splitter;
 import com.google.common.collect.ListMultimap;
-import com.google.common.collect.Maps;
 import com.google.common.collect.MultimapBuilder;
 import com.google.gson.JsonObject;
 import net.minecraft.command.CommandBase;
@@ -37,7 +34,6 @@ import net.minecraft.server.MinecraftServer;
 import net.minecraft.util.text.TextComponentTranslation;
 import net.minecraftforge.server.permission.DefaultPermissionLevel;
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.io.FilenameUtils;
 import org.apache.logging.log4j.Level;
 import org.jetbrains.annotations.Nullable;
 
@@ -45,8 +41,9 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.StandardOpenOption;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.stream.Stream;
@@ -168,7 +165,7 @@ public class QuestCommandDefaults extends QuestCommandBase {
         boolean editMode = QuestSettings.INSTANCE.getProperty(NativeProps.EDIT_MODE);
         // Don't write edit mode to json
         QuestSettings.INSTANCE.setProperty(NativeProps.EDIT_MODE, false);
-        NBTTagCompound settingsTag = QuestSettings.INSTANCE.writeToNBT(new NBTTagCompound());
+        NBTTagCompound settingsTag = QuestSettings.INSTANCE.writeToNBT(new NBTTagCompound(), true);
         settingsTag.setString("format", BetterQuesting.FORMAT);
         JsonHelper.WriteToFile(settingsFile, NBTConverter.NBTtoJSON_Compound(settingsTag, new JsonObject(), true));
         // Turn on edit mode if it was on before
@@ -191,7 +188,7 @@ public class QuestCommandDefaults extends QuestCommandBase {
             String questLineNameTranslated = QuestTranslation.translate(questLineName);
 
             File questLineFile = new File(questLineDir, buildFileName.apply(questLineNameTranslated, questLineId) + ".json");
-            NBTTagCompound questLineTag = questLine.writeToNBT(new NBTTagCompound(), null);
+            NBTTagCompound questLineTag = questLine.writeToNBT(new NBTTagCompound(), null, true);
             JsonHelper.WriteToFile(questLineFile, NBTConverter.NBTtoJSON_Compound(questLineTag, new JsonObject(), true));
         }
         ;
@@ -230,7 +227,7 @@ public class QuestCommandDefaults extends QuestCommandBase {
                 return;
             }
 
-            NBTTagCompound questTag = quest.writeToNBT(new NBTTagCompound());
+            NBTTagCompound questTag = quest.writeToNBT(new NBTTagCompound(), true);
             JsonHelper.WriteToFile(questFile, NBTConverter.NBTtoJSON_Compound(questTag, new JsonObject(), true));
         }
 
@@ -247,10 +244,10 @@ public class QuestCommandDefaults extends QuestCommandBase {
         NBTTagCompound base = new NBTTagCompound();
 
         QuestSettings.INSTANCE.setProperty(NativeProps.EDIT_MODE, false);
-        base.setTag("questSettings", QuestSettings.INSTANCE.writeToNBT(new NBTTagCompound()));
+        base.setTag("questSettings", QuestSettings.INSTANCE.writeToNBT(new NBTTagCompound(), true));
         QuestSettings.INSTANCE.setProperty(NativeProps.EDIT_MODE, editMode);
-        base.setTag("questDatabase", QuestDatabase.INSTANCE.writeToNBT(new NBTTagList(), null));
-        base.setTag("questLines", QuestLineDatabase.INSTANCE.writeToNBT(new NBTTagList(), null));
+        base.setTag("questDatabase", QuestDatabase.INSTANCE.writeToNBT(new NBTTagList(), null, true));
+        base.setTag("questLines", QuestLineDatabase.INSTANCE.writeToNBT(new NBTTagList(), null, true));
         base.setString("format", BetterQuesting.FORMAT);
         base.setString("build", ModReference.VERSION);
         JsonHelper.WriteToFile(legacyFile, NBTConverter.NBTtoJSON_Compound(base, new JsonObject(), true));
@@ -274,7 +271,7 @@ public class QuestCommandDefaults extends QuestCommandBase {
         boolean editMode = QuestSettings.INSTANCE.getProperty(NativeProps.EDIT_MODE);
         boolean hardMode = QuestSettings.INSTANCE.getProperty(NativeProps.HARDCORE);
         NBTTagList jsonP = QuestDatabase.INSTANCE.writeProgressToNBT(new NBTTagList(), null);
-        
+
         File settingsFile = new File(dataDir, SETTINGS_FILE);
         if (!settingsFile.exists()) {
             QuestingAPI.getLogger().log(Level.ERROR, "Failed to find file\n{}", settingsFile);

--- a/src/main/java/betterquesting/commands/admin/QuestCommandDefaults.java
+++ b/src/main/java/betterquesting/commands/admin/QuestCommandDefaults.java
@@ -32,6 +32,7 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.util.text.TextComponentTranslation;
+import net.minecraftforge.common.util.Constants;
 import net.minecraftforge.server.permission.DefaultPermissionLevel;
 import org.apache.commons.io.FileUtils;
 import org.apache.logging.log4j.Level;
@@ -319,7 +320,7 @@ public class QuestCommandDefaults extends QuestCommandBase {
                     path -> {
                         File questFile = path.toFile();
                         NBTTagCompound questTag = readNbt.apply(questFile);
-                        int questId = questTag.hasKey("questID", 99) ? questTag.getInteger("questID") : -1;
+                        int questId = questTag.hasKey("questID", Constants.NBT.TAG_ANY_NUMERIC) ? questTag.getInteger("questID") : -1;
 
                         if (questId < 0) {
                             questId = Integer.parseInt(questFile.getName().replaceAll("[^0-9]+", ""));

--- a/src/main/java/betterquesting/commands/admin/QuestCommandDefaults.java
+++ b/src/main/java/betterquesting/commands/admin/QuestCommandDefaults.java
@@ -308,6 +308,7 @@ public class QuestCommandDefaults extends QuestCommandBase {
                 .forEach(questLineDatabase::appendTag);
 
         QuestLineDatabase.INSTANCE.readFromNBT(questLineDatabase, false);
+        QuestDatabase.INSTANCE.reset();
 
         File questDir = new File(dataDir, QUEST_DIR);
         try (Stream<Path> paths = Files.walk(questDir.toPath())) {

--- a/src/main/java/betterquesting/commands/bqs/BQS_Commands.java
+++ b/src/main/java/betterquesting/commands/bqs/BQS_Commands.java
@@ -41,7 +41,7 @@ public class BQS_Commands extends CommandBase {
         if (args[0].equalsIgnoreCase("default")) {
             if (args[1].equalsIgnoreCase("save")) {
                 NBTTagCompound jsonQ = new NBTTagCompound();
-                LootRegistry.INSTANCE.writeToNBT(jsonQ, null);
+                LootRegistry.INSTANCE.writeToNBT(jsonQ, null, true);
                 JsonHelper.WriteToFile(new File(server.getFile("config/betterquesting/"), "DefaultLoot.json"), NBTConverter.NBTtoJSON_Compound(jsonQ, new JsonObject(), true));
                 sender.sendMessage(new TextComponentString("Loot database set as global default"));
             } else if (args[1].equalsIgnoreCase("load")) {

--- a/src/main/java/betterquesting/core/BetterQuesting.java
+++ b/src/main/java/betterquesting/core/BetterQuesting.java
@@ -48,7 +48,7 @@ import org.apache.logging.log4j.Logger;
 @Mod(modid = ModReference.MODID, version = BetterQuesting.VERSION, name = ModReference.NAME, guiFactory = "betterquesting.handlers.ConfigGuiFactory")
 public class BetterQuesting {
     public static final String VERSION = ModReference.VERSION;
-    public static final String FORMAT = "2.0.0";
+    public static final String FORMAT = "2.1.0";
 
     // Used for some legacy compat
     public static final String MODID_STD = "bq_standard";

--- a/src/main/java/betterquesting/handlers/LootSaveLoad.java
+++ b/src/main/java/betterquesting/handlers/LootSaveLoad.java
@@ -41,7 +41,7 @@ public class LootSaveLoad {
     }
 
     public void SaveLoot() {
-        JsonHelper.WriteToFile(new File(worldDir, "QuestLoot.json"), NBTConverter.NBTtoJSON_Compound(LootRegistry.INSTANCE.writeToNBT(new NBTTagCompound(), null), new JsonObject(), true));
+        JsonHelper.WriteToFile(new File(worldDir, "QuestLoot.json"), NBTConverter.NBTtoJSON_Compound(LootRegistry.INSTANCE.writeToNBT(new NBTTagCompound(), null, true), new JsonObject(), true));
     }
 
     public void UnloadLoot() {

--- a/src/main/java/betterquesting/handlers/SaveLoadHandler.java
+++ b/src/main/java/betterquesting/handlers/SaveLoadHandler.java
@@ -310,9 +310,9 @@ public class SaveLoadHandler {
     private Future<Void> saveConfig() {
         NBTTagCompound json = new NBTTagCompound();
 
-        json.setTag("questSettings", QuestSettings.INSTANCE.writeToNBT(new NBTTagCompound()));
-        json.setTag("questDatabase", QuestDatabase.INSTANCE.writeToNBT(new NBTTagList(), null));
-        json.setTag("questLines", QuestLineDatabase.INSTANCE.writeToNBT(new NBTTagList(), null));
+        json.setTag("questSettings", QuestSettings.INSTANCE.writeToNBT(new NBTTagCompound(), true));
+        json.setTag("questDatabase", QuestDatabase.INSTANCE.writeToNBT(new NBTTagList(), null, true));
+        json.setTag("questLines", QuestLineDatabase.INSTANCE.writeToNBT(new NBTTagList(), null, true));
 
         json.setString("format", BetterQuesting.FORMAT);
         json.setString("build", ModReference.VERSION);
@@ -329,7 +329,7 @@ public class SaveLoadHandler {
     private Future<Void> saveParties() {
         NBTTagCompound json = new NBTTagCompound();
 
-        json.setTag("parties", PartyManager.INSTANCE.writeToNBT(new NBTTagList(), null));
+        json.setTag("parties", PartyManager.INSTANCE.writeToNBT(new NBTTagList(), null, true));
 
         return JsonHelper.WriteToFile(fileParties, NBTConverter.NBTtoJSON_Compound(json, new JsonObject(), true));
     }
@@ -337,7 +337,7 @@ public class SaveLoadHandler {
     private Future<Void> saveNames() {
         NBTTagCompound json = new NBTTagCompound();
 
-        json.setTag("nameCache", NameCache.INSTANCE.writeToNBT(new NBTTagList(), null));
+        json.setTag("nameCache", NameCache.INSTANCE.writeToNBT(new NBTTagList(), null, true));
 
         return JsonHelper.WriteToFile(fileNames, NBTConverter.NBTtoJSON_Compound(json, new JsonObject(), true));
     }
@@ -345,7 +345,7 @@ public class SaveLoadHandler {
     private Future<Void> saveLives() {
         NBTTagCompound json = new NBTTagCompound();
 
-        json.setTag("lifeDatabase", LifeDatabase.INSTANCE.writeToNBT(new NBTTagCompound(), null));
+        json.setTag("lifeDatabase", LifeDatabase.INSTANCE.writeToNBT(new NBTTagCompound(), null, true));
 
         return JsonHelper.WriteToFile(fileLives, NBTConverter.NBTtoJSON_Compound(json, new JsonObject(), true));
     }

--- a/src/main/java/betterquesting/importers/hqm/HQMBagImporter.java
+++ b/src/main/java/betterquesting/importers/hqm/HQMBagImporter.java
@@ -117,7 +117,7 @@ public class HQMBagImporter implements IImporter {
 
         for (LootGroup group : hqmLoot) {
             NBTTagCompound jGrp = new NBTTagCompound();
-            group.writeToNBT(jGrp);
+            group.writeToNBT(jGrp, true);
             jAry.appendTag(jGrp);
         }
 

--- a/src/main/java/betterquesting/importers/hqm/converters/tasks/HQMTaskBlockPlace.java
+++ b/src/main/java/betterquesting/importers/hqm/converters/tasks/HQMTaskBlockPlace.java
@@ -22,7 +22,7 @@ public class HQMTaskBlockPlace {
 
             TaskInteractItem task = new TaskInteractItem();
             BigItemStack stack = HQMUtilities.HQMStackT1(JsonHelper.GetObject(jObj, "item"));
-            task.targetItem = new BigItemStack(stack.writeToNBT(new NBTTagCompound()));
+            task.targetItem = new BigItemStack(stack.writeToNBT(new NBTTagCompound(), false));
             task.required = JsonHelper.GetNumber(jObj, "required", 1).intValue();
             tList.add(task);
         }

--- a/src/main/java/betterquesting/items/ItemLootChest.java
+++ b/src/main/java/betterquesting/items/ItemLootChest.java
@@ -202,7 +202,7 @@ public class ItemLootChest extends Item {
         tag = new NBTTagCompound();
         tag.setBoolean("hideLootInfo", true);
         NBTTagList tagList = new NBTTagList();
-        tagList.appendTag(new BigItemStack(Blocks.STONE).writeToNBT(new NBTTagCompound()));
+        tagList.appendTag(new BigItemStack(Blocks.STONE).writeToNBT(new NBTTagCompound(), false));
         ItemStack fixedLootStack = new ItemStack(this, 1, 104);
         tag.setTag("fixedLootList", tagList);
         tag.setString("fixedLootName", "Item Set");

--- a/src/main/java/betterquesting/network/handlers/NetChapterSync.java
+++ b/src/main/java/betterquesting/network/handlers/NetChapterSync.java
@@ -45,7 +45,7 @@ public class NetChapterSync {
                 NBTTagCompound entry = new NBTTagCompound();
                 entry.setInteger("chapterID", chapter.getID());
                 //entry.setInteger("order", QuestLineDatabase.INSTANCE.getOrderIndex(chapter.getID()));
-                entry.setTag("config", chapter.getValue().writeToNBT(new NBTTagCompound(), null));
+                entry.setTag("config", chapter.getValue().writeToNBT(new NBTTagCompound(), null, true));
                 data.appendTag(entry);
             }
 

--- a/src/main/java/betterquesting/network/handlers/NetImport.java
+++ b/src/main/java/betterquesting/network/handlers/NetImport.java
@@ -41,8 +41,8 @@ public class NetImport {
 
     public static void sendImport(@Nonnull IQuestDatabase questDB, @Nonnull IQuestLineDatabase chapterDB) {
         NBTTagCompound payload = new NBTTagCompound();
-        payload.setTag("quests", questDB.writeToNBT(new NBTTagList(), null));
-        payload.setTag("chapters", chapterDB.writeToNBT(new NBTTagList(), null));
+        payload.setTag("quests", questDB.writeToNBT(new NBTTagList(), null, true));
+        payload.setTag("chapters", chapterDB.writeToNBT(new NBTTagList(), null, true));
         PacketSender.INSTANCE.sendToServer(new QuestingPacket(ID_NAME, payload));
     }
 

--- a/src/main/java/betterquesting/network/handlers/NetInviteSync.java
+++ b/src/main/java/betterquesting/network/handlers/NetInviteSync.java
@@ -36,7 +36,7 @@ public class NetInviteSync {
         NBTTagCompound payload = new NBTTagCompound();
         UUID playerID = QuestingAPI.getQuestingUUID(player);
         payload.setInteger("action", 0);
-        payload.setTag("data", PartyInvitations.INSTANCE.writeToNBT(new NBTTagList(), Collections.singletonList(playerID)));
+        payload.setTag("data", PartyInvitations.INSTANCE.writeToNBT(new NBTTagList(), Collections.singletonList(playerID), true));
         PacketSender.INSTANCE.sendToPlayers(new QuestingPacket(ID_NAME, payload), player);
     }
 

--- a/src/main/java/betterquesting/network/handlers/NetLifeSync.java
+++ b/src/main/java/betterquesting/network/handlers/NetLifeSync.java
@@ -27,7 +27,7 @@ public class NetLifeSync {
 
     public static void sendSync(@Nullable EntityPlayerMP[] players, @Nullable UUID[] playerIDs) {
         NBTTagCompound payload = new NBTTagCompound();
-        payload.setTag("data", LifeDatabase.INSTANCE.writeToNBT(new NBTTagCompound(), playerIDs == null ? null : Arrays.asList(playerIDs)));
+        payload.setTag("data", LifeDatabase.INSTANCE.writeToNBT(new NBTTagCompound(), playerIDs == null ? null : Arrays.asList(playerIDs), true));
         payload.setBoolean("merge", playerIDs != null);
 
         if (players != null) {

--- a/src/main/java/betterquesting/network/handlers/NetLootClaim.java
+++ b/src/main/java/betterquesting/network/handlers/NetLootClaim.java
@@ -31,7 +31,7 @@ public class NetLootClaim {
         NBTTagCompound payload = new NBTTagCompound();
         NBTTagList list = new NBTTagList();
         for (BigItemStack stack : items) {
-            list.appendTag(stack.writeToNBT(new NBTTagCompound()));
+            list.appendTag(stack.writeToNBT(new NBTTagCompound(), true));
         }
         payload.setTag("rewards", list);
         payload.setString("title", title);

--- a/src/main/java/betterquesting/network/handlers/NetLootSync.java
+++ b/src/main/java/betterquesting/network/handlers/NetLootSync.java
@@ -37,7 +37,7 @@ public class NetLootSync {
 
     public static void sendSync(@Nullable EntityPlayerMP player) {
         NBTTagCompound payload = new NBTTagCompound();
-        payload.setTag("data", LootRegistry.INSTANCE.writeToNBT(new NBTTagCompound(), null));
+        payload.setTag("data", LootRegistry.INSTANCE.writeToNBT(new NBTTagCompound(), null, true));
 
         if (player == null) {
             QuestingAPI.getAPI(ApiReference.PACKET_SENDER).sendToAll(new QuestingPacket(ID_NAME, payload));

--- a/src/main/java/betterquesting/network/handlers/NetNameSync.java
+++ b/src/main/java/betterquesting/network/handlers/NetNameSync.java
@@ -68,7 +68,7 @@ public class NetNameSync {
         if (party == null) return;
 
         NBTTagCompound payload = new NBTTagCompound();
-        payload.setTag("data", NameCache.INSTANCE.writeToNBT(new NBTTagList(), party.getMembers()));
+        payload.setTag("data", NameCache.INSTANCE.writeToNBT(new NBTTagList(), party.getMembers(), true));
         payload.setBoolean("merge", true);
 
         if (player != null) {
@@ -96,7 +96,7 @@ public class NetNameSync {
         }
 
         NBTTagCompound payload = new NBTTagCompound();
-        payload.setTag("data", NameCache.INSTANCE.writeToNBT(new NBTTagList(), idList));
+        payload.setTag("data", NameCache.INSTANCE.writeToNBT(new NBTTagList(), idList, true));
         payload.setBoolean("merge", idList != null);
 
         if (players == null) {

--- a/src/main/java/betterquesting/network/handlers/NetQuestSync.java
+++ b/src/main/java/betterquesting/network/handlers/NetQuestSync.java
@@ -75,7 +75,7 @@ public class NetQuestSync {
             for (DBEntry<IQuest> entry : questSubset) {
                 NBTTagCompound tag = new NBTTagCompound();
 
-                if (config) tag.setTag("config", entry.getValue().writeToNBT(new NBTTagCompound()));
+                if (config) tag.setTag("config", entry.getValue().writeToNBT(new NBTTagCompound(), true));
                 if (progress)
                     tag.setTag("progress", entry.getValue().writeProgressToNBT(new NBTTagCompound(), pidList));
                 if (resetIDs != null) tag.setIntArray("resets", resetIDs);

--- a/src/main/java/betterquesting/network/handlers/NetScoreSync.java
+++ b/src/main/java/betterquesting/network/handlers/NetScoreSync.java
@@ -24,7 +24,7 @@ public class NetScoreSync {
 
     public static void sendScore(@Nullable EntityPlayerMP player) {
         NBTTagCompound payload = new NBTTagCompound();
-        payload.setTag("data", ScoreboardBQ.INSTANCE.writeToNBT(new NBTTagList(), player == null ? null : Collections.singletonList(QuestingAPI.getQuestingUUID(player))));
+        payload.setTag("data", ScoreboardBQ.INSTANCE.writeToNBT(new NBTTagList(), player == null ? null : Collections.singletonList(QuestingAPI.getQuestingUUID(player)), true));
         payload.setBoolean("merge", player != null);
 
         if (player == null) {

--- a/src/main/java/betterquesting/network/handlers/NetSettingSync.java
+++ b/src/main/java/betterquesting/network/handlers/NetSettingSync.java
@@ -34,13 +34,13 @@ public class NetSettingSync {
     @SideOnly(Side.CLIENT)
     public static void requestEdit() {
         NBTTagCompound payload = new NBTTagCompound();
-        payload.setTag("data", QuestSettings.INSTANCE.writeToNBT(new NBTTagCompound()));
+        payload.setTag("data", QuestSettings.INSTANCE.writeToNBT(new NBTTagCompound(), true));
         PacketSender.INSTANCE.sendToServer(new QuestingPacket(ID_NAME, payload));
     }
 
     public static void sendSync(@Nullable EntityPlayerMP player) {
         NBTTagCompound payload = new NBTTagCompound();
-        payload.setTag("data", QuestSettings.INSTANCE.writeToNBT(new NBTTagCompound()));
+        payload.setTag("data", QuestSettings.INSTANCE.writeToNBT(new NBTTagCompound(), true));
         if (player != null) {
             PacketSender.INSTANCE.sendToPlayers(new QuestingPacket(ID_NAME, payload), player);
         } else {

--- a/src/main/java/betterquesting/questing/QuestDatabase.java
+++ b/src/main/java/betterquesting/questing/QuestDatabase.java
@@ -54,17 +54,23 @@ public final class QuestDatabase extends RandomIndexDatabase<IQuest> implements 
         if (hasRemoved) quest.setRequirements(rem);
     }
 
+    @Deprecated
     @Override
-    public synchronized NBTTagList writeToNBT(NBTTagList json, @Nullable List<Integer> subset) {
+    public synchronized NBTTagList writeToNBT(NBTTagList nbt, @Nullable List<Integer> subset) {
+        return writeToNBT(nbt, subset, false);
+    }
+
+    @Override
+    public synchronized NBTTagList writeToNBT(NBTTagList nbt, @Nullable List<Integer> subset, boolean reduce) {
         for (DBEntry<IQuest> entry : this.getEntries()) {
             if (subset != null && !subset.contains(entry.getID())) continue;
-            NBTTagCompound jq = entry.getValue().writeToNBT(new NBTTagCompound());
+            NBTTagCompound jq = entry.getValue().writeToNBT(new NBTTagCompound(), reduce);
             if (subset != null && jq.isEmpty()) continue;
             jq.setInteger("questID", entry.getID());
-            json.appendTag(jq);
+            nbt.appendTag(jq);
         }
 
-        return json;
+        return nbt;
     }
 
     @Override

--- a/src/main/java/betterquesting/questing/QuestInstance.java
+++ b/src/main/java/betterquesting/questing/QuestInstance.java
@@ -1,5 +1,6 @@
 package betterquesting.questing;
 
+import betterquesting.NBTUtil;
 import betterquesting.api.api.QuestingAPI;
 import betterquesting.api.enums.EnumFrameType;
 import betterquesting.api.enums.EnumLogic;
@@ -406,21 +407,29 @@ public class QuestInstance implements IQuest {
             prereqTypes.put(req, kind);
     }
 
+    @Deprecated
     @Override
-    public NBTTagCompound writeToNBT(NBTTagCompound jObj) {
-        jObj.setTag("properties", qInfo.writeToNBT(new NBTTagCompound()));
-        jObj.setTag("tasks", tasks.writeToNBT(new NBTTagList(), null));
-        jObj.setTag("rewards", rewards.writeToNBT(new NBTTagList(), null));
-        jObj.setTag("preRequisites", new NBTTagIntArray(getRequirements()));
+    public NBTTagCompound writeToNBT(NBTTagCompound nbt) {
+        return writeToNBT(nbt, false);
+    }
+
+    @Override
+    public NBTTagCompound writeToNBT(NBTTagCompound nbt, boolean reduce) {
+        NBTTagCompound nbtProperties = qInfo.writeToNBT(new NBTTagCompound(), reduce);
+        NBTUtil.setTag(nbt, "properties", nbtProperties, reduce);
+        nbt.setTag("tasks", tasks.writeToNBT(new NBTTagList(), null, reduce));
+        NBTTagList nbtRewards = rewards.writeToNBT(new NBTTagList(), null, reduce);
+        NBTUtil.setTag(nbt, "rewards", nbtRewards, reduce);
+        if (!reduce || getRequirements().length > 0) nbt.setTag("preRequisites", new NBTTagIntArray(getRequirements()));
         if (!prereqTypes.isEmpty()) {
             byte[] types = new byte[preRequisites.length];
             int[] req = this.preRequisites;
             for (int i = 0, requirementsLength = req.length; i < requirementsLength; i++)
                 types[i] = getRequirementType(req[i]).id();
-            jObj.setTag("preRequisiteTypes", new NBTTagByteArray(types));
+            nbt.setTag("preRequisiteTypes", new NBTTagByteArray(types));
         }
 
-        return jObj;
+        return nbt;
     }
 
     @Override

--- a/src/main/java/betterquesting/questing/QuestLine.java
+++ b/src/main/java/betterquesting/questing/QuestLine.java
@@ -86,9 +86,15 @@ public class QuestLine extends SimpleDatabase<IQuestLineEntry> implements IQuest
         return null;
     }
 
+    @Deprecated
     @Override
-    public NBTTagCompound writeToNBT(NBTTagCompound json, @Nullable List<Integer> subset) {
-        json.setTag("properties", info.writeToNBT(new NBTTagCompound()));
+    public NBTTagCompound writeToNBT(NBTTagCompound nbt, @Nullable List<Integer> subset) {
+        return writeToNBT(nbt, subset, false);
+    }
+
+    @Override
+    public NBTTagCompound writeToNBT(NBTTagCompound nbt, @Nullable List<Integer> subset, boolean reduce) {
+        nbt.setTag("properties", info.writeToNBT(new NBTTagCompound(), reduce));
 
         NBTTagList jArr = new NBTTagList();
 
@@ -99,8 +105,8 @@ public class QuestLine extends SimpleDatabase<IQuestLineEntry> implements IQuest
             jArr.appendTag(qle);
         }
 
-        json.setTag("quests", jArr);
-        return json;
+        nbt.setTag("quests", jArr);
+        return nbt;
     }
 
     @Override

--- a/src/main/java/betterquesting/questing/QuestLineDatabase.java
+++ b/src/main/java/betterquesting/questing/QuestLineDatabase.java
@@ -58,17 +58,23 @@ public final class QuestLineDatabase extends SimpleDatabase<IQuestLine> implemen
         }
     }
 
+    @Deprecated
     @Override
-    public synchronized NBTTagList writeToNBT(NBTTagList json, @Nullable List<Integer> subset) {
+    public synchronized NBTTagList writeToNBT(NBTTagList nbt, @Nullable List<Integer> subset) {
+        return writeToNBT(nbt, subset, false);
+    }
+
+    @Override
+    public synchronized NBTTagList writeToNBT(NBTTagList nbt, @Nullable List<Integer> subset, boolean reduce) {
         for (DBEntry<IQuestLine> entry : getEntries()) {
             if (subset != null && !subset.contains(entry.getID())) continue;
-            NBTTagCompound jObj = entry.getValue().writeToNBT(new NBTTagCompound(), null);
+            NBTTagCompound jObj = entry.getValue().writeToNBT(new NBTTagCompound(), null, reduce);
             jObj.setInteger("lineID", entry.getID());
             jObj.setInteger("order", getOrderIndex(entry.getID()));
-            json.appendTag(jObj);
+            nbt.appendTag(jObj);
         }
 
-        return json;
+        return nbt;
     }
 
     @Override

--- a/src/main/java/betterquesting/questing/QuestLineEntry.java
+++ b/src/main/java/betterquesting/questing/QuestLineEntry.java
@@ -78,12 +78,12 @@ public class QuestLineEntry implements IQuestLineEntry {
     }
 
     @Override
-    public NBTTagCompound writeToNBT(NBTTagCompound json) {
-        json.setInteger("sizeX", sizeX);
-        json.setInteger("sizeY", sizeY);
-        json.setInteger("x", posX);
-        json.setInteger("y", posY);
-        return json;
+    public NBTTagCompound writeToNBT(NBTTagCompound nbt) {
+        nbt.setInteger("sizeX", sizeX);
+        nbt.setInteger("sizeY", sizeY);
+        nbt.setInteger("x", posX);
+        nbt.setInteger("y", posY);
+        return nbt;
     }
 
     @Override

--- a/src/main/java/betterquesting/questing/party/PartyInstance.java
+++ b/src/main/java/betterquesting/questing/party/PartyInstance.java
@@ -137,7 +137,7 @@ public class PartyInstance implements IParty {
     }
 
     @Override
-    public NBTTagCompound writeToNBT(NBTTagCompound json) {
+    public NBTTagCompound writeToNBT(NBTTagCompound nbt) {
         NBTTagList memJson = new NBTTagList();
         for (Entry<UUID, EnumPartyStatus> mem : members.entrySet()) {
             NBTTagCompound jm = new NBTTagCompound();
@@ -145,11 +145,11 @@ public class PartyInstance implements IParty {
             jm.setString("status", mem.getValue().toString());
             memJson.appendTag(jm);
         }
-        json.setTag("members", memJson);
+        nbt.setTag("members", memJson);
 
-        json.setTag("properties", pInfo.writeToNBT(new NBTTagCompound()));
+        nbt.setTag("properties", pInfo.writeToNBT(new NBTTagCompound(), false));
 
-        return json;
+        return nbt;
     }
 
     @Override
@@ -181,7 +181,7 @@ public class PartyInstance implements IParty {
 
     @Override
     public NBTTagCompound writeProperties(NBTTagCompound nbt) {
-        return pInfo.writeToNBT(nbt);
+        return pInfo.writeToNBT(nbt, true);
     }
 
     @Override

--- a/src/main/java/betterquesting/questing/party/PartyInvitations.java
+++ b/src/main/java/betterquesting/questing/party/PartyInvitations.java
@@ -102,8 +102,14 @@ public class PartyInvitations implements INBTPartial<NBTTagList, UUID> {
         invites.clear();
     }
 
+    @Deprecated
     @Override
-    public synchronized NBTTagList writeToNBT(NBTTagList nbt, @Nullable List<UUID> subset) // Don't bother saving this to disk. We do need to send packets though
+    public synchronized NBTTagList writeToNBT(NBTTagList nbt, @Nullable List<UUID> subset) {
+        return writeToNBT(nbt, subset, false);
+    }
+
+    @Override
+    public synchronized NBTTagList writeToNBT(NBTTagList nbt, @Nullable List<UUID> subset, boolean reduce) // Don't bother saving this to disk. We do need to send packets though
     {
         if (subset != null) {
             subset.forEach((uuid) -> {

--- a/src/main/java/betterquesting/questing/party/PartyManager.java
+++ b/src/main/java/betterquesting/questing/party/PartyManager.java
@@ -61,15 +61,15 @@ public class PartyManager extends SimpleDatabase<IParty> implements IPartyDataba
     }
 
     @Override
-    public synchronized NBTTagList writeToNBT(NBTTagList json, List<Integer> subset) {
+    public synchronized NBTTagList writeToNBT(NBTTagList nbt, List<Integer> subset) {
         for (DBEntry<IParty> entry : getEntries()) {
             if (subset != null && !subset.contains(entry.getID())) continue;
             NBTTagCompound jp = entry.getValue().writeToNBT(new NBTTagCompound());
             jp.setInteger("partyID", entry.getID());
-            json.appendTag(jp);
+            nbt.appendTag(jp);
         }
 
-        return json;
+        return nbt;
     }
 
     @Override

--- a/src/main/java/betterquesting/questing/rewards/RewardChoice.java
+++ b/src/main/java/betterquesting/questing/rewards/RewardChoice.java
@@ -1,6 +1,6 @@
 package betterquesting.questing.rewards;
 
-import betterquesting.NBTReplaceUtil;
+import betterquesting.NBTUtil;
 import betterquesting.api.api.QuestingAPI;
 import betterquesting.api.questing.IQuest;
 import betterquesting.api.questing.rewards.IReward;
@@ -92,8 +92,8 @@ public class RewardChoice implements IReward {
 
         for (ItemStack s : stack.getCombinedStacks()) {
             if (s.getTagCompound() != null) {
-                s.setTagCompound(NBTReplaceUtil.replaceStrings(s.getTagCompound(), "VAR_NAME", player.getName()));
-                s.setTagCompound(NBTReplaceUtil.replaceStrings(s.getTagCompound(), "VAR_UUID", QuestingAPI.getQuestingUUID(player).toString()));
+                s.setTagCompound(NBTUtil.replaceStrings(s.getTagCompound(), "VAR_NAME", player.getName()));
+                s.setTagCompound(NBTUtil.replaceStrings(s.getTagCompound(), "VAR_UUID", QuestingAPI.getQuestingUUID(player).toString()));
             }
 
             if (!player.inventory.addItemStackToInventory(s)) {

--- a/src/main/java/betterquesting/questing/rewards/RewardChoice.java
+++ b/src/main/java/betterquesting/questing/rewards/RewardChoice.java
@@ -111,11 +111,17 @@ public class RewardChoice implements IReward {
         }
     }
 
+    @Deprecated
     @Override
     public NBTTagCompound writeToNBT(NBTTagCompound nbt) {
+        return writeToNBT(nbt, false);
+    }
+
+    @Override
+    public NBTTagCompound writeToNBT(NBTTagCompound nbt, boolean reduce) {
         NBTTagList rJson = new NBTTagList();
         for (BigItemStack stack : choices) {
-            rJson.appendTag(JsonHelper.ItemStackToJson(stack, new NBTTagCompound()));
+            rJson.appendTag(JsonHelper.ItemStackToJson(stack, new NBTTagCompound(), reduce));
         }
         nbt.setTag("choices", rJson);
         return nbt;

--- a/src/main/java/betterquesting/questing/rewards/RewardCommand.java
+++ b/src/main/java/betterquesting/questing/rewards/RewardCommand.java
@@ -1,6 +1,7 @@
 package betterquesting.questing.rewards;
 
 import betterquesting.AdminExecute;
+import betterquesting.NBTUtil;
 import betterquesting.api.api.QuestingAPI;
 import betterquesting.api.questing.IQuest;
 import betterquesting.api.questing.rewards.IReward;
@@ -28,12 +29,18 @@ import java.util.Arrays;
 import java.util.UUID;
 
 public class RewardCommand implements IReward {
+
+    private static final String DEFAULT_TITLE = "bq_standard.reward.command";
+    private static final String DEFAULT_DESC = "Run a command script";
+    private static final boolean DEFAULT_VIA_PLAYER = false;
+    private static final boolean DEFAULT_HIDE_ICON = true;
+    private static final boolean DEFAULT_AS_SCRIPT = true;
     public String command = "#Script Comment\nsay Running reward script...\nsay @s Claimed a reward";
-    public String title = "bq_standard.reward.command";
-    public String desc = "Run a command script";
-    public boolean viaPlayer = false;
-    public boolean hideIcon = true;
-    public boolean asScript = true;
+    public String title = DEFAULT_TITLE;
+    public String desc = DEFAULT_DESC;
+    public boolean viaPlayer = DEFAULT_VIA_PLAYER;
+    public boolean hideIcon = DEFAULT_HIDE_ICON;
+    public boolean asScript = DEFAULT_AS_SCRIPT;
 
     @Override
     public ResourceLocation getFactoryID() {
@@ -81,21 +88,27 @@ public class RewardCommand implements IReward {
     @Override
     public void readFromNBT(NBTTagCompound nbt) {
         command = nbt.getString("command");
-        title = nbt.hasKey("title", 8) ? nbt.getString("title") : "bq_standard.reward.command";
-        desc = nbt.hasKey("description", 8) ? nbt.getString("description") : "Run a command script";
-        viaPlayer = nbt.getBoolean("viaPlayer");
-        hideIcon = !nbt.hasKey("hideBlockIcon", 1) || nbt.getBoolean("hideBlockIcon");
-        asScript = !nbt.hasKey("asScript", 1) || nbt.getBoolean("asScript");
+        title = NBTUtil.getString(nbt, "title", DEFAULT_TITLE);
+        desc = NBTUtil.getString(nbt, "description", DEFAULT_DESC);
+        viaPlayer = NBTUtil.getBoolean(nbt, "viaPlayer", DEFAULT_VIA_PLAYER);
+        hideIcon = NBTUtil.getBoolean(nbt, "hideBlockIcon", DEFAULT_HIDE_ICON);
+        asScript = NBTUtil.getBoolean(nbt, "asScript", DEFAULT_AS_SCRIPT);
+    }
+
+    @Deprecated
+    @Override
+    public NBTTagCompound writeToNBT(NBTTagCompound nbt) {
+        return writeToNBT(nbt, false);
     }
 
     @Override
-    public NBTTagCompound writeToNBT(NBTTagCompound nbt) {
+    public NBTTagCompound writeToNBT(NBTTagCompound nbt, boolean reduce) {
         nbt.setString("command", command);
-        nbt.setString("title", title);
-        nbt.setString("description", desc);
-        nbt.setBoolean("viaPlayer", viaPlayer);
-        nbt.setBoolean("hideBlockIcon", hideIcon);
-        nbt.setBoolean("asScript", asScript);
+        NBTUtil.setString(nbt, "title", title, DEFAULT_TITLE, reduce);
+        NBTUtil.setString(nbt, "description", desc, DEFAULT_TITLE, reduce);
+        NBTUtil.setBoolean(nbt, "viaPlayer", viaPlayer, DEFAULT_VIA_PLAYER, reduce);
+        NBTUtil.setBoolean(nbt, "hideBlockIcon", hideIcon, DEFAULT_HIDE_ICON, reduce);
+        NBTUtil.setBoolean(nbt, "asScript", asScript, DEFAULT_AS_SCRIPT, reduce);
         return nbt;
     }
 

--- a/src/main/java/betterquesting/questing/rewards/RewardItem.java
+++ b/src/main/java/betterquesting/questing/rewards/RewardItem.java
@@ -1,6 +1,6 @@
 package betterquesting.questing.rewards;
 
-import betterquesting.NBTReplaceUtil;
+import betterquesting.NBTUtil;
 import betterquesting.api.api.QuestingAPI;
 import betterquesting.api.questing.IQuest;
 import betterquesting.api.questing.rewards.IReward;
@@ -48,8 +48,8 @@ public class RewardItem implements IReward {
 
             for (ItemStack s : stack.getCombinedStacks()) {
                 if (s.getTagCompound() != null) {
-                    s.setTagCompound(NBTReplaceUtil.replaceStrings(s.getTagCompound(), "VAR_NAME", player.getName()));
-                    s.setTagCompound(NBTReplaceUtil.replaceStrings(s.getTagCompound(), "VAR_UUID", QuestingAPI.getQuestingUUID(player).toString()));
+                    s.setTagCompound(NBTUtil.replaceStrings(s.getTagCompound(), "VAR_NAME", player.getName()));
+                    s.setTagCompound(NBTUtil.replaceStrings(s.getTagCompound(), "VAR_UUID", QuestingAPI.getQuestingUUID(player).toString()));
                 }
 
                 if (!player.inventory.addItemStackToInventory(s)) {

--- a/src/main/java/betterquesting/questing/rewards/RewardItem.java
+++ b/src/main/java/betterquesting/questing/rewards/RewardItem.java
@@ -73,11 +73,17 @@ public class RewardItem implements IReward {
         }
     }
 
+    @Deprecated
     @Override
     public NBTTagCompound writeToNBT(NBTTagCompound nbt) {
+        return writeToNBT(nbt, false);
+    }
+
+    @Override
+    public NBTTagCompound writeToNBT(NBTTagCompound nbt, boolean reduce) {
         NBTTagList rJson = new NBTTagList();
         for (BigItemStack stack : items) {
-            rJson.appendTag(JsonHelper.ItemStackToJson(stack, new NBTTagCompound()));
+            rJson.appendTag(JsonHelper.ItemStackToJson(stack, new NBTTagCompound(), reduce));
         }
         nbt.setTag("rewards", rJson);
         return nbt;

--- a/src/main/java/betterquesting/questing/rewards/RewardRecipe.java
+++ b/src/main/java/betterquesting/questing/rewards/RewardRecipe.java
@@ -58,8 +58,14 @@ public class RewardRecipe implements IReward {
         return null;
     }
 
+    @Deprecated
     @Override
     public NBTTagCompound writeToNBT(NBTTagCompound nbt) {
+        return writeToNBT(nbt, false);
+    }
+
+    @Override
+    public NBTTagCompound writeToNBT(NBTTagCompound nbt, boolean reduce) {
         nbt.setString("recipes", recipeNames);
         return nbt;
     }

--- a/src/main/java/betterquesting/questing/rewards/RewardScoreboard.java
+++ b/src/main/java/betterquesting/questing/rewards/RewardScoreboard.java
@@ -1,5 +1,6 @@
 package betterquesting.questing.rewards;
 
+import betterquesting.NBTUtil;
 import betterquesting.api.questing.IQuest;
 import betterquesting.api.questing.rewards.IReward;
 import betterquesting.api2.client.gui.misc.IGuiRect;
@@ -18,9 +19,12 @@ import net.minecraftforge.fml.relauncher.SideOnly;
 import org.apache.logging.log4j.Level;
 
 public class RewardScoreboard implements IReward {
+
+    private static final String DEFAULT_TYPE = "dummy";
+    private static final boolean DEFAULT_RELATIVE = true;
     public String score = "Reputation";
-    public String type = "dummy";
-    public boolean relative = true;
+    public String type = DEFAULT_TYPE;
+    public boolean relative = DEFAULT_RELATIVE;
     public int value = 1;
 
     @Override
@@ -69,20 +73,26 @@ public class RewardScoreboard implements IReward {
     }
 
     @Override
-    public void readFromNBT(NBTTagCompound json) {
-        score = json.getString("score");
-        type = json.getString("type");
-        value = json.getInteger("value");
-        relative = json.getBoolean("relative");
+    public void readFromNBT(NBTTagCompound nbt) {
+        score = nbt.getString("score");
+        type = NBTUtil.getString(nbt, "type", DEFAULT_TYPE);
+        value = nbt.getInteger("value");
+        relative = NBTUtil.getBoolean(nbt, "relative", DEFAULT_RELATIVE);
+    }
+
+    @Deprecated
+    @Override
+    public NBTTagCompound writeToNBT(NBTTagCompound nbt) {
+        return writeToNBT(nbt, false);
     }
 
     @Override
-    public NBTTagCompound writeToNBT(NBTTagCompound json) {
-        json.setString("score", score);
-        json.setString("type", "dummy");
-        json.setInteger("value", value);
-        json.setBoolean("relative", relative);
-        return json;
+    public NBTTagCompound writeToNBT(NBTTagCompound nbt, boolean reduce) {
+        nbt.setString("score", score);
+        NBTUtil.setString(nbt, "type", type, DEFAULT_TYPE, reduce);
+        nbt.setInteger("value", value);
+        NBTUtil.setBoolean(nbt, "relative", relative, DEFAULT_RELATIVE, reduce);
+        return nbt;
     }
 
     @Override

--- a/src/main/java/betterquesting/questing/rewards/RewardStorage.java
+++ b/src/main/java/betterquesting/questing/rewards/RewardStorage.java
@@ -15,18 +15,24 @@ import java.util.List;
 import java.util.UUID;
 
 public class RewardStorage extends SimpleDatabase<IReward> implements IDatabaseNBT<IReward, NBTTagList, NBTTagList> {
+    @Deprecated
     @Override
-    public NBTTagList writeToNBT(NBTTagList json, @Nullable List<Integer> subset) {
+    public NBTTagList writeToNBT(NBTTagList nbt, @Nullable List<Integer> subset) {
+        return writeToNBT(nbt, subset, false);
+    }
+
+    @Override
+    public NBTTagList writeToNBT(NBTTagList nbt, @Nullable List<Integer> subset, boolean reduce) {
         for (DBEntry<IReward> rew : getEntries()) {
             if (subset != null && !subset.contains(rew.getID())) continue;
             ResourceLocation rewardID = rew.getValue().getFactoryID();
-            NBTTagCompound rJson = rew.getValue().writeToNBT(new NBTTagCompound());
+            NBTTagCompound rJson = rew.getValue().writeToNBT(new NBTTagCompound(), reduce);
             rJson.setString("rewardID", rewardID.toString());
             rJson.setInteger("index", rew.getID());
-            json.appendTag(rJson);
+            nbt.appendTag(rJson);
         }
 
-        return json;
+        return nbt;
     }
 
     @Override

--- a/src/main/java/betterquesting/questing/rewards/RewardXP.java
+++ b/src/main/java/betterquesting/questing/rewards/RewardXP.java
@@ -1,5 +1,6 @@
 package betterquesting.questing.rewards;
 
+import betterquesting.NBTUtil;
 import betterquesting.XPHelper;
 import betterquesting.api.questing.IQuest;
 import betterquesting.api.questing.rewards.IReward;
@@ -16,8 +17,10 @@ import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
 public class RewardXP implements IReward {
-    public int amount = 1;
-    public boolean levels = true;
+    private static final int DEFAULT_AMOUNT = 1;
+    private static final boolean DEFAULT_LEVELS = true;
+    public int amount = DEFAULT_AMOUNT;
+    public boolean levels = DEFAULT_LEVELS;
 
     @Override
     public ResourceLocation getFactoryID() {
@@ -41,14 +44,20 @@ public class RewardXP implements IReward {
 
     @Override
     public void readFromNBT(NBTTagCompound nbt) {
-        amount = nbt.getInteger("amount");
-        levels = nbt.getBoolean("isLevels");
+        amount = NBTUtil.getInteger(nbt, "amount", DEFAULT_AMOUNT);
+        levels = NBTUtil.getBoolean(nbt, "isLevels", DEFAULT_LEVELS);
+    }
+
+    @Deprecated
+    @Override
+    public NBTTagCompound writeToNBT(NBTTagCompound nbt) {
+        return writeToNBT(nbt, false);
     }
 
     @Override
-    public NBTTagCompound writeToNBT(NBTTagCompound nbt) {
-        nbt.setInteger("amount", amount);
-        nbt.setBoolean("isLevels", levels);
+    public NBTTagCompound writeToNBT(NBTTagCompound nbt, boolean reduce) {
+        NBTUtil.setInteger(nbt, "amount", amount, DEFAULT_AMOUNT, reduce);
+        NBTUtil.setBoolean(nbt, "isLevels", levels, DEFAULT_LEVELS, reduce);
         return nbt;
     }
 

--- a/src/main/java/betterquesting/questing/rewards/loot/LootGroup.java
+++ b/src/main/java/betterquesting/questing/rewards/loot/LootGroup.java
@@ -72,22 +72,28 @@ public class LootGroup extends SimpleDatabase<LootGroup.LootEntry> implements IN
         }
     }
 
+    @Deprecated
     @Override
-    public NBTTagCompound writeToNBT(NBTTagCompound tag) {
-        tag.setString("name", name);
-        tag.setInteger("weight", weight);
+    public NBTTagCompound writeToNBT(NBTTagCompound nbt) {
+        return writeToNBT(nbt, false);
+    }
+
+    @Override
+    public NBTTagCompound writeToNBT(NBTTagCompound nbt, boolean reduce) {
+        nbt.setString("name", name);
+        nbt.setInteger("weight", weight);
 
         NBTTagList jRew = new NBTTagList();
         for (DBEntry<LootEntry> entry : getEntries()) {
             if (entry == null) continue;
 
-            NBTTagCompound jLoot = entry.getValue().writeToNBT(new NBTTagCompound());
+            NBTTagCompound jLoot = entry.getValue().writeToNBT(new NBTTagCompound(), reduce);
             jLoot.setInteger("ID", entry.getID());
             jRew.appendTag(jLoot);
         }
-        tag.setTag("rewards", jRew);
+        nbt.setTag("rewards", jRew);
 
-        return tag;
+        return nbt;
     }
 
     public static class LootEntry implements INBTSaveLoad<NBTTagCompound> {
@@ -106,13 +112,19 @@ public class LootGroup extends SimpleDatabase<LootGroup.LootEntry> implements IN
             }
         }
 
+        @Deprecated
         @Override
-        public NBTTagCompound writeToNBT(NBTTagCompound tag) {
+        public NBTTagCompound writeToNBT(NBTTagCompound nbt) {
+            return writeToNBT(nbt, false);
+        }
+
+        @Override
+        public NBTTagCompound writeToNBT(NBTTagCompound tag, boolean reduce) {
             tag.setInteger("weight", weight);
 
             NBTTagList jItm = new NBTTagList();
             for (BigItemStack stack : items) {
-                jItm.appendTag(JsonHelper.ItemStackToJson(stack, new NBTTagCompound()));
+                jItm.appendTag(JsonHelper.ItemStackToJson(stack, new NBTTagCompound(), reduce));
             }
             tag.setTag("items", jItm);
 

--- a/src/main/java/betterquesting/questing/rewards/loot/LootRegistry.java
+++ b/src/main/java/betterquesting/questing/rewards/loot/LootRegistry.java
@@ -62,18 +62,24 @@ public class LootRegistry extends SimpleDatabase<LootGroup> implements INBTParti
         return null;
     }
 
+    @Deprecated
     @Override
-    public synchronized NBTTagCompound writeToNBT(NBTTagCompound tag, @Nullable List<Integer> subset) {
+    public synchronized NBTTagCompound writeToNBT(NBTTagCompound nbt, @Nullable List<Integer> subset) {
+        return writeToNBT(nbt, subset, false);
+    }
+
+    @Override
+    public synchronized NBTTagCompound writeToNBT(NBTTagCompound nbt, @Nullable List<Integer> subset, boolean reduce) {
         NBTTagList jRew = new NBTTagList();
         for (DBEntry<LootGroup> entry : getEntries()) {
             if (subset != null && !subset.contains(entry.getID())) continue;
-            NBTTagCompound jGrp = entry.getValue().writeToNBT(new NBTTagCompound());
+            NBTTagCompound jGrp = entry.getValue().writeToNBT(new NBTTagCompound(), reduce);
             jGrp.setInteger("ID", entry.getID());
             jRew.appendTag(jGrp);
         }
-        tag.setTag("groups", jRew);
+        nbt.setTag("groups", jRew);
 
-        return tag;
+        return nbt;
     }
 
     @Override

--- a/src/main/java/betterquesting/questing/tasks/TaskAdvancement.java
+++ b/src/main/java/betterquesting/questing/tasks/TaskAdvancement.java
@@ -116,8 +116,14 @@ public class TaskAdvancement implements ITask {
         }
     }
 
+    @Deprecated
     @Override
     public NBTTagCompound writeToNBT(NBTTagCompound nbt) {
+        return writeToNBT(nbt, false);
+    }
+
+    @Override
+    public NBTTagCompound writeToNBT(NBTTagCompound nbt, boolean reduce) {
         nbt.setString("advancement_id", advID == null ? "" : advID.toString());
         return nbt;
     }

--- a/src/main/java/betterquesting/questing/tasks/TaskBlockBreak.java
+++ b/src/main/java/betterquesting/questing/tasks/TaskBlockBreak.java
@@ -108,11 +108,17 @@ public class TaskBlockBreak implements ITask {
         }
     }
 
+    @Deprecated
     @Override
     public NBTTagCompound writeToNBT(NBTTagCompound nbt) {
+        return writeToNBT(nbt, false);
+    }
+
+    @Override
+    public NBTTagCompound writeToNBT(NBTTagCompound nbt, boolean reduce) {
         NBTTagList bAry = new NBTTagList();
         for (NbtBlockType block : blockTypes) {
-            bAry.appendTag(block.writeToNBT(new NBTTagCompound()));
+            bAry.appendTag(block.writeToNBT(new NBTTagCompound(), reduce));
         }
         nbt.setTag("blocks", bAry);
 

--- a/src/main/java/betterquesting/questing/tasks/TaskCheckbox.java
+++ b/src/main/java/betterquesting/questing/tasks/TaskCheckbox.java
@@ -56,8 +56,14 @@ public class TaskCheckbox implements ITask {
         }
     }
 
+    @Deprecated
     @Override
     public NBTTagCompound writeToNBT(NBTTagCompound nbt) {
+        return writeToNBT(nbt, false);
+    }
+
+    @Override
+    public NBTTagCompound writeToNBT(NBTTagCompound nbt, boolean reduce) {
         return nbt;
     }
 

--- a/src/main/java/betterquesting/questing/tasks/TaskCrafting.java
+++ b/src/main/java/betterquesting/questing/tasks/TaskCrafting.java
@@ -1,5 +1,6 @@
 package betterquesting.questing.tasks;
 
+import betterquesting.NBTUtil;
 import betterquesting.api.questing.IQuest;
 import betterquesting.api.questing.tasks.ITask;
 import betterquesting.api.utils.BigItemStack;
@@ -30,14 +31,20 @@ import javax.annotation.Nullable;
 import java.util.*;
 
 public class TaskCrafting implements ITask {
+
+    private static final boolean DEFAULT_PARTIAL_MATCH = true;
+    private static final boolean DEFAULT_IGNORE_NBT = false;
+    private static final boolean DEFAULT_ALLOW_ANVIL = false;
+    private static final boolean DEFAULT_ALLOW_SMELT = true;
+    private static final boolean DEFAULT_ALLOW_CRAFT = true;
     private final Set<UUID> completeUsers = new TreeSet<>();
     public final NonNullList<BigItemStack> requiredItems = NonNullList.create();
     public final TreeMap<UUID, int[]> userProgress = new TreeMap<>();
-    public boolean partialMatch = true;
-    public boolean ignoreNBT = false;
-    public boolean allowAnvil = false;
-    public boolean allowSmelt = true;
-    public boolean allowCraft = true;
+    public boolean partialMatch = DEFAULT_PARTIAL_MATCH;
+    public boolean ignoreNBT = DEFAULT_IGNORE_NBT;
+    public boolean allowAnvil = DEFAULT_ALLOW_ANVIL;
+    public boolean allowSmelt = DEFAULT_ALLOW_SMELT;
+    public boolean allowCraft = DEFAULT_ALLOW_CRAFT;
 
     @Override
     public ResourceLocation getFactoryID() {
@@ -115,17 +122,23 @@ public class TaskCrafting implements ITask {
         }
     }
 
+    @Deprecated
     @Override
     public NBTTagCompound writeToNBT(NBTTagCompound nbt) {
-        nbt.setBoolean("partialMatch", partialMatch);
-        nbt.setBoolean("ignoreNBT", ignoreNBT);
-        nbt.setBoolean("allowCraft", allowCraft);
-        nbt.setBoolean("allowSmelt", allowSmelt);
-        nbt.setBoolean("allowAnvil", allowAnvil);
+        return writeToNBT(nbt, false);
+    }
+
+    @Override
+    public NBTTagCompound writeToNBT(NBTTagCompound nbt, boolean reduce) {
+        NBTUtil.setBoolean(nbt, "partialMatch", partialMatch, DEFAULT_PARTIAL_MATCH, reduce);
+        NBTUtil.setBoolean(nbt, "ignoreNBT", ignoreNBT, DEFAULT_IGNORE_NBT, reduce);
+        NBTUtil.setBoolean(nbt, "allowCraft", allowCraft, DEFAULT_ALLOW_CRAFT, reduce);
+        NBTUtil.setBoolean(nbt, "allowSmelt", allowSmelt, DEFAULT_ALLOW_SMELT, reduce);
+        NBTUtil.setBoolean(nbt, "allowAnvil", allowAnvil, DEFAULT_ALLOW_ANVIL, reduce);
 
         NBTTagList itemArray = new NBTTagList();
         for (BigItemStack stack : this.requiredItems) {
-            itemArray.appendTag(JsonHelper.ItemStackToJson(stack, new NBTTagCompound()));
+            itemArray.appendTag(JsonHelper.ItemStackToJson(stack, new NBTTagCompound(), reduce));
         }
         nbt.setTag("requiredItems", itemArray);
 
@@ -134,11 +147,11 @@ public class TaskCrafting implements ITask {
 
     @Override
     public void readFromNBT(NBTTagCompound nbt) {
-        partialMatch = nbt.getBoolean("partialMatch");
-        ignoreNBT = nbt.getBoolean("ignoreNBT");
-        if (nbt.hasKey("allowCraft")) allowCraft = nbt.getBoolean("allowCraft");
-        if (nbt.hasKey("allowSmelt")) allowSmelt = nbt.getBoolean("allowSmelt");
-        if (nbt.hasKey("allowAnvil")) allowAnvil = nbt.getBoolean("allowAnvil");
+        partialMatch = NBTUtil.getBoolean(nbt, "partialMatch", DEFAULT_PARTIAL_MATCH);
+        ignoreNBT = NBTUtil.getBoolean(nbt, "ignoreNBT", DEFAULT_IGNORE_NBT);
+        allowCraft = NBTUtil.getBoolean(nbt, "allowCraft", DEFAULT_ALLOW_CRAFT);
+        allowSmelt = NBTUtil.getBoolean(nbt, "allowSmelt", DEFAULT_ALLOW_SMELT);
+        allowAnvil = NBTUtil.getBoolean(nbt, "allowAnvil", DEFAULT_ALLOW_ANVIL);
 
         requiredItems.clear();
         NBTTagList iList = nbt.getTagList("requiredItems", 10);

--- a/src/main/java/betterquesting/questing/tasks/TaskFluid.java
+++ b/src/main/java/betterquesting/questing/tasks/TaskFluid.java
@@ -1,5 +1,6 @@
 package betterquesting.questing.tasks;
 
+import betterquesting.NBTUtil;
 import betterquesting.api.questing.IQuest;
 import betterquesting.api.questing.tasks.IFluidTask;
 import betterquesting.api.questing.tasks.IItemTask;
@@ -37,14 +38,19 @@ import javax.annotation.Nullable;
 import java.util.*;
 
 public class TaskFluid implements ITaskInventory, IFluidTask, IItemTask {
+
+    private static final boolean DEFAULT_IGNORE_NBT = false;
+    private static final boolean DEFAULT_CONSUME = true;
+    private static final boolean DEFAULT_GROUP_DETECT = false;
+    private static final boolean DEFAULT_AUTO_CONSUME = false;
     private final Set<UUID> completeUsers = new TreeSet<>();
     public final NonNullList<FluidStack> requiredFluids = NonNullList.create();
     public final TreeMap<UUID, int[]> userProgress = new TreeMap<>();
     //public boolean partialMatch = true; // Not many ideal ways of implementing this with fluid handlers
-    public boolean ignoreNbt = false;
-    public boolean consume = true;
-    public boolean groupDetect = false;
-    public boolean autoConsume = false;
+    public boolean ignoreNbt = DEFAULT_IGNORE_NBT;
+    public boolean consume = DEFAULT_CONSUME;
+    public boolean groupDetect = DEFAULT_GROUP_DETECT;
+    public boolean autoConsume = DEFAULT_AUTO_CONSUME;
 
     @Override
     public ResourceLocation getFactoryID() {
@@ -184,13 +190,19 @@ public class TaskFluid implements ITaskInventory, IFluidTask, IItemTask {
         }
     }
 
+    @Deprecated
     @Override
     public NBTTagCompound writeToNBT(NBTTagCompound nbt) {
+        return writeToNBT(nbt, false);
+    }
+
+    @Override
+    public NBTTagCompound writeToNBT(NBTTagCompound nbt, boolean reduce) {
         //json.setBoolean("partialMatch", partialMatch);
-        nbt.setBoolean("ignoreNBT", ignoreNbt);
-        nbt.setBoolean("consume", consume);
-        nbt.setBoolean("groupDetect", groupDetect);
-        nbt.setBoolean("autoConsume", autoConsume);
+        NBTUtil.setBoolean(nbt, "ignoreNBT", ignoreNbt, DEFAULT_IGNORE_NBT, reduce);
+        NBTUtil.setBoolean(nbt, "consume", consume, DEFAULT_CONSUME, reduce);
+        NBTUtil.setBoolean(nbt, "groupDetect", groupDetect, DEFAULT_GROUP_DETECT, reduce);
+        NBTUtil.setBoolean(nbt, "autoConsume", autoConsume, DEFAULT_AUTO_CONSUME, reduce);
 
         NBTTagList itemArray = new NBTTagList();
         for (FluidStack stack : this.requiredFluids) {
@@ -204,10 +216,10 @@ public class TaskFluid implements ITaskInventory, IFluidTask, IItemTask {
     @Override
     public void readFromNBT(NBTTagCompound nbt) {
         //partialMatch = json.getBoolean("partialMatch");
-        ignoreNbt = nbt.getBoolean("ignoreNBT");
-        consume = nbt.getBoolean("consume");
-        groupDetect = nbt.getBoolean("groupDetect");
-        autoConsume = nbt.getBoolean("autoConsume");
+        ignoreNbt = NBTUtil.getBoolean(nbt, "ignoreNBT", DEFAULT_IGNORE_NBT);
+        consume = NBTUtil.getBoolean(nbt, "consume", DEFAULT_CONSUME);
+        groupDetect = NBTUtil.getBoolean(nbt, "groupDetect", DEFAULT_GROUP_DETECT);
+        autoConsume = NBTUtil.getBoolean(nbt, "autoConsume", DEFAULT_AUTO_CONSUME);
 
         requiredFluids.clear();
         NBTTagList fList = nbt.getTagList("requiredFluids", 10);

--- a/src/main/java/betterquesting/questing/tasks/TaskHunt.java
+++ b/src/main/java/betterquesting/questing/tasks/TaskHunt.java
@@ -1,5 +1,6 @@
 package betterquesting.questing.tasks;
 
+import betterquesting.NBTUtil;
 import betterquesting.api.questing.IQuest;
 import betterquesting.api.questing.tasks.ITask;
 import betterquesting.api.utils.ItemComparison;
@@ -30,13 +31,19 @@ import javax.annotation.Nullable;
 import java.util.*;
 
 public class TaskHunt implements ITask {
+
+    private static final String DEFAULT_ENTITY = "minecraft:zombie";
+    private static final String DEFAULT_DAMAGE_TYPE = "";
+    private static final int DEFAULT_REQUIRED = 1;
+    private static final boolean DEFAULT_IGNORE_NBT = true;
+    private static final boolean DEFAULT_SUBTYPES = true;
     private final Set<UUID> completeUsers = new TreeSet<>();
     private final TreeMap<UUID, Integer> userProgress = new TreeMap<>();
-    public String idName = "minecraft:zombie";
-    public String damageType = "";
-    public int required = 1;
-    public boolean ignoreNBT = true;
-    public boolean subtypes = true;
+    public String idName = DEFAULT_ENTITY;
+    public String damageType = DEFAULT_DAMAGE_TYPE;
+    public int required = DEFAULT_REQUIRED;
+    public boolean ignoreNBT = DEFAULT_IGNORE_NBT;
+    public boolean subtypes = DEFAULT_SUBTYPES;
 
     /**
      * NBT representation of the intended target. Used only for NBT comparison checks
@@ -106,26 +113,31 @@ public class TaskHunt implements ITask {
         pInfo.markDirtyParty(Collections.singletonList(quest.getID()));
     }
 
+    @Deprecated
     @Override
     public NBTTagCompound writeToNBT(NBTTagCompound nbt) {
-        nbt.setString("target", idName);
-        nbt.setInteger("required", required);
-        nbt.setBoolean("subtypes", subtypes);
-        nbt.setBoolean("ignoreNBT", ignoreNBT);
-        nbt.setTag("targetNBT", targetTags);
-        nbt.setString("damageType", damageType);
+        return writeToNBT(nbt, false);
+    }
 
+    @Override
+    public NBTTagCompound writeToNBT(NBTTagCompound nbt, boolean reduce) {
+        NBTUtil.setString(nbt, "target", idName, DEFAULT_ENTITY, reduce);
+        NBTUtil.setInteger(nbt, "required", required, DEFAULT_REQUIRED, reduce);
+        NBTUtil.setBoolean(nbt, "subtypes", subtypes, DEFAULT_SUBTYPES, reduce);
+        NBTUtil.setBoolean(nbt, "ignoreNBT", ignoreNBT, DEFAULT_IGNORE_NBT, reduce);
+        NBTUtil.setTag(nbt, "targetNBT", targetTags, reduce);
+        NBTUtil.setString(nbt, "damageType", damageType, DEFAULT_DAMAGE_TYPE, reduce);
         return nbt;
     }
 
     @Override
     public void readFromNBT(NBTTagCompound nbt) {
-        idName = nbt.getString("target");
-        required = nbt.getInteger("required");
-        subtypes = nbt.getBoolean("subtypes");
-        ignoreNBT = nbt.getBoolean("ignoreNBT");
+        idName = NBTUtil.getString(nbt, "target", DEFAULT_ENTITY);
+        required = NBTUtil.getInteger(nbt, "required", DEFAULT_REQUIRED);
+        subtypes = NBTUtil.getBoolean(nbt, "subtypes", DEFAULT_SUBTYPES);
+        ignoreNBT = NBTUtil.getBoolean(nbt, "ignoreNBT", DEFAULT_IGNORE_NBT);
         targetTags = nbt.getCompoundTag("targetNBT");
-        damageType = nbt.getString("damageType");
+        damageType = NBTUtil.getString(nbt, "damageType", DEFAULT_DAMAGE_TYPE);
     }
 
     @Override

--- a/src/main/java/betterquesting/questing/tasks/TaskInteractEntity.java
+++ b/src/main/java/betterquesting/questing/tasks/TaskInteractEntity.java
@@ -1,5 +1,6 @@
 package betterquesting.questing.tasks;
 
+import betterquesting.NBTUtil;
 import betterquesting.api.questing.IQuest;
 import betterquesting.api.questing.tasks.ITask;
 import betterquesting.api.utils.BigItemStack;
@@ -31,23 +32,33 @@ import javax.annotation.Nullable;
 import java.util.*;
 
 public class TaskInteractEntity implements ITask {
+
+    private static final boolean DEFAULT_IGNORE_ITEM_NBT = false;
+    private static final boolean DEFAULT_PARTIAL_ITEM_MATCH = true;
+    private static final boolean DEFAULT_USE_MAIN_HAND = true;
+    private static final boolean DEFAULT_USE_OFFHAND = true;
+    private static final boolean DEFAULT_ENTITY_SUBTYPES = true;
+    private static final boolean DEFAULT_IGNORE_ENTITY_NBT = true;
+    private static final boolean DEFAULT_ON_INTERACT = true;
+    private static final boolean DEFAULT_ON_HIT = false;
+    private static final int DEFAULT_REQUIRED = 1;
     private final Set<UUID> completeUsers = new TreeSet<>();
     private final TreeMap<UUID, Integer> userProgress = new TreeMap<>();
 
     public BigItemStack targetItem = new BigItemStack(Items.AIR);
-    public boolean ignoreItemNBT = false;
-    public boolean partialItemMatch = true;
-    public boolean useMainHand = true;
-    public boolean useOffHand = true;
+    public boolean ignoreItemNBT = DEFAULT_IGNORE_ITEM_NBT;
+    public boolean partialItemMatch = DEFAULT_PARTIAL_ITEM_MATCH;
+    public boolean useMainHand = DEFAULT_USE_MAIN_HAND;
+    public boolean useOffHand = DEFAULT_USE_OFFHAND;
 
     public String entityID = "minecraft:villager";
     public NBTTagCompound entityTags = new NBTTagCompound();
-    public boolean entitySubtypes = true;
-    public boolean ignoreEntityNBT = true;
+    public boolean entitySubtypes = DEFAULT_ENTITY_SUBTYPES;
+    public boolean ignoreEntityNBT = DEFAULT_IGNORE_ENTITY_NBT;
 
-    public boolean onInteract = true;
-    public boolean onHit = false;
-    public int required = 1;
+    public boolean onInteract = DEFAULT_ON_INTERACT;
+    public boolean onHit = DEFAULT_ON_HIT;
+    public int required = DEFAULT_REQUIRED;
 
     @Override
     public String getUnlocalisedName() {
@@ -206,41 +217,47 @@ public class TaskInteractEntity implements ITask {
         return nbt;
     }
 
+    @Deprecated
     @Override
     public NBTTagCompound writeToNBT(NBTTagCompound nbt) {
-        nbt.setTag("item", targetItem.writeToNBT(new NBTTagCompound()));
-        nbt.setBoolean("ignoreItemNBT", ignoreItemNBT);
-        nbt.setBoolean("partialItemMatch", partialItemMatch);
+        return writeToNBT(nbt, false);
+    }
+
+    @Override
+    public NBTTagCompound writeToNBT(NBTTagCompound nbt, boolean reduce) {
+        nbt.setTag("item", targetItem.writeToNBT(new NBTTagCompound(), reduce));
+        NBTUtil.setBoolean(nbt, "ignoreItemNBT", ignoreItemNBT, DEFAULT_IGNORE_ITEM_NBT, reduce);
+        NBTUtil.setBoolean(nbt, "partialItemMatch", partialItemMatch, DEFAULT_PARTIAL_ITEM_MATCH, reduce);
 
         nbt.setString("targetID", entityID);
-        nbt.setTag("targetNBT", entityTags);
-        nbt.setBoolean("ignoreTargetNBT", ignoreEntityNBT);
-        nbt.setBoolean("targetSubtypes", entitySubtypes);
+        NBTUtil.setTag(nbt, "targetNBT", entityTags, reduce);
+        NBTUtil.setBoolean(nbt, "ignoreTargetNBT", ignoreEntityNBT, DEFAULT_IGNORE_ENTITY_NBT, reduce);
+        NBTUtil.setBoolean(nbt, "targetSubtypes", entitySubtypes, DEFAULT_ENTITY_SUBTYPES, reduce);
 
-        nbt.setBoolean("allowMainHand", useMainHand);
-        nbt.setBoolean("allowOffHand", useOffHand);
-        nbt.setInteger("requiredUses", required);
-        nbt.setBoolean("onInteract", onInteract);
-        nbt.setBoolean("onHit", onHit);
+        NBTUtil.setBoolean(nbt, "allowMainHand", useMainHand, DEFAULT_USE_MAIN_HAND, reduce);
+        NBTUtil.setBoolean(nbt, "allowOffHand", useOffHand, DEFAULT_USE_OFFHAND, reduce);
+        NBTUtil.setInteger(nbt, "requiredUses", required, DEFAULT_REQUIRED, reduce);
+        NBTUtil.setBoolean(nbt, "onInteract", onInteract, DEFAULT_ON_INTERACT, reduce);
+        NBTUtil.setBoolean(nbt, "onHit", onHit, DEFAULT_ON_HIT, reduce);
         return nbt;
     }
 
     @Override
     public void readFromNBT(NBTTagCompound nbt) {
         targetItem = new BigItemStack(nbt.getCompoundTag("item"));
-        ignoreItemNBT = nbt.getBoolean("ignoreItemNBT");
-        partialItemMatch = nbt.getBoolean("partialItemMatch");
+        ignoreItemNBT = NBTUtil.getBoolean(nbt, "ignoreItemNBT", DEFAULT_IGNORE_ITEM_NBT);
+        partialItemMatch = NBTUtil.getBoolean(nbt, "partialItemMatch", DEFAULT_PARTIAL_ITEM_MATCH);
 
         entityID = nbt.getString("targetID");
         entityTags = nbt.getCompoundTag("targetNBT");
-        ignoreEntityNBT = nbt.getBoolean("ignoreTargetNBT");
-        entitySubtypes = nbt.getBoolean("targetSubtypes");
+        ignoreEntityNBT = NBTUtil.getBoolean(nbt, "ignoreTargetNBT", DEFAULT_IGNORE_ENTITY_NBT);
+        entitySubtypes = NBTUtil.getBoolean(nbt, "targetSubtypes", DEFAULT_ENTITY_SUBTYPES);
 
-        useMainHand = nbt.getBoolean("allowMainHand");
-        useOffHand = nbt.getBoolean("allowOffHand");
-        required = nbt.getInteger("requiredUses");
-        onInteract = nbt.getBoolean("onInteract");
-        onHit = nbt.getBoolean("onHit");
+        useMainHand = NBTUtil.getBoolean(nbt, "allowMainHand", DEFAULT_USE_MAIN_HAND);
+        useOffHand = NBTUtil.getBoolean(nbt, "allowOffHand", DEFAULT_USE_OFFHAND);
+        required = NBTUtil.getInteger(nbt, "requiredUses", DEFAULT_REQUIRED);
+        onInteract = NBTUtil.getBoolean(nbt, "onInteract", DEFAULT_ON_INTERACT);
+        onHit = NBTUtil.getBoolean(nbt, "onHit", DEFAULT_ON_HIT);
     }
 
     private void setUserProgress(UUID uuid, int progress) {

--- a/src/main/java/betterquesting/questing/tasks/TaskInteractItem.java
+++ b/src/main/java/betterquesting/questing/tasks/TaskInteractItem.java
@@ -1,5 +1,6 @@
 package betterquesting.questing.tasks;
 
+import betterquesting.NBTUtil;
 import betterquesting.NbtBlockType;
 import betterquesting.api.questing.IQuest;
 import betterquesting.api.questing.tasks.ITask;
@@ -35,18 +36,26 @@ import javax.annotation.Nullable;
 import java.util.*;
 
 public class TaskInteractItem implements ITask {
+
+    private static final boolean DEFAULT_PARTIAL_MATCH = true;
+    private static final boolean DEFAULT_IGNORE_NBT = false;
+    private static final boolean DEFAULT_USE_MAIN_HAND = true;
+    private static final boolean DEFAULT_USE_OFFHAND = true;
+    private static final boolean DEFAULT_ON_INTERACT = true;
+    private static final boolean DEFAULT_ON_HIT = false;
+    private static final int DEFAULT_REQUIRED = 1;
     private final Set<UUID> completeUsers = new TreeSet<>();
     private final TreeMap<UUID, Integer> userProgress = new TreeMap<>();
 
     public BigItemStack targetItem = new BigItemStack(Items.AIR);
     public final NbtBlockType targetBlock = new NbtBlockType(Blocks.AIR);
-    public boolean partialMatch = true;
-    public boolean ignoreNBT = false;
-    public boolean useMainHand = true;
-    public boolean useOffHand = true;
-    public boolean onInteract = true;
-    public boolean onHit = false;
-    public int required = 1;
+    public boolean partialMatch = DEFAULT_PARTIAL_MATCH;
+    public boolean ignoreNBT = DEFAULT_IGNORE_NBT;
+    public boolean useMainHand = DEFAULT_USE_MAIN_HAND;
+    public boolean useOffHand = DEFAULT_USE_OFFHAND;
+    public boolean onInteract = DEFAULT_ON_INTERACT;
+    public boolean onHit = DEFAULT_ON_HIT;
+    public int required = DEFAULT_REQUIRED;
 
     @Override
     public String getUnlocalisedName() {
@@ -202,17 +211,23 @@ public class TaskInteractItem implements ITask {
         return nbt;
     }
 
+    @Deprecated
     @Override
     public synchronized NBTTagCompound writeToNBT(NBTTagCompound nbt) {
-        nbt.setTag("item", targetItem.writeToNBT(new NBTTagCompound()));
-        nbt.setTag("block", targetBlock.writeToNBT(new NBTTagCompound()));
-        nbt.setBoolean("ignoreNbt", ignoreNBT);
-        nbt.setBoolean("partialMatch", partialMatch);
-        nbt.setBoolean("allowMainHand", useMainHand);
-        nbt.setBoolean("allowOffHand", useOffHand);
-        nbt.setInteger("requiredUses", required);
-        nbt.setBoolean("onInteract", onInteract);
-        nbt.setBoolean("onHit", onHit);
+        return writeToNBT(nbt, false);
+    }
+
+    @Override
+    public synchronized NBTTagCompound writeToNBT(NBTTagCompound nbt, boolean reduce) {
+        nbt.setTag("item", targetItem.writeToNBT(new NBTTagCompound(), reduce));
+        nbt.setTag("block", targetBlock.writeToNBT(new NBTTagCompound(), reduce));
+        NBTUtil.setBoolean(nbt, "ignoreNbt", ignoreNBT, DEFAULT_IGNORE_NBT, reduce);// Not "ignoreNBT"!!
+        NBTUtil.setBoolean(nbt, "partialMatch", partialMatch, DEFAULT_PARTIAL_MATCH, reduce);
+        NBTUtil.setBoolean(nbt, "allowMainHand", useMainHand, DEFAULT_USE_MAIN_HAND, reduce);
+        NBTUtil.setBoolean(nbt, "allowOffHand", useOffHand, DEFAULT_USE_OFFHAND, reduce);
+        NBTUtil.setInteger(nbt, "requiredUses", required, DEFAULT_REQUIRED, reduce);
+        NBTUtil.setBoolean(nbt, "onInteract", onInteract, DEFAULT_ON_INTERACT, reduce);
+        NBTUtil.setBoolean(nbt, "onHit", onHit, DEFAULT_ON_HIT, reduce);
         return nbt;
     }
 
@@ -220,13 +235,13 @@ public class TaskInteractItem implements ITask {
     public synchronized void readFromNBT(NBTTagCompound nbt) {
         targetItem = new BigItemStack(nbt.getCompoundTag("item"));
         targetBlock.readFromNBT(nbt.getCompoundTag("block"));
-        ignoreNBT = nbt.getBoolean("ignoreNbt");
-        partialMatch = nbt.getBoolean("partialMatch");
-        useMainHand = nbt.getBoolean("allowMainHand");
-        useOffHand = nbt.getBoolean("allowOffHand");
-        required = nbt.getInteger("requiredUses");
-        onInteract = nbt.getBoolean("onInteract");
-        onHit = nbt.getBoolean("onHit");
+        ignoreNBT = NBTUtil.getBoolean(nbt, "ignoreNbt", DEFAULT_IGNORE_NBT);
+        partialMatch = NBTUtil.getBoolean(nbt, "partialMatch", DEFAULT_PARTIAL_MATCH);
+        useMainHand = NBTUtil.getBoolean(nbt, "allowMainHand", DEFAULT_USE_MAIN_HAND);
+        useOffHand = NBTUtil.getBoolean(nbt, "allowOffHand", DEFAULT_USE_OFFHAND);
+        required = NBTUtil.getInteger(nbt, "requiredUses", DEFAULT_REQUIRED);
+        onInteract = NBTUtil.getBoolean(nbt, "onInteract", DEFAULT_ON_INTERACT);
+        onHit = NBTUtil.getBoolean(nbt, "onHit", DEFAULT_ON_HIT);
     }
 
     private void setUserProgress(UUID uuid, Integer progress) {

--- a/src/main/java/betterquesting/questing/tasks/TaskLocation.java
+++ b/src/main/java/betterquesting/questing/tasks/TaskLocation.java
@@ -1,5 +1,6 @@
 package betterquesting.questing.tasks;
 
+import betterquesting.NBTUtil;
 import betterquesting.api.questing.IQuest;
 import betterquesting.api2.client.gui.misc.IGuiRect;
 import betterquesting.api2.client.gui.panels.IGuiPanel;
@@ -26,19 +27,31 @@ import javax.annotation.Nullable;
 import java.util.*;
 
 public class TaskLocation implements ITaskTickable {
+
+    private static final String DEFAULT_STRUCTURE = "";
+    private static final String DEFAULT_BIOME = "";
+    private static final int DEFAULT_X = 0;
+    private static final int DEFAULT_Y = 0;
+    private static final int DEFAULT_Z = 0;
+    private static final int DEFAULT_DIM = 0;
+    private static final int DEFAULT_RANGE = -1;
+    private static final boolean DEFAULT_VISIBLE = false;
+    private static final boolean DEFAULT_HIDE_INFO = false;
+    private static final boolean DEFAULT_INVERT = false;
+    private static final boolean DEFAULT_TAXI_CAB = false;
     private final Set<UUID> completeUsers = new TreeSet<>();
     public String name = "New Location";
-    public String structure = "";
-    public String biome = "";
-    public int x = 0;
-    public int y = 0;
-    public int z = 0;
-    public int dim = 0;
-    public int range = -1;
-    public boolean visible = false;
-    public boolean hideInfo = false;
-    public boolean invert = false;
-    public boolean taxiCab = false;
+    public String structure = DEFAULT_STRUCTURE;
+    public String biome = DEFAULT_BIOME;
+    public int x = DEFAULT_X;
+    public int y = DEFAULT_Y;
+    public int z = DEFAULT_Z;
+    public int dim = DEFAULT_DIM;
+    public int range = DEFAULT_RANGE;
+    public boolean visible = DEFAULT_VISIBLE;
+    public boolean hideInfo = DEFAULT_HIDE_INFO;
+    public boolean invert = DEFAULT_INVERT;
+    public boolean taxiCab = DEFAULT_TAXI_CAB;
 
     @Override
     public ResourceLocation getFactoryID() {
@@ -122,38 +135,43 @@ public class TaskLocation implements ITaskTickable {
         }
     }
 
+    @Deprecated
     @Override
     public NBTTagCompound writeToNBT(NBTTagCompound nbt) {
-        nbt.setString("name", name);
-        nbt.setInteger("posX", x);
-        nbt.setInteger("posY", y);
-        nbt.setInteger("posZ", z);
-        nbt.setInteger("dimension", dim);
-        nbt.setString("biome", biome);
-        nbt.setString("structure", structure);
-        nbt.setInteger("range", range);
-        nbt.setBoolean("visible", visible);
-        nbt.setBoolean("hideInfo", hideInfo);
-        nbt.setBoolean("invert", invert);
-        nbt.setBoolean("taxiCabDist", taxiCab);
+        return writeToNBT(nbt, false);
+    }
 
+    @Override
+    public NBTTagCompound writeToNBT(NBTTagCompound nbt, boolean reduce) {
+        nbt.setString("name", name);
+        NBTUtil.setInteger(nbt, "posX", x, DEFAULT_X, reduce);
+        NBTUtil.setInteger(nbt, "posY", y, DEFAULT_Y, reduce);
+        NBTUtil.setInteger(nbt, "posZ", z, DEFAULT_Z, reduce);
+        NBTUtil.setInteger(nbt, "dimension", dim, DEFAULT_DIM, reduce);
+        NBTUtil.setString(nbt, "biome", biome, DEFAULT_BIOME, reduce);
+        NBTUtil.setString(nbt, "structure", structure, DEFAULT_STRUCTURE, reduce);
+        NBTUtil.setInteger(nbt, "range", range, DEFAULT_RANGE, reduce);
+        NBTUtil.setBoolean(nbt, "visible", visible, DEFAULT_VISIBLE, reduce);
+        NBTUtil.setBoolean(nbt, "hideInfo", hideInfo, DEFAULT_HIDE_INFO, reduce);
+        NBTUtil.setBoolean(nbt, "invert", invert, DEFAULT_INVERT, reduce);
+        NBTUtil.setBoolean(nbt, "taxiCabDist", taxiCab, DEFAULT_TAXI_CAB, reduce);
         return nbt;
     }
 
     @Override
     public void readFromNBT(NBTTagCompound nbt) {
         name = nbt.getString("name");
-        x = nbt.getInteger("posX");
-        y = nbt.getInteger("posY");
-        z = nbt.getInteger("posZ");
-        dim = nbt.getInteger("dimension");
-        biome = nbt.getString("biome");
-        structure = nbt.getString("structure");
-        range = nbt.getInteger("range");
-        visible = nbt.getBoolean("visible");
-        hideInfo = nbt.getBoolean("hideInfo");
-        invert = nbt.getBoolean("invert") || nbt.getBoolean("invertDistance");
-        taxiCab = nbt.getBoolean("taxiCabDist");
+        x = NBTUtil.getInteger(nbt, "posX", DEFAULT_X);
+        y = NBTUtil.getInteger(nbt, "posY", DEFAULT_Y);
+        z = NBTUtil.getInteger(nbt, "posZ", DEFAULT_Z);
+        dim = NBTUtil.getInteger(nbt, "dimension", DEFAULT_DIM);
+        biome = NBTUtil.getString(nbt, "biome", DEFAULT_BIOME);
+        structure = NBTUtil.getString(nbt, "structure", DEFAULT_STRUCTURE);
+        range = NBTUtil.getInteger(nbt, "range", DEFAULT_RANGE);
+        visible = NBTUtil.getBoolean(nbt, "visible", DEFAULT_VISIBLE);
+        hideInfo = NBTUtil.getBoolean(nbt, "hideInfo", DEFAULT_HIDE_INFO);
+        invert = NBTUtil.getBoolean(nbt, "invert", DEFAULT_INVERT) || nbt.getBoolean("invertDistance");
+        taxiCab = NBTUtil.getBoolean(nbt, "taxiCabDist", DEFAULT_TAXI_CAB);
     }
 
     @Override

--- a/src/main/java/betterquesting/questing/tasks/TaskMeeting.java
+++ b/src/main/java/betterquesting/questing/tasks/TaskMeeting.java
@@ -1,5 +1,6 @@
 package betterquesting.questing.tasks;
 
+import betterquesting.NBTUtil;
 import betterquesting.api.questing.IQuest;
 import betterquesting.api.utils.ItemComparison;
 import betterquesting.api2.client.gui.misc.IGuiRect;
@@ -26,13 +27,19 @@ import javax.annotation.Nullable;
 import java.util.*;
 
 public class TaskMeeting implements ITaskTickable {
+
+    private static final String DEFAULT_ENTITY = "minecraft:villager";
+    private static final int DEFAULT_RANGE = 4;
+    private static final int DEFAULT_AMOUNT = 1;
+    private static final boolean DEFAULT_IGNORE_NBT = true;
+    private static final boolean DEFAULT_SUBTYPES = true;
     private final Set<UUID> completeUsers = new TreeSet<>();
 
-    public String idName = "minecraft:villager";
-    public int range = 4;
-    public int amount = 1;
-    public boolean ignoreNBT = true;
-    public boolean subtypes = true;
+    public String idName = DEFAULT_ENTITY;
+    public int range = DEFAULT_RANGE;
+    public int amount = DEFAULT_AMOUNT;
+    public boolean ignoreNBT = DEFAULT_IGNORE_NBT;
+    public boolean subtypes = DEFAULT_SUBTYPES;
 
     /**
      * NBT representation of the intended target. Used only for NBT comparison checks
@@ -113,26 +120,33 @@ public class TaskMeeting implements ITaskTickable {
         }
     }
 
+    @Deprecated
     @Override
-    public NBTTagCompound writeToNBT(NBTTagCompound json) {
+    public NBTTagCompound writeToNBT(NBTTagCompound nbt) {
+        return writeToNBT(nbt, false);
+    }
+
+    @Override
+    public NBTTagCompound writeToNBT(NBTTagCompound json, boolean reduce) {
         json.setString("target", idName);
-        json.setInteger("range", range);
-        json.setInteger("amount", amount);
-        json.setBoolean("subtypes", subtypes);
-        json.setBoolean("ignoreNBT", ignoreNBT);
-        json.setTag("targetNBT", targetTags);
+        NBTUtil.setString(json, "target", idName, DEFAULT_ENTITY, reduce);
+        NBTUtil.setInteger(json, "range", range, DEFAULT_RANGE, reduce);
+        NBTUtil.setInteger(json, "amount", amount, DEFAULT_AMOUNT, reduce);
+        NBTUtil.setBoolean(json, "subtypes", subtypes, DEFAULT_SUBTYPES, reduce);
+        NBTUtil.setBoolean(json, "ignoreNBT", ignoreNBT, DEFAULT_IGNORE_NBT, reduce);
+        NBTUtil.setTag(json, "targetNBT", targetTags, reduce);
 
         return json;
     }
 
     @Override
-    public void readFromNBT(NBTTagCompound json) {
-        idName = json.hasKey("target", 8) ? json.getString("target") : "minecraft:villager";
-        range = json.getInteger("range");
-        amount = json.getInteger("amount");
-        subtypes = json.getBoolean("subtypes");
-        ignoreNBT = json.getBoolean("ignoreNBT");
-        targetTags = json.getCompoundTag("targetNBT");
+    public void readFromNBT(NBTTagCompound nbt) {
+        idName = NBTUtil.getString(nbt, "target", DEFAULT_ENTITY);
+        range = NBTUtil.getInteger(nbt, "range", DEFAULT_RANGE);
+        amount = NBTUtil.getInteger(nbt, "amount", DEFAULT_AMOUNT);
+        subtypes = NBTUtil.getBoolean(nbt, "subtypes", DEFAULT_SUBTYPES);
+        ignoreNBT = NBTUtil.getBoolean(nbt, "ignoreNBT", DEFAULT_IGNORE_NBT);
+        targetTags = nbt.getCompoundTag("targetNBT");
     }
 
     @Override

--- a/src/main/java/betterquesting/questing/tasks/TaskScoreboard.java
+++ b/src/main/java/betterquesting/questing/tasks/TaskScoreboard.java
@@ -1,5 +1,6 @@
 package betterquesting.questing.tasks;
 
+import betterquesting.NBTUtil;
 import betterquesting.ScoreboardBQ;
 import betterquesting.api.questing.IQuest;
 import betterquesting.api2.client.gui.misc.IGuiRect;
@@ -30,14 +31,19 @@ import javax.annotation.Nullable;
 import java.util.*;
 
 public class TaskScoreboard implements ITaskTickable {
+
+    private static final String DEFAULT_TYPE = "dummy";
+    private static final float DEFAULT_CONVERSION = 1F;
+    private static final String DEFAULT_SUFFIX = "";
+    private static final ScoreOperation DEFAULT_OPERATION = ScoreOperation.MORE_OR_EQUAL;
     private final Set<UUID> completeUsers = new TreeSet<>();
     public String scoreName = "Score";
     public String scoreDisp = "Score";
-    public String type = "dummy";
+    public String type = DEFAULT_TYPE;
     public int target = 1;
-    public float conversion = 1F;
-    public String suffix = "";
-    public ScoreOperation operation = ScoreOperation.MORE_OR_EQUAL;
+    public float conversion = DEFAULT_CONVERSION;
+    public String suffix = DEFAULT_SUFFIX;
+    public ScoreOperation operation = DEFAULT_OPERATION;
 
     @Override
     public ResourceLocation getFactoryID() {
@@ -103,33 +109,33 @@ public class TaskScoreboard implements ITaskTickable {
         }
     }
 
+    @Deprecated
     @Override
     public NBTTagCompound writeToNBT(NBTTagCompound nbt) {
+        return writeToNBT(nbt, false);
+    }
+
+    @Override
+    public NBTTagCompound writeToNBT(NBTTagCompound nbt, boolean reduce) {
         nbt.setString("scoreName", scoreName);
         nbt.setString("scoreDisp", scoreDisp);
-        nbt.setString("type", type);
+        NBTUtil.setString(nbt, "type", type, DEFAULT_TYPE, reduce);
         nbt.setInteger("target", target);
-        nbt.setFloat("unitConversion", conversion);
-        nbt.setString("unitSuffix", suffix);
-        nbt.setString("operation", operation.name());
-
+        NBTUtil.setFloat(nbt, "unitConversion", conversion, DEFAULT_CONVERSION, reduce);
+        NBTUtil.setString(nbt, "unitSuffix", suffix, DEFAULT_SUFFIX, reduce);
+        NBTUtil.setString(nbt, "operation", operation.name(), DEFAULT_OPERATION.name(), reduce);
         return nbt;
     }
 
     @Override
     public void readFromNBT(NBTTagCompound nbt) {
-        scoreName = nbt.getString("scoreName");
-        scoreName = scoreName.replaceAll(" ", "_");
+        scoreName = nbt.getString("scoreName").replaceAll(" ", "_");
         scoreDisp = nbt.getString("scoreDisp");
-        type = nbt.hasKey("type", 8) ? nbt.getString("type") : "dummy";
+        type = NBTUtil.getString(nbt, "type", DEFAULT_TYPE);
         target = nbt.getInteger("target");
-        conversion = nbt.getFloat("unitConversion");
-        suffix = nbt.getString("unitSuffix");
-        try {
-            operation = ScoreOperation.valueOf(nbt.hasKey("operation", 8) ? nbt.getString("operation") : "MORE_OR_EQUAL");
-        } catch (Exception e) {
-            operation = ScoreOperation.MORE_OR_EQUAL;
-        }
+        conversion = NBTUtil.getFloat(nbt, "unitConversion", DEFAULT_CONVERSION);
+        suffix = NBTUtil.getString(nbt, "unitSuffix", DEFAULT_SUFFIX);
+        operation = NBTUtil.getEnum(nbt, "operation", ScoreOperation.class, true, DEFAULT_OPERATION);
     }
 
     @Override

--- a/src/main/java/betterquesting/questing/tasks/TaskStorage.java
+++ b/src/main/java/betterquesting/questing/tasks/TaskStorage.java
@@ -16,17 +16,23 @@ import java.util.List;
 import java.util.UUID;
 
 public class TaskStorage extends SimpleDatabase<ITask> implements IDatabaseNBT<ITask, NBTTagList, NBTTagList> {
+    @Deprecated
     @Override
-    public NBTTagList writeToNBT(NBTTagList json, @Nullable List<Integer> subset) {
+    public NBTTagList writeToNBT(NBTTagList nbt, @Nullable List<Integer> subset) {
+        return writeToNBT(nbt, subset, false);
+    }
+
+    @Override
+    public NBTTagList writeToNBT(NBTTagList nbt, @Nullable List<Integer> subset, boolean reduce) {
         for (DBEntry<ITask> entry : getEntries()) {
             if (subset != null && !subset.contains(entry.getID())) continue;
             ResourceLocation taskID = entry.getValue().getFactoryID();
-            NBTTagCompound qJson = entry.getValue().writeToNBT(new NBTTagCompound());
+            NBTTagCompound qJson = entry.getValue().writeToNBT(new NBTTagCompound(), reduce);
             qJson.setString("taskID", taskID.toString());
             qJson.setInteger("index", entry.getID());
-            json.appendTag(qJson);
+            nbt.appendTag(qJson);
         }
-        return json;
+        return nbt;
     }
 
     @Override

--- a/src/main/java/betterquesting/questing/tasks/TaskTame.java
+++ b/src/main/java/betterquesting/questing/tasks/TaskTame.java
@@ -1,5 +1,6 @@
 package betterquesting.questing.tasks;
 
+import betterquesting.NBTUtil;
 import betterquesting.api.questing.IQuest;
 import betterquesting.api.questing.tasks.ITask;
 import betterquesting.api.utils.ItemComparison;
@@ -29,12 +30,17 @@ import javax.annotation.Nullable;
 import java.util.*;
 
 public class TaskTame implements ITask {
+
+    private static final String DEFAULT_ENTITY = "minecraft:wolf";
+    private static final int DEFAULT_REQUIRED = 1;
+    private static final boolean DEFAULT_IGNORE_NBT = true;
+    private static final boolean DEFAULT_SUBTYPES = true;
     private final Set<UUID> completeUsers = new TreeSet<>();
     public final HashMap<UUID, Integer> userProgress = new HashMap<>();
-    public String idName = "minecraft:wolf";
-    public int required = 1;
-    public boolean ignoreNBT = true;
-    public boolean subtypes = true;
+    public String idName = DEFAULT_ENTITY;
+    public int required = DEFAULT_REQUIRED;
+    public boolean ignoreNBT = DEFAULT_IGNORE_NBT;
+    public boolean subtypes = DEFAULT_SUBTYPES;
 
     /**
      * NBT representation of the intended target. Used only for NBT comparison checks
@@ -128,24 +134,30 @@ public class TaskTame implements ITask {
         return new GuiEditTaskTame(parent, quest, this);
     }
 
+    @Deprecated
     @Override
-    public NBTTagCompound writeToNBT(NBTTagCompound json) {
-        json.setString("target", idName);
-        json.setInteger("required", required);
-        json.setBoolean("subtypes", subtypes);
-        json.setBoolean("ignoreNBT", ignoreNBT);
-        json.setTag("targetNBT", targetTags);
-
-        return json;
+    public NBTTagCompound writeToNBT(NBTTagCompound nbt) {
+        return writeToNBT(nbt, false);
     }
 
     @Override
-    public void readFromNBT(NBTTagCompound json) {
-        idName = json.getString("target");
-        required = json.getInteger("required");
-        subtypes = json.getBoolean("subtypes");
-        ignoreNBT = json.getBoolean("ignoreNBT");
-        targetTags = json.getCompoundTag("targetNBT");
+    public NBTTagCompound writeToNBT(NBTTagCompound nbt, boolean reduce) {
+        NBTUtil.setString(nbt, "target", idName, DEFAULT_ENTITY, reduce);
+        NBTUtil.setInteger(nbt, "required", required, DEFAULT_REQUIRED, reduce);
+        NBTUtil.setBoolean(nbt, "subtypes", subtypes, DEFAULT_SUBTYPES, reduce);
+        NBTUtil.setBoolean(nbt, "ignoreNBT", ignoreNBT, DEFAULT_IGNORE_NBT, reduce);
+        NBTUtil.setTag(nbt, "targetNBT", targetTags, reduce);
+
+        return nbt;
+    }
+
+    @Override
+    public void readFromNBT(NBTTagCompound nbt) {
+        idName = NBTUtil.getString(nbt, "target", DEFAULT_ENTITY);
+        required = NBTUtil.getInteger(nbt, "required", DEFAULT_REQUIRED);
+        subtypes = NBTUtil.getBoolean(nbt, "subtypes", DEFAULT_SUBTYPES);
+        ignoreNBT = NBTUtil.getBoolean(nbt, "ignoreNBT", DEFAULT_IGNORE_NBT);
+        targetTags = nbt.getCompoundTag("targetNBT");
     }
 
     @Override

--- a/src/main/java/betterquesting/questing/tasks/TaskTrigger.java
+++ b/src/main/java/betterquesting/questing/tasks/TaskTrigger.java
@@ -184,8 +184,14 @@ public class TaskTrigger implements ITask {
         }
     }
 
+    @Deprecated
     @Override
     public NBTTagCompound writeToNBT(NBTTagCompound nbt) {
+        return writeToNBT(nbt, false);
+    }
+
+    @Override
+    public NBTTagCompound writeToNBT(NBTTagCompound nbt, boolean reduce) {
         nbt.setString("description", desc);
         nbt.setString("trigger", triggerID);
         nbt.setString("conditions", critJson);

--- a/src/main/java/betterquesting/questing/tasks/TaskXP.java
+++ b/src/main/java/betterquesting/questing/tasks/TaskXP.java
@@ -1,5 +1,6 @@
 package betterquesting.questing.tasks;
 
+import betterquesting.NBTUtil;
 import betterquesting.XPHelper;
 import betterquesting.api.questing.IQuest;
 import betterquesting.api2.client.gui.misc.IGuiRect;
@@ -21,11 +22,15 @@ import javax.annotation.Nullable;
 import java.util.*;
 
 public class TaskXP implements ITaskTickable {
+
+    private static final boolean DEFAULT_LEVELS = true;
+    private static final int DEFAULT_AMOUNT = 30;
+    private static final boolean DEFAULT_CONSUME = true;
     private final Set<UUID> completeUsers = new TreeSet<>();
     private final HashMap<UUID, Long> userProgress = new HashMap<>();
-    public boolean levels = true;
-    public int amount = 30;
-    public boolean consume = true;
+    public boolean levels = DEFAULT_LEVELS;
+    public int amount = DEFAULT_AMOUNT;
+    public boolean consume = DEFAULT_CONSUME;
 
     @Override
     public ResourceLocation getFactoryID() {
@@ -100,19 +105,25 @@ public class TaskXP implements ITaskTickable {
         return "bq_standard.task.xp";
     }
 
+    @Deprecated
     @Override
-    public NBTTagCompound writeToNBT(NBTTagCompound json) {
-        json.setInteger("amount", amount);
-        json.setBoolean("isLevels", levels);
-        json.setBoolean("consume", consume);
-        return json;
+    public NBTTagCompound writeToNBT(NBTTagCompound nbt) {
+        return writeToNBT(nbt, false);
     }
 
     @Override
-    public void readFromNBT(NBTTagCompound json) {
-        amount = json.hasKey("amount", 99) ? json.getInteger("amount") : 30;
-        levels = json.getBoolean("isLevels");
-        consume = json.getBoolean("consume");
+    public NBTTagCompound writeToNBT(NBTTagCompound nbt, boolean reduce) {
+        NBTUtil.setInteger(nbt, "amount", amount, DEFAULT_AMOUNT, reduce);
+        NBTUtil.setBoolean(nbt, "isLevels", levels, DEFAULT_LEVELS, reduce);
+        NBTUtil.setBoolean(nbt, "consume", consume, DEFAULT_CONSUME, reduce);
+        return nbt;
+    }
+
+    @Override
+    public void readFromNBT(NBTTagCompound nbt) {
+        amount = NBTUtil.getInteger(nbt, "amount", DEFAULT_AMOUNT);
+        levels = NBTUtil.getBoolean(nbt, "isLevels", DEFAULT_LEVELS);
+        consume = NBTUtil.getBoolean(nbt, "consume", DEFAULT_CONSUME);
     }
 
     @Override

--- a/src/main/java/betterquesting/storage/LifeDatabase.java
+++ b/src/main/java/betterquesting/storage/LifeDatabase.java
@@ -28,8 +28,14 @@ public final class LifeDatabase implements ILifeDatabase {
         playerLives.put(uuid, MathHelper.clamp(value, 0, QuestSettings.INSTANCE.getProperty(NativeProps.LIVES_MAX)));
     }
 
+    @Deprecated
     @Override
     public synchronized NBTTagCompound writeToNBT(NBTTagCompound nbt, @Nullable List<UUID> users) {
+        return writeToNBT(nbt, users, false);
+    }
+
+    @Override
+    public synchronized NBTTagCompound writeToNBT(NBTTagCompound nbt, @Nullable List<UUID> users, boolean reduce) {
         NBTTagList jul = new NBTTagList();
         for (Entry<UUID, Integer> entry : playerLives.entrySet()) {
             if (users != null && !users.contains(entry.getKey())) continue;

--- a/src/main/java/betterquesting/storage/NameCache.java
+++ b/src/main/java/betterquesting/storage/NameCache.java
@@ -63,8 +63,14 @@ public final class NameCache implements INameCache {
         return cache.size();
     }
 
+    @Deprecated
     @Override
     public synchronized NBTTagList writeToNBT(NBTTagList nbt, @Nullable List<UUID> users) {
+        return writeToNBT(nbt, users, false);
+    }
+
+    @Override
+    public synchronized NBTTagList writeToNBT(NBTTagList nbt, @Nullable List<UUID> users, boolean reduce) {
         for (Entry<UUID, NBTTagCompound> entry : cache.entrySet()) {
             if (users != null && !users.contains(entry.getKey())) continue;
             NBTTagCompound jn = new NBTTagCompound();

--- a/src/main/java/betterquesting/storage/PropertyContainer.java
+++ b/src/main/java/betterquesting/storage/PropertyContainer.java
@@ -1,16 +1,24 @@
 package betterquesting.storage;
 
 import betterquesting.api.properties.IPropertyContainer;
+import betterquesting.api.properties.IPropertyReducible;
 import betterquesting.api.properties.IPropertyType;
 import betterquesting.api2.storage.INBTSaveLoad;
+import com.google.common.collect.BiMap;
+import com.google.common.collect.HashBiMap;
+import net.minecraft.nbt.NBTBase;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.ResourceLocation;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 public class PropertyContainer implements IPropertyContainer, INBTSaveLoad<NBTTagCompound> {
     private final NBTTagCompound nbtInfo = new NBTTagCompound();
+    // For reducing nbt
+    // To hold nbt values if the properties are not used (ex: the addon is temporarily removed), we cache and use only used properties to reduce nbt.
+    private final BiMap<ResourceLocation, IPropertyType<?>> id2PropertyMap = HashBiMap.create(); // property.getKey() -> property
 
     @Override
     public synchronized <T> T getProperty(IPropertyType<T> prop) {
@@ -23,6 +31,7 @@ public class PropertyContainer implements IPropertyContainer, INBTSaveLoad<NBTTa
     public synchronized <T> T getProperty(IPropertyType<T> prop, T def) {
         if (prop == null) return def;
 
+        id2PropertyMap.put(prop.getKey(), prop);
         NBTTagCompound jProp = getDomain(prop.getKey());
 
         if (!jProp.hasKey(prop.getKey().getPath())) return def;
@@ -33,12 +42,14 @@ public class PropertyContainer implements IPropertyContainer, INBTSaveLoad<NBTTa
     @Override
     public synchronized boolean hasProperty(IPropertyType<?> prop) {
         if (prop == null) return false;
+        id2PropertyMap.put(prop.getKey(), prop);
         return getDomain(prop.getKey()).hasKey(prop.getKey().getPath());
     }
 
     @Override
     public synchronized void removeProperty(IPropertyType<?> prop) {
         if (prop == null) return;
+        id2PropertyMap.put(prop.getKey(), prop);
         NBTTagCompound jProp = getDomain(prop.getKey());
 
         if (!jProp.hasKey(prop.getKey().getPath())) return;
@@ -51,6 +62,7 @@ public class PropertyContainer implements IPropertyContainer, INBTSaveLoad<NBTTa
     @Override
     public synchronized <T> void setProperty(IPropertyType<T> prop, T value) {
         if (prop == null || value == null) return;
+        id2PropertyMap.put(prop.getKey(), prop);
         NBTTagCompound dom = getDomain(prop.getKey());
         dom.setTag(prop.getKey().getPath(), prop.writeValue(value));
         nbtInfo.setTag(prop.getKey().getNamespace(), dom);
@@ -62,22 +74,45 @@ public class PropertyContainer implements IPropertyContainer, INBTSaveLoad<NBTTa
         for (String key : keys) nbtInfo.removeTag(key);
     }
 
+    @Deprecated
     @Override
     public synchronized NBTTagCompound writeToNBT(NBTTagCompound nbt) {
-        nbt.merge(nbtInfo);
+        return writeToNBT(nbt, false);
+    }
+
+    @Override
+    public synchronized NBTTagCompound writeToNBT(NBTTagCompound nbt, boolean reduce) {
+        if (reduce) {
+            NBTTagCompound reducedNbtInfo = new NBTTagCompound();
+            for (String namespace : nbtInfo.getKeySet()) {
+                NBTTagCompound dom = nbtInfo.getCompoundTag(namespace);
+                NBTTagCompound reducedDom = new NBTTagCompound();
+                for (String key : dom.getKeySet()) {
+                    IPropertyType<?> prop = id2PropertyMap.get(new ResourceLocation(namespace, key));
+                    NBTBase tag = dom.getTag(key);
+                    if (prop != null && Objects.equals(prop.getDefault(), prop.readValue(tag))) continue;
+                    if (prop instanceof IPropertyReducible<?> reducible) tag = reducible.reduceNBT(tag);
+                    reducedDom.setTag(key, tag);
+                }
+                if (!reducedDom.isEmpty()) reducedNbtInfo.setTag(namespace, reducedDom);
+            }
+            nbt.merge(reducedNbtInfo);
+        } else {
+            nbt.merge(nbtInfo);
+        }
         return nbt;
     }
 
     @Override
     public synchronized void readFromNBT(NBTTagCompound nbt) {
-        for (String key : nbtInfo.getKeySet()) nbtInfo.removeTag(key);
+        removeAllProps();
         nbtInfo.merge(nbt);
 
-        // TODO: FIX CASING
+        // TODO: FIX CASING <- ???
         /*List<String> keys = new ArrayList<>(nbtInfo.getKeySet());
         for(nbt)
         {
-        
+
         }*/
     }
 


### PR DESCRIPTION
changes in this PR:
- add default values for most tasks and rewards.
- when saving to the database, only save non-default values. this reduces the size of the questbook significantly - reportedly around 50% by both Nomifactory and DJ2.
- deprecate `NBTReplaceUtil` and add `NBTUtil`, which simplifies code related to these operations.
- fix an error where trying to load quests from the new database would error due to simply not clearing current quests (this used to happen when calling `QuestDatabase.INSTANCE.readFromNBT(nbt1.getTagList("questDatabase", 10), false);`, with the `false` causes a `QuestDatabase.INSTANCE.reset();` to be called. however, due to breaking the database into separate files, this method is no longer called, and reset didnt get copied over).
- similarly, readded `questID`, `lineID`, and `order` tags to the quest database and questline when running `save`, as those are called via the `writeToNBT` methods, which are unused in this context (only used in `saveLegacy`).
- update the questbook format from `2.0.0` to `2.1.0`.


difference from #109:
- expanded significantly on what `NBTUtil` does.
- added more default things, fixed a few situations where NBT data tags were changed.
- apply reduction to saving and loading in the new save/load layout.
- fix some whitespace issues.

supersedes #109