### PR TITLE
Add Optional Fluid Task

### DIFF
--- a/src/main/java/betterquesting/core/proxies/CommonProxy.java
+++ b/src/main/java/betterquesting/core/proxies/CommonProxy.java
@@ -54,6 +54,7 @@ public class CommonProxy {
         taskReg.register(FactoryTaskInteractEntity.INSTANCE);
         taskReg.register(FactoryTaskTrigger.INSTANCE);
         taskReg.register(FactoryTaskOptionalRetrieval.INSTANCE);
+        taskReg.register(FactoryTaskOptionalFluid.INSTANCE);
 
         IRegistry<IFactoryData<IReward, NBTTagCompound>, IReward> rewardReg = QuestingAPI.getAPI(ApiReference.REWARD_REG);
         rewardReg.register(FactoryRewardChoice.INSTANCE);

--- a/src/main/java/betterquesting/questing/tasks/TaskOptionalFluid.java
+++ b/src/main/java/betterquesting/questing/tasks/TaskOptionalFluid.java
@@ -1,0 +1,25 @@
+package betterquesting.questing.tasks;
+
+import betterquesting.core.BetterQuesting;
+import betterquesting.questing.tasks.factory.FactoryTaskOptionalFluid;
+import net.minecraft.util.ResourceLocation;
+
+import java.util.UUID;
+
+public class TaskOptionalFluid extends TaskFluid {
+
+    @Override
+    public String getUnlocalisedName() {
+        return BetterQuesting.MODID_STD + ".task.optional_fluid";
+    }
+
+    @Override
+    public ResourceLocation getFactoryID() {
+        return FactoryTaskOptionalFluid.INSTANCE.getRegistryName();
+    }
+
+    @Override
+    public boolean ignored(UUID uuid) {
+        return true;
+    }
+}

--- a/src/main/java/betterquesting/questing/tasks/factory/FactoryTaskOptionalFluid.java
+++ b/src/main/java/betterquesting/questing/tasks/factory/FactoryTaskOptionalFluid.java
@@ -1,0 +1,30 @@
+package betterquesting.questing.tasks.factory;
+
+import betterquesting.api.questing.tasks.ITask;
+import betterquesting.api2.registry.IFactoryData;
+import betterquesting.core.BetterQuesting;
+import betterquesting.questing.tasks.TaskOptionalFluid;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.util.ResourceLocation;
+
+public class FactoryTaskOptionalFluid implements IFactoryData<ITask, NBTTagCompound> {
+
+    public static final FactoryTaskOptionalFluid INSTANCE = new FactoryTaskOptionalFluid();
+
+    @Override
+    public ResourceLocation getRegistryName() {
+        return new ResourceLocation(BetterQuesting.MODID_STD + ":optional_fluid");
+    }
+
+    @Override
+    public TaskOptionalFluid createNew() {
+        return new TaskOptionalFluid();
+    }
+
+    @Override
+    public TaskOptionalFluid loadFromData(NBTTagCompound json) {
+        TaskOptionalFluid task = new TaskOptionalFluid();
+        task.readFromNBT(json);
+        return task;
+    }
+}

--- a/src/main/resources/assets/betterquesting/lang/en_us.lang
+++ b/src/main/resources/assets/betterquesting/lang/en_us.lang
@@ -258,6 +258,7 @@ bq_standard.task.hunt=Mob Hunt Task
 bq_standard.task.scoreboard=Scoreboard Task
 bq_standard.task.location=Location Task
 bq_standard.task.fluid=Fluid Task
+bq_standard.task.optional_fluid=Optional Fluid Task
 bq_standard.task.meeting=Meeting Task
 bq_standard.task.xp=Experience Task
 bq_standard.task.block_break=Break Block Task


### PR DESCRIPTION
This PR simply adds an optional fluid task. Implementation is the same as the optional retrieval task.