### PR TITLE
Fix Fluid Task Detection with Stacked Fluid Containers

### DIFF
--- a/src/main/java/betterquesting/questing/tasks/TaskFluid.java
+++ b/src/main/java/betterquesting/questing/tasks/TaskFluid.java
@@ -83,15 +83,16 @@ public class TaskFluid implements ITaskInventory, IFluidTask, IItemTask {
     public void detect(ParticipantInfo pInfo, DBEntry<IQuest> quest) {
         if (isComplete(pInfo.UUID)) return;
 
-        // Removing the consume check here would make the task cheaper on groups and for that reason sharing is restricted to detect only
-        final List<Tuple<UUID, int[]>> progress = getBulkProgress(consume ? Collections.singletonList(pInfo.UUID) : pInfo.ALL_UUIDS);
+        // Removing the consume check here would make the task cheaper on groups and for that reason sharing is
+        // restricted to detect only
+        List<Tuple<UUID, int[]>> progress = getBulkProgress(
+                consume ? Collections.singletonList(pInfo.UUID) : pInfo.ALL_UUIDS);
         boolean updated = false;
 
         if (!consume) {
             if (groupDetect) // Reset all detect progress
-            {
                 progress.forEach((value) -> Arrays.fill(value.getSecond(), 0));
-            } else {
+            else {
                 for (int i = 0; i < requiredFluids.size(); i++) {
                     final int r = requiredFluids.get(i).amount;
                     for (Tuple<UUID, int[]> value : progress) {
@@ -105,9 +106,9 @@ public class TaskFluid implements ITaskInventory, IFluidTask, IItemTask {
             }
         }
 
-        final List<InventoryPlayer> invoList;
+        List<InventoryPlayer> invoList;
         if (consume) {
-            // We do not support consuming resources from other member's invetories.
+            // We do not support consuming resources from other member's inventories.
             // This could otherwise be abused to siphon items/fluids unknowingly
             invoList = Collections.singletonList(pInfo.PLAYER.inventory);
         } else {
@@ -118,46 +119,84 @@ public class TaskFluid implements ITaskInventory, IFluidTask, IItemTask {
         for (InventoryPlayer invo : invoList) {
             for (int i = 0; i < invo.getSizeInventory(); i++) {
                 ItemStack stack = invo.getStackInSlot(i);
+
                 if (stack.isEmpty()) continue;
-                IFluidHandlerItem handler = FluidUtil.getFluidHandler(stack);
+
+                // Make a copy of the stack to retrieve the fluid amount & info.
+                // Set count to 1, otherwise fluid handlers may not allow draining
+                var toRetrieveInfo = stack.copy();
+                toRetrieveInfo.setCount(1);
+
+                var handler = FluidUtil.getFluidHandler(toRetrieveInfo);
                 if (handler == null) continue;
 
-                boolean hasDrained = false;
-
                 for (int j = 0; j < requiredFluids.size(); j++) {
-                    final FluidStack rStack = requiredFluids.get(j);
-                    FluidStack drainOG = rStack.copy();
-                    if (ignoreNbt) drainOG.tag = null;
+                    FluidStack rStack = requiredFluids.get(j);
 
-                    // Pre-check
-                    FluidStack sample = handler.drain(drainOG, false);
-                    if (sample == null || sample.amount <= 0) continue;
+                    boolean hasDrained = false;
+                    boolean requiresFullDrain = false;
+                    int fullDrainAmt = 0;
 
-                    // Theoretically this could work in consume mode for parties but the priority order and manual submission code would need changing
+                    // Initial Check
+                    FluidStack rStackOg = rStack.copy();
+                    rStackOg.amount = (int) Math.ceil((double) rStack.amount / (double) stack.getCount());
+                    FluidStack sample = handler.drain(rStackOg, false);
+                    if (sample == null || sample.amount <= 0) {
+                        // Check if we can drain the entire container instead (Simple Fluid Handler)
+                        if (handler.getTankProperties().length < 1) continue;
+
+                        fullDrainAmt = handler.getTankProperties()[0].getCapacity();
+                        if (fullDrainAmt <= 0) continue;
+                        rStackOg.amount = fullDrainAmt;
+
+                        sample = handler.drain(rStackOg, false);
+                        if (sample == null || sample.amount <= 0) continue;
+
+                        requiresFullDrain = true;
+                    }
+
+                    // Theoretically this could work in consume mode for parties but the priority order and manual
+                    // submission code would need changing
                     for (Tuple<UUID, int[]> value : progress) {
                         if (value.getSecond()[j] >= rStack.amount) continue;
                         int remaining = rStack.amount - value.getSecond()[j];
 
                         FluidStack drain = rStack.copy();
-                        drain.amount = remaining / stack.getCount(); // Must be a multiple of the stack size
+
+                        // Take the ceiling, so we are not removing less than required
+                        if (requiresFullDrain)
+                            drain.amount = fullDrainAmt;
+                        else
+                            drain.amount = (int) Math.ceil((double) remaining / (double) stack.getCount());
                         if (ignoreNbt) drain.tag = null;
                         if (drain.amount <= 0) continue;
 
-                        FluidStack fluid = handler.drain(drain, consume); // TODO: Look into reducing this to a single call if possible
+                        FluidStack fluid = handler.drain(drain, consume);
                         if (fluid == null || fluid.amount <= 0) continue;
 
-                        value.getSecond()[j] += fluid.amount * stack.getCount();
+                        value.getSecond()[j] += Math.min(fluid.amount * stack.getCount(), remaining);
                         hasDrained = true;
                         updated = true;
                     }
+
+                    if (!hasDrained) continue;
+
+                    if (consume) {
+                        // Restore Stack Count
+                        var result = handler.getContainer();
+                        result.setCount(stack.getCount());
+
+                        // Set Contents
+                        invo.setInventorySlotContents(i, result);
+                    }
+
+                    break;
                 }
-
-                if (hasDrained && consume) invo.setInventorySlotContents(i, handler.getContainer());
             }
-        }
 
-        if (updated) setBulkProgress(progress);
-        checkAndComplete(pInfo, quest, updated);
+            if (updated) setBulkProgress(progress);
+            checkAndComplete(pInfo, quest, updated);
+        }
     }
 
     private void checkAndComplete(ParticipantInfo pInfo, DBEntry<IQuest> quest, boolean resync) {


### PR DESCRIPTION
This PR fixes Fluid Tasks not working with certain stacked fluid containers, due to the default fluid container logic returning if the stack size is 1. For example, this happens with EnderIO Portable Tanks and GregTech CEu Fluid Cells.

See https://github.com/Nomi-CEu/Nomi-CEu/issues/938 for more information on the problem.

Note: Consuming tries to consume partial amounts of the fluid container when possible (e.g. if consuming 1 Bucket, and the fluid container is a stack of 4, it will try to take away 250mB from each container), but when this is not possible (buckets or GT Universal Cells), it will instead consume all the fluid of all the containers. This may not be the best solution, but I cannot think of a better one, as we cannot just create a new ItemStack.

This has been tested in Nomi-CEu for a while, which contains many non-consumable fluid tasks. For consumable ones, there was testing conducted, when this feature was a mixin. Testing has not been performed on its integration into BQu, but it is the exact same code.