### PR TITLE
make Back a keybind

### DIFF
--- a/src/main/java/betterquesting/api2/client/gui/GuiContainerCanvas.java
+++ b/src/main/java/betterquesting/api2/client/gui/GuiContainerCanvas.java
@@ -193,14 +193,8 @@ public class GuiContainerCanvas extends GuiContainer implements IScene {
 
     @Override
     public void keyTyped(char c, int keyCode) {
-        if (keyCode == 1) {
-            if (this.isVolatile || this instanceof IVolatileScreen) {
-                openPopup(new PopChoice(QuestTranslation.translate("betterquesting.gui.closing_warning") + "\n\n" + QuestTranslation.translate("betterquesting.gui.closing_confirm"), PresetIcon.ICON_NOTICE.getTexture(), this::confirmClose, QuestTranslation.translate("gui.yes"), QuestTranslation.translate("gui.no")));
-            } else {
-                this.mc.displayGuiScreen(null);
-                if (this.mc.currentScreen == null) this.mc.setIngameFocus();
-            }
-
+        if (keyCode == Keyboard.KEY_ESCAPE) {
+            confirmVolatileClose();
             return;
         }
 
@@ -314,15 +308,18 @@ public class GuiContainerCanvas extends GuiContainer implements IScene {
         }
 
         if (!used && (BQ_Keybindings.openQuests.getKeyCode() == keycode || mc.gameSettings.keyBindInventory.getKeyCode() == keycode)) {
-            if (this.isVolatile || this instanceof IVolatileScreen) {
-                openPopup(new PopChoice(QuestTranslation.translate("betterquesting.gui.closing_warning") + "\n\n" + QuestTranslation.translate("betterquesting.gui.closing_confirm"), PresetIcon.ICON_NOTICE.getTexture(), this::confirmClose, QuestTranslation.translate("gui.yes"), QuestTranslation.translate("gui.no")));
-            } else {
-                this.mc.displayGuiScreen(null);
-                if (this.mc.currentScreen == null) this.mc.setIngameFocus();
-            }
+            confirmVolatileClose();
         }
 
         return used;
+    }
+
+    private void confirmVolatileClose() {
+        if (this.isVolatile || this instanceof IVolatileScreen) {
+            openPopup(new PopChoice(QuestTranslation.translate("betterquesting.gui.closing_warning") + "\n\n" + QuestTranslation.translate("betterquesting.gui.closing_confirm"), PresetIcon.ICON_NOTICE.getTexture(), this::confirmClose, QuestTranslation.translate("gui.yes"), QuestTranslation.translate("gui.no")));
+        } else {
+            confirmClose(0);
+        }
     }
 
     @Override

--- a/src/main/java/betterquesting/api2/client/gui/GuiScreenCanvas.java
+++ b/src/main/java/betterquesting/api2/client/gui/GuiScreenCanvas.java
@@ -194,15 +194,8 @@ public class GuiScreenCanvas extends GuiScreen implements IScene {
 
     @Override
     public void keyTyped(char c, int keyCode) {
-        if (keyCode == 1) // ESCAPE
-        {
-            if (this.isVolatile || this instanceof IVolatileScreen) {
-                openPopup(new PopChoice(QuestTranslation.translate("betterquesting.gui.closing_warning") + "\n\n" + QuestTranslation.translate("betterquesting.gui.closing_confirm"), PresetIcon.ICON_NOTICE.getTexture(), this::confirmClose, QuestTranslation.translate("gui.yes"), QuestTranslation.translate("gui.no")));
-            } else {
-                this.mc.displayGuiScreen(null);
-                if (this.mc.currentScreen == null) this.mc.setIngameFocus();
-            }
-
+        if (keyCode == Keyboard.KEY_ESCAPE) {
+            confirmVolatileClose();
             return;
         }
         if (keyCode == BQ_Keybindings.backPage.getKeyCode()) { // BACKSPACE
@@ -330,15 +323,18 @@ public class GuiScreenCanvas extends GuiScreen implements IScene {
         }
 
         if (!used && (BQ_Keybindings.openQuests.getKeyCode() == keycode || mc.gameSettings.keyBindInventory.getKeyCode() == keycode)) {
-            if (this.isVolatile || this instanceof IVolatileScreen) {
-                openPopup(new PopChoice(QuestTranslation.translate("betterquesting.gui.closing_warning") + "\n\n" + QuestTranslation.translate("betterquesting.gui.closing_confirm"), PresetIcon.ICON_NOTICE.getTexture(), this::confirmClose, QuestTranslation.translate("gui.yes"), QuestTranslation.translate("gui.no")));
-            } else {
-                this.mc.displayGuiScreen(null);
-                if (this.mc.currentScreen == null) this.mc.setIngameFocus();
-            }
+            confirmVolatileClose();
         }
 
         return used;
+    }
+
+    private void confirmVolatileClose() {
+        if (this.isVolatile || this instanceof IVolatileScreen) {
+            openPopup(new PopChoice(QuestTranslation.translate("betterquesting.gui.closing_warning") + "\n\n" + QuestTranslation.translate("betterquesting.gui.closing_confirm"), PresetIcon.ICON_NOTICE.getTexture(), this::confirmClose, QuestTranslation.translate("gui.yes"), QuestTranslation.translate("gui.no")));
+        } else {
+            confirmClose(0);
+        }
     }
 
     @Override

--- a/src/main/java/betterquesting/api2/client/gui/GuiScreenCanvas.java
+++ b/src/main/java/betterquesting/api2/client/gui/GuiScreenCanvas.java
@@ -205,7 +205,7 @@ public class GuiScreenCanvas extends GuiScreen implements IScene {
 
             return;
         }
-        if (keyCode == 14) { // BACKSPACE
+        if (keyCode == BQ_Keybindings.backPage.getKeyCode()) { // BACKSPACE
             if (this.mc.currentScreen instanceof GuiScreenCanvas) {
                 GuiScreenCanvas canvas = (GuiScreenCanvas) mc.currentScreen;
                 boolean hasKeyAction = false;

--- a/src/main/java/betterquesting/client/BQ_Keybindings.java
+++ b/src/main/java/betterquesting/client/BQ_Keybindings.java
@@ -7,10 +7,13 @@ import org.lwjgl.input.Keyboard;
 
 public class BQ_Keybindings {
     public static KeyBinding openQuests;
+    public static KeyBinding backPage;
 
     public static void RegisterKeys() {
         openQuests = new KeyBinding("key.betterquesting.quests", Keyboard.KEY_GRAVE, ModReference.NAME);
+        backPage = new KeyBinding("key.betterquesting.back", Keyboard.KEY_BACK, ModReference.NAME);
 
         ClientRegistry.registerKeyBinding(openQuests);
+        ClientRegistry.registerKeyBinding(backPage);
     }
 }

--- a/src/main/resources/assets/betterquesting/lang/en_us.lang
+++ b/src/main/resources/assets/betterquesting/lang/en_us.lang
@@ -129,6 +129,7 @@ betterquesting.msg.copy_quest_copied=§eCopied to clipboard: §b%s
 betterquesting.msg.copy_quest_failed=§cCould not copy §b%s§r§c to clipboard!
 
 key.betterquesting.quests=Open Quests
+key.betterquesting.back=Page Back
 key.betterquesting.party=Party Manager
 key.betterquesting.themes=Change Theme
 

--- a/src/main/resources/assets/betterquesting/lang/en_us.lang
+++ b/src/main/resources/assets/betterquesting/lang/en_us.lang
@@ -129,7 +129,7 @@ betterquesting.msg.copy_quest_copied=§eCopied to clipboard: §b%s
 betterquesting.msg.copy_quest_failed=§cCould not copy §b%s§r§c to clipboard!
 
 key.betterquesting.quests=Open Quests
-key.betterquesting.back=Page Back
+key.betterquesting.back=Return to Previous Page
 key.betterquesting.party=Party Manager
 key.betterquesting.themes=Change Theme
 


### PR DESCRIPTION
changes in this PR:
- adds a keybind to go back instead of having it be hardcoded to "14" (what are we, barbarians?).
- keybind defaults to `backspace`.
- move some duplicate code relating to closing volatile screens into a separate method in two locations.