### PR TITLE
Set Fluid Task Default Consume to false

### DIFF
--- a/src/main/java/betterquesting/questing/tasks/TaskFluid.java
+++ b/src/main/java/betterquesting/questing/tasks/TaskFluid.java
@@ -40,7 +40,7 @@ import java.util.*;
 public class TaskFluid implements ITaskInventory, IFluidTask, IItemTask {
 
     private static final boolean DEFAULT_IGNORE_NBT = false;
-    private static final boolean DEFAULT_CONSUME = true;
+    private static final boolean DEFAULT_CONSUME = false;
     private static final boolean DEFAULT_GROUP_DETECT = false;
     private static final boolean DEFAULT_AUTO_CONSUME = false;
     private final Set<UUID> completeUsers = new TreeSet<>();


### PR DESCRIPTION
changes in this PR:
- set fluid task default to not consume
- not consuming by default is a more logical position than consuming by default
- fixes a situation where previously removing the value from the task would result in it being set to `false`, but due to the creation of a default fallback value, it would be set to `true` when removed instead.