### PR TITLE
remove listener when logging out

### DIFF
--- a/src/main/java/betterquesting/handlers/EventHandler.java
+++ b/src/main/java/betterquesting/handlers/EventHandler.java
@@ -725,7 +725,7 @@ public class EventHandler {
     }
 
     @SubscribeEvent
-    public static void onPlayerLoggedOut(PlayerEvent.PlayerLoggedOutEvent event) {
+    public void onPlayerLoggedOut(PlayerEvent.PlayerLoggedOutEvent event) {
         if (event.player == null || event.player.world.isRemote) return;
         PlayerContainerListener.removeListener(event.player);
     }

--- a/src/main/java/betterquesting/handlers/EventHandler.java
+++ b/src/main/java/betterquesting/handlers/EventHandler.java
@@ -725,6 +725,12 @@ public class EventHandler {
     }
 
     @SubscribeEvent
+    public static void onPlayerLoggedOut(PlayerEvent.PlayerLoggedOutEvent event) {
+        if (event.player == null || event.player.world.isRemote) return;
+        PlayerContainerListener.removeListener(event.player);
+    }
+
+    @SubscribeEvent
     public void onMarkDirtyPlayer(MarkDirtyPlayerEvent event) {
         SaveLoadHandler.INSTANCE.addDirtyPlayers(event.getDirtyPlayerIDs());
     }

--- a/src/main/java/betterquesting/handlers/PlayerContainerListener.java
+++ b/src/main/java/betterquesting/handlers/PlayerContainerListener.java
@@ -37,6 +37,11 @@ public class PlayerContainerListener implements IContainerListener {
         }
     }
 
+    public static void removeListener(@Nonnull EntityPlayer player) {
+        UUID uuid = QuestingAPI.getQuestingUUID(player);
+        LISTEN_MAP.remove(uuid);
+    }
+
     private EntityPlayer player;
 
     private PlayerContainerListener(@Nonnull EntityPlayer player) {


### PR DESCRIPTION
changes in this PR:
- removes the player listener when the player is logging out

currently it just... stays there. waiting. listening.