### PR TITLE
Add `SequentialDataBase` as a better `SimpleDatabase`

### DIFF
--- a/src/main/java/betterquesting/api2/storage/SequentialDataBase.java
+++ b/src/main/java/betterquesting/api2/storage/SequentialDataBase.java
@@ -1,0 +1,52 @@
+package betterquesting.api2.storage;
+
+import java.util.BitSet;
+
+/**
+ * a database implementation specialized for ids that're sequential, dense and not randomly generated
+ * <p>
+ * see {@link RandomIndexDatabase} for database specialized in handling randomly generated ids
+ */
+public class SequentialDataBase<T> extends AbstractDatabase<T> {
+
+    private final BitSet ids = new BitSet();
+    /**
+     * the "smallest acceptable" id, any id smaller than this is considered as used and can
+     * be skipped when searching for new id, this condition can be maintained by:
+     * - refresh lowerBound after new id is generated: {@link #nextID()}
+     * - refresh lowerBound after one id is removed: {@link #removeID(int)}
+     */
+    private int lowerBound = 0;
+
+    @Override
+    public synchronized int nextID() {
+        int next = ids.nextSetBit(lowerBound);
+        lowerBound = next + 1;
+        return next;
+    }
+
+    @Override
+    public synchronized DBEntry<T> add(int id, T value) {
+        DBEntry<T> result = super.add(id, value);
+        // Don't add when an exception is thrown
+        ids.set(id);
+        // lowerBound = id; //no, lowerBound will not be refreshed here, delay to next `nextID()` call instead
+        return result;
+    }
+
+    @Override
+    public synchronized boolean removeID(int key) {
+        boolean result = super.removeID(key);
+        if (result) {
+            ids.clear(key);
+            lowerBound = Math.min(key, lowerBound);
+        }
+        return result;
+    }
+
+    @Override
+    public synchronized void reset() {
+        super.reset();
+        ids.clear();
+    }
+}

--- a/src/main/java/betterquesting/api2/storage/SequentialDataBase.java
+++ b/src/main/java/betterquesting/api2/storage/SequentialDataBase.java
@@ -20,7 +20,7 @@ public class SequentialDataBase<T> extends AbstractDatabase<T> {
 
     @Override
     public synchronized int nextID() {
-        int next = ids.nextSetBit(lowerBound);
+        int next = ids.nextClearBit(lowerBound);
         lowerBound = next + 1;
         return next;
     }

--- a/src/main/java/betterquesting/api2/storage/SimpleDatabase.java
+++ b/src/main/java/betterquesting/api2/storage/SimpleDatabase.java
@@ -5,17 +5,24 @@ import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
 public class SimpleDatabase<T> extends AbstractDatabase<T> {
 
     private final IntOpenHashSet ids = new IntOpenHashSet();
+    /**
+     * the "smallest acceptable" id, any id smaller than this is considered as used and can
+     * be skipped when searching for new id, this condition can be maintained by:
+     * - refresh lowerBound after new id is generated: {@link #nextID()}
+     * - refresh lowerBound after one id is removed: {@link #removeID(int)}
+     */
     private int lowerBound = 0;
 
     @Override
     public synchronized int nextID() {
         for (int i = lowerBound; i < Integer.MAX_VALUE ; i++) {
             if (!ids.contains(i)) {
+                ids.add(i);
                 lowerBound = i + 1;
                 return i;
             }
         }
-        throw new IllegalStateException(String.format("All integer id from 0 to %s have been consumed", Integer.MAX_VALUE));
+        throw new IllegalStateException(String.format("All integer id from 0 to %s have been consumed, it's abnormal", Integer.MAX_VALUE));
     }
 
     @Override

--- a/src/main/java/betterquesting/api2/storage/SimpleDatabase.java
+++ b/src/main/java/betterquesting/api2/storage/SimpleDatabase.java
@@ -5,11 +5,13 @@ import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
 public class SimpleDatabase<T> extends AbstractDatabase<T> {
 
     private final IntOpenHashSet ids = new IntOpenHashSet();
+    private int lowerBound = 0;
 
     @Override
     public synchronized int nextID() {
-        for (int i = 0; i < Integer.MAX_VALUE ; i++) {
+        for (int i = lowerBound; i < Integer.MAX_VALUE ; i++) {
             if (!ids.contains(i)) {
+                lowerBound = i + 1;
                 return i;
             }
         }
@@ -21,6 +23,7 @@ public class SimpleDatabase<T> extends AbstractDatabase<T> {
         DBEntry<T> result = super.add(id, value);
         // Don't add when an exception is thrown
         ids.add(id);
+        // lowerBound = id; //no, lowerBound will not be refreshed here, but delayed to next `nextID()` call
         return result;
     }
 
@@ -29,6 +32,7 @@ public class SimpleDatabase<T> extends AbstractDatabase<T> {
         boolean result = super.removeID(key);
         if (result) {
             ids.remove(key);
+            lowerBound = Math.min(key, lowerBound);
         }
         return result;
     }

--- a/src/main/java/betterquesting/api2/storage/SimpleDatabase.java
+++ b/src/main/java/betterquesting/api2/storage/SimpleDatabase.java
@@ -1,52 +1,8 @@
 package betterquesting.api2.storage;
 
-import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
+/**
+ * @see SequentialDataBase
+ */
+public class SimpleDatabase<T> extends SequentialDataBase<T> {
 
-public class SimpleDatabase<T> extends AbstractDatabase<T> {
-
-    private final IntOpenHashSet ids = new IntOpenHashSet();
-    /**
-     * the "smallest acceptable" id, any id smaller than this is considered as used and can
-     * be skipped when searching for new id, this condition can be maintained by:
-     * - refresh lowerBound after new id is generated: {@link #nextID()}
-     * - refresh lowerBound after one id is removed: {@link #removeID(int)}
-     */
-    private int lowerBound = 0;
-
-    @Override
-    public synchronized int nextID() {
-        for (int i = lowerBound; i < Integer.MAX_VALUE ; i++) {
-            if (!ids.contains(i)) {
-                ids.add(i);
-                lowerBound = i + 1;
-                return i;
-            }
-        }
-        throw new IllegalStateException(String.format("All integer id from 0 to %s have been consumed, it's abnormal", Integer.MAX_VALUE));
-    }
-
-    @Override
-    public synchronized DBEntry<T> add(int id, T value) {
-        DBEntry<T> result = super.add(id, value);
-        // Don't add when an exception is thrown
-        ids.add(id);
-        // lowerBound = id; //no, lowerBound will not be refreshed here, but delayed to next `nextID()` call
-        return result;
-    }
-
-    @Override
-    public synchronized boolean removeID(int key) {
-        boolean result = super.removeID(key);
-        if (result) {
-            ids.remove(key);
-            lowerBound = Math.min(key, lowerBound);
-        }
-        return result;
-    }
-
-    @Override
-    public synchronized void reset() {
-        super.reset();
-        ids.clear();
-    }
 }

--- a/src/main/java/betterquesting/api2/storage/SimpleDatabase.java
+++ b/src/main/java/betterquesting/api2/storage/SimpleDatabase.java
@@ -1,38 +1,41 @@
 package betterquesting.api2.storage;
 
-import java.util.BitSet;
-import java.util.Collections;
-import java.util.List;
-import java.util.TreeMap;
+import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
 
 public class SimpleDatabase<T> extends AbstractDatabase<T> {
 
-    private final BitSet idMap = new BitSet();
+    private final IntOpenHashSet ids = new IntOpenHashSet();
 
     @Override
     public synchronized int nextID() {
-        return idMap.nextClearBit(0);
+        for (int i = 0; i < Integer.MAX_VALUE ; i++) {
+            if (!ids.contains(i)) {
+                return i;
+            }
+        }
+        throw new IllegalStateException(String.format("All integer id from 0 to %s have been consumed", Integer.MAX_VALUE));
     }
 
     @Override
     public synchronized DBEntry<T> add(int id, T value) {
         DBEntry<T> result = super.add(id, value);
         // Don't add when an exception is thrown
-        idMap.set(id);
+        ids.add(id);
         return result;
     }
 
     @Override
     public synchronized boolean removeID(int key) {
         boolean result = super.removeID(key);
-        if (result) idMap.clear(key);
+        if (result) {
+            ids.remove(key);
+        }
         return result;
     }
 
     @Override
     public synchronized void reset() {
         super.reset();
-        idMap.clear();
+        ids.clear();
     }
-
 }


### PR DESCRIPTION
This PR is made for resolving this issue:

![img](https://github.com/user-attachments/assets/8638a6f8-47fb-4d4e-9481-4ae8c8ae2e5e)

but unlike PR128, who made a stupid and not-working `LongSet`, this PR replaced `BitSet` with `IntOpenHashSet` for id usage lookup, with a `lowerBound` for skipping ids that are certainly used when generating new id, it works like this:

- when generating new id through `nextID`, it will return the first id not in `ids` and in range `[lowerBound, Integer.MAX_VALUE)`, if found, `lowerBound` will be set to id+1, and the id will be added to `ids`
- when removing id (`removeID()`), lowerBound can be set to the removed id because it might be the smallest unused id now. But note that this will not happen when removed id is smaller than `lowerBound`