### PR TITLE
Use RandomIndexDB for questlines & entries

### DIFF
--- a/src/main/java/betterquesting/questing/QuestLine.java
+++ b/src/main/java/betterquesting/questing/QuestLine.java
@@ -6,7 +6,7 @@ import betterquesting.api.questing.IQuestLine;
 import betterquesting.api.questing.IQuestLineEntry;
 import betterquesting.api.utils.BigItemStack;
 import betterquesting.api2.storage.DBEntry;
-import betterquesting.api2.storage.SimpleDatabase;
+import betterquesting.api2.storage.RandomIndexDatabase;
 import betterquesting.storage.PropertyContainer;
 import net.minecraft.init.Items;
 import net.minecraft.nbt.NBTTagCompound;
@@ -15,7 +15,7 @@ import net.minecraft.nbt.NBTTagList;
 import javax.annotation.Nullable;
 import java.util.List;
 
-public class QuestLine extends SimpleDatabase<IQuestLineEntry> implements IQuestLine {
+public class QuestLine extends RandomIndexDatabase<IQuestLineEntry> implements IQuestLine {
     private PropertyContainer info = new PropertyContainer();
 
     public QuestLine() {

--- a/src/main/java/betterquesting/questing/QuestLineDatabase.java
+++ b/src/main/java/betterquesting/questing/QuestLineDatabase.java
@@ -3,7 +3,7 @@ package betterquesting.questing;
 import betterquesting.api.questing.IQuestLine;
 import betterquesting.api.questing.IQuestLineDatabase;
 import betterquesting.api2.storage.DBEntry;
-import betterquesting.api2.storage.SimpleDatabase;
+import betterquesting.api2.storage.RandomIndexDatabase;
 import betterquesting.api2.utils.QuestLineSorter;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
@@ -15,7 +15,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 
-public final class QuestLineDatabase extends SimpleDatabase<IQuestLine> implements IQuestLineDatabase {
+public final class QuestLineDatabase extends RandomIndexDatabase<IQuestLine> implements IQuestLineDatabase {
     public static final QuestLineDatabase INSTANCE = new QuestLineDatabase();
 
     private final List<Integer> lineOrder = new ArrayList<>();


### PR DESCRIPTION
Uses the random index database added in #113 for questline entries (the quests as an entry in a questline) and questlines (the questlines themselves). I believe because quests were changed to use random IDs but the quest entries were not, the bitset `idMap` in `SimpleDatabase` that `QuestLine` extends ends up being sparsely populated and expands to very large sizes, causing excessive memory usage.

Should be a better fix than #129 for specifically questlines, although that PR may still have use in other databases that use `SimpleDatabase`.