### PR TITLE
Improve Retrieval/Fluid task inventory detection

### DIFF
--- a/src/main/java/betterquesting/api/properties/IPropertyListener.java
+++ b/src/main/java/betterquesting/api/properties/IPropertyListener.java
@@ -1,0 +1,5 @@
+package betterquesting.api.properties;
+
+public interface IPropertyListener<T> {
+    void propertyChanged(IPropertyType<T> prop, T newValue);
+}

--- a/src/main/java/betterquesting/api/properties/IPropertyType.java
+++ b/src/main/java/betterquesting/api/properties/IPropertyType.java
@@ -11,4 +11,8 @@ public interface IPropertyType<T> {
     T readValue(NBTBase nbt);
 
     NBTBase writeValue(T value);
+
+    void addListener(IPropertyListener<T> listener);
+
+    void notifyListeners(T newValue);
 }

--- a/src/main/java/betterquesting/api/properties/basic/PropertyTypeBase.java
+++ b/src/main/java/betterquesting/api/properties/basic/PropertyTypeBase.java
@@ -1,11 +1,16 @@
 package betterquesting.api.properties.basic;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import betterquesting.api.properties.IPropertyListener;
 import betterquesting.api.properties.IPropertyType;
 import net.minecraft.util.ResourceLocation;
 
 public abstract class PropertyTypeBase<T> implements IPropertyType<T> {
     private final ResourceLocation key;
     private final T def;
+    private final List<IPropertyListener<T>> listeners = new ArrayList<>();
 
     public PropertyTypeBase(ResourceLocation key, T def) {
         this.key = key;
@@ -20,5 +25,17 @@ public abstract class PropertyTypeBase<T> implements IPropertyType<T> {
     @Override
     public T getDefault() {
         return def;
+    }
+
+    @Override
+    public void addListener(IPropertyListener<T> listener) {
+        listeners.add(listener);
+    }
+
+    @Override
+    public void notifyListeners(T newValue) {
+        for (var listener : listeners) {
+            listener.propertyChanged(this, newValue);
+        }
     }
 }

--- a/src/main/java/betterquesting/api/questing/IQuestDatabase.java
+++ b/src/main/java/betterquesting/api/questing/IQuestDatabase.java
@@ -1,10 +1,29 @@
 package betterquesting.api.questing;
 
+import betterquesting.api2.storage.DBEntry;
 import betterquesting.api2.storage.IDatabase;
 import betterquesting.api2.storage.INBTPartial;
 import betterquesting.api2.storage.INBTProgress;
+import betterquesting.api2.utils.ParticipantInfo;
 import net.minecraft.nbt.NBTTagList;
+
+import javax.annotation.Nonnull;
+import java.util.List;
+import java.util.UUID;
 
 public interface IQuestDatabase extends IDatabase<IQuest>, INBTPartial<NBTTagList, Integer>, INBTProgress<NBTTagList> {
     IQuest createNew(int id);
+
+    /**
+     * Variant of {@link #bulkLookup(int...)} that caches the lookup of shared quests.
+     * @param pInfo the participant to get shared quests from
+     * @return the (cached) database entries for the shared quests
+     */
+    List<DBEntry<IQuest>> bulkLookupShared(@Nonnull ParticipantInfo pInfo);
+
+    /**
+     * Invalidate the cached result from {@link #bulkLookupShared(ParticipantInfo)} for a given participant.
+     * @param participantId the participant's id
+     */
+    void invalidateBulkCache(@Nonnull UUID participantId);
 }

--- a/src/main/java/betterquesting/api/questing/party/IParty.java
+++ b/src/main/java/betterquesting/api/questing/party/IParty.java
@@ -11,6 +11,8 @@ import java.util.List;
 import java.util.UUID;
 
 public interface IParty extends INBTSaveLoad<NBTTagCompound> {
+    UUID getID();
+
     IPropertyContainer getProperties();
 
     void kickUser(@Nonnull UUID uuid);

--- a/src/main/java/betterquesting/api/storage/BQ_Settings.java
+++ b/src/main/java/betterquesting/api/storage/BQ_Settings.java
@@ -38,4 +38,6 @@ public class BQ_Settings {
 
     public static boolean spawnWithQuestBook = true;
     public static boolean saveQuestsWithNames = false;
+
+    public static int retrievalDetectionDelay = 20;
 }

--- a/src/main/java/betterquesting/api/utils/BigItemStack.java
+++ b/src/main/java/betterquesting/api/utils/BigItemStack.java
@@ -1,11 +1,11 @@
 package betterquesting.api.utils;
 
 import betterquesting.NBTUtil;
-import betterquesting.questing.party.PartyInventory;
 import net.minecraft.block.Block;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.StringUtils;
 import net.minecraftforge.oredict.OreDictionary;
 import net.minecraftforge.oredict.OreIngredient;
@@ -36,7 +36,7 @@ public class BigItemStack {
         baseStack = stack.copy();
         this.stackSize = baseStack.getCount();
         baseStack.setCount(1);
-        this.hashKey = PartyInventory.getHashKey(baseStack);
+        this.hashKey = getHashKey(baseStack);
     }
 
     public BigItemStack(@Nonnull Block block) {
@@ -62,7 +62,15 @@ public class BigItemStack {
     public BigItemStack(@Nonnull Item item, int amount, int damage) {
         baseStack = new ItemStack(item, 1, damage);
         this.stackSize = amount;
-        this.hashKey = PartyInventory.getHashKey(baseStack);
+        this.hashKey = getHashKey(baseStack);
+    }
+
+    public static int getHashKey(ItemStack stack) {
+        ResourceLocation registryName = stack.getItem().getRegistryName();
+        if (registryName == null) {
+            return 0;
+        }
+        return registryName.hashCode();
     }
 
     /**
@@ -73,7 +81,7 @@ public class BigItemStack {
     }
 
     /**
-     * @see PartyInventory#getHashKey(ItemStack)
+     * @see BigItemStack#getHashKey(ItemStack)
      * @return the hash key to use for this BigItemStack to compare with other stacks
      */
     public int getHashKey() {
@@ -167,7 +175,7 @@ public class BigItemStack {
         this.setOreDict(tags.getString("OreDict"));
         this.baseStack = new ItemStack(itemNBT); // Minecraft does the ID conversions for me
         if (tags.getShort("Damage") < 0) this.baseStack.setItemDamage(OreDictionary.WILDCARD_VALUE);
-        this.hashKey = PartyInventory.getHashKey(baseStack);
+        this.hashKey = getHashKey(baseStack);
     }
 
     @Deprecated

--- a/src/main/java/betterquesting/api/utils/BigItemStack.java
+++ b/src/main/java/betterquesting/api/utils/BigItemStack.java
@@ -1,6 +1,7 @@
 package betterquesting.api.utils;
 
 import betterquesting.NBTUtil;
+import betterquesting.questing.party.PartyInventory;
 import net.minecraft.block.Block;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
@@ -28,10 +29,14 @@ public class BigItemStack {
     private String oreDict = DEFAULT_OREDICT;
     private OreIngredient oreIng = NO_ORE;
 
+    // Cache item key to use for comparing to PartyInventory
+    private final int hashKey;
+
     public BigItemStack(ItemStack stack) {
         baseStack = stack.copy();
         this.stackSize = baseStack.getCount();
         baseStack.setCount(1);
+        this.hashKey = PartyInventory.getHashKey(baseStack);
     }
 
     public BigItemStack(@Nonnull Block block) {
@@ -57,6 +62,7 @@ public class BigItemStack {
     public BigItemStack(@Nonnull Item item, int amount, int damage) {
         baseStack = new ItemStack(item, 1, damage);
         this.stackSize = amount;
+        this.hashKey = PartyInventory.getHashKey(baseStack);
     }
 
     /**
@@ -64,6 +70,14 @@ public class BigItemStack {
      */
     public ItemStack getBaseStack() {
         return baseStack;
+    }
+
+    /**
+     * @see PartyInventory#getHashKey(ItemStack)
+     * @return the hash key to use for this BigItemStack to compare with other stacks
+     */
+    public int getHashKey() {
+        return hashKey;
     }
 
     public boolean hasOreDict() {
@@ -153,6 +167,7 @@ public class BigItemStack {
         this.setOreDict(tags.getString("OreDict"));
         this.baseStack = new ItemStack(itemNBT); // Minecraft does the ID conversions for me
         if (tags.getShort("Damage") < 0) this.baseStack.setItemDamage(OreDictionary.WILDCARD_VALUE);
+        this.hashKey = PartyInventory.getHashKey(baseStack);
     }
 
     @Deprecated

--- a/src/main/java/betterquesting/api/utils/ItemComparison.java
+++ b/src/main/java/betterquesting/api/utils/ItemComparison.java
@@ -235,4 +235,12 @@ public class ItemComparison {
 
         return false; // No shared ore dictionary types
     }
+
+    /**
+     * Check if a BigItemStack and a regular ItemStack match with optional NBT and OreDictionary checks
+     */
+    public static boolean BigStackMatch(BigItemStack req, ItemStack stack, boolean ignoreNBT, boolean partialMatch) {
+        return StackMatch(req.getBaseStack(), stack, !ignoreNBT, partialMatch)
+                || (req.hasOreDict() && OreDictionaryMatch(req.getOreIngredient(), req.GetTagCompound(), stack, !ignoreNBT, partialMatch));
+    }
 }

--- a/src/main/java/betterquesting/api2/cache/QuestCache.java
+++ b/src/main/java/betterquesting/api2/cache/QuestCache.java
@@ -19,6 +19,7 @@ import net.minecraft.nbt.NBTTagList;
 import net.minecraft.util.NonNullList;
 import net.minecraftforge.common.util.INBTSerializable;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.TreeSet;
 import java.util.UUID;
@@ -120,6 +121,11 @@ public class QuestCache implements INBTSerializable<NBTTagCompound> {
                 tmpVisible.add(entry.getID());
             }
         }
+        int[] tmpActiveArr = tmpActive.toIntArray();
+        if (!Arrays.equals(getActiveQuests(), tmpActiveArr)) {
+            QuestingAPI.getAPI(ApiReference.QUEST_DB).invalidateBulkCache(uuid);
+        }
+
         visibleQuests.clear();
         activeQuests.clear();
         resetSchedule.clear();
@@ -127,7 +133,7 @@ public class QuestCache implements INBTSerializable<NBTTagCompound> {
 
         // Copy the temp sorted sets to array lists for better locality
         visibleQuests.addAll(tmpVisible);
-        activeQuests.addAll(tmpActive);
+        activeQuests.addElements(0, tmpActiveArr);
         resetSchedule.addAll(tmpReset);
 
         autoClaims.addAll(tmpAutoClaim);

--- a/src/main/java/betterquesting/api2/cache/QuestCache.java
+++ b/src/main/java/betterquesting/api2/cache/QuestCache.java
@@ -9,6 +9,9 @@ import betterquesting.api.storage.BQ_Settings;
 import betterquesting.api2.storage.DBEntry;
 import betterquesting.network.handlers.NetCacheSync;
 import betterquesting.questing.QuestDatabase;
+import it.unimi.dsi.fastutil.ints.IntArrayList;
+import it.unimi.dsi.fastutil.ints.IntRBTreeSet;
+import it.unimi.dsi.fastutil.ints.IntSortedSet;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.nbt.NBTTagCompound;
@@ -22,42 +25,30 @@ import java.util.UUID;
 
 public class QuestCache implements INBTSerializable<NBTTagCompound> {
     // Quests that are visible to the player
-    private final TreeSet<Integer> visibleQuests = new TreeSet<>();
+    private final IntArrayList visibleQuests = new IntArrayList();
 
     // Quests that are currently being undertaken. NOTE: Quests can be locked but still processing data if configured to do so
-    private final TreeSet<Integer> activeQuests = new TreeSet<>();
+    private final IntArrayList activeQuests = new IntArrayList();
 
     // Quests and their scheduled time of being reset
     private final TreeSet<QResetTime> resetSchedule = new TreeSet<>((o1, o2) -> o1.questID == o2.questID ? 0 : Long.compare(o1.time, o2.time));
 
     // Quests with pending auto claims (usually should be empty unless a condition needs to be met)
-    private final TreeSet<Integer> autoClaims = new TreeSet<>();
+    private final IntArrayList autoClaims = new IntArrayList();
 
     // Quests that need to be sent to the client to update progression (NOT for edits. Handle that elsewhere)
     private final TreeSet<Integer> markedDirty = new TreeSet<>();
 
     public synchronized int[] getActiveQuests() {
-        // Probably a better way of doing this but this will do for now
-        int i = 0;
-        int[] aryAct = new int[activeQuests.size()];
-        for (Integer q : activeQuests) aryAct[i++] = q;
-        return aryAct;
+        return activeQuests.toIntArray();
     }
 
     public synchronized int[] getVisibleQuests() {
-        // Probably a better way of doing this but this will do for now
-        int i = 0;
-        int[] aryVis = new int[visibleQuests.size()];
-        for (Integer q : visibleQuests) aryVis[i++] = q;
-        return aryVis;
+        return visibleQuests.toIntArray();
     }
 
     public synchronized int[] getPendingAutoClaims() {
-        // Probably a better way of doing this but this will do for now
-        int i = 0;
-        int[] aryAC = new int[autoClaims.size()];
-        for (Integer q : autoClaims) aryAC[i++] = q;
-        return aryAC;
+        return autoClaims.toIntArray();
     }
 
     public synchronized QResetTime[] getScheduledResets() // Already sorted by time
@@ -95,10 +86,11 @@ public class QuestCache implements INBTSerializable<NBTTagCompound> {
         UUID uuid = QuestingAPI.getQuestingUUID(player);
         List<DBEntry<IQuest>> questDB = QuestingAPI.getAPI(ApiReference.QUEST_DB).getEntries();
 
-        NonNullList<Integer> tmpVisible = NonNullList.create();
-        NonNullList<Integer> tmpActive = NonNullList.create();
+        IntSortedSet tmpVisible = new IntRBTreeSet();
+        IntSortedSet tmpActive = new IntRBTreeSet();
+        IntSortedSet tmpAutoClaim = new IntRBTreeSet();
+
         NonNullList<QResetTime> tmpReset = NonNullList.create();
-        NonNullList<Integer> tmpAutoClaim = NonNullList.create();
 
         for (DBEntry<IQuest> entry : questDB) {
             if (entry.getValue().isUnlocked(uuid) || entry.getValue().isComplete(uuid) || entry.getValue().getProperty(NativeProps.LOCKED_PROGRESS)) // Unlocked or actively processing progression data
@@ -128,17 +120,16 @@ public class QuestCache implements INBTSerializable<NBTTagCompound> {
                 tmpVisible.add(entry.getID());
             }
         }
-
         visibleQuests.clear();
-        visibleQuests.addAll(tmpVisible);
-
         activeQuests.clear();
-        activeQuests.addAll(tmpActive);
-
         resetSchedule.clear();
+        autoClaims.clear();
+
+        // Copy the temp sorted sets to array lists for better locality
+        visibleQuests.addAll(tmpVisible);
+        activeQuests.addAll(tmpActive);
         resetSchedule.addAll(tmpReset);
 
-        autoClaims.clear();
         autoClaims.addAll(tmpAutoClaim);
 
         if (player instanceof EntityPlayerMP) NetCacheSync.sendSync((EntityPlayerMP) player);
@@ -173,9 +164,9 @@ public class QuestCache implements INBTSerializable<NBTTagCompound> {
         autoClaims.clear();
         markedDirty.clear();
 
-        for (int i : nbt.getIntArray("visibleQuests")) visibleQuests.add(i);
-        for (int i : nbt.getIntArray("activeQuests")) activeQuests.add(i);
-        for (int i : nbt.getIntArray("autoClaims")) autoClaims.add(i);
+        visibleQuests.addElements(0, nbt.getIntArray("visibleQuests"));
+        activeQuests.addElements(0, nbt.getIntArray("activeQuests"));
+        autoClaims.addElements(0, nbt.getIntArray("autoClaims"));
         for (int i : nbt.getIntArray("markedDirty")) markedDirty.add(i);
 
         NBTTagList tagList = nbt.getTagList("resetSchedule", 10);

--- a/src/main/java/betterquesting/api2/storage/NaiveLookupLogic.java
+++ b/src/main/java/betterquesting/api2/storage/NaiveLookupLogic.java
@@ -1,14 +1,14 @@
 package betterquesting.api2.storage;
 
-import gnu.trove.map.TIntObjectMap;
-import gnu.trove.map.hash.TIntObjectHashMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 
 import java.util.ArrayList;
 import java.util.List;
 
 class NaiveLookupLogic<T> extends LookupLogic<T> {
 
-    private TIntObjectMap<DBEntry<T>> backingMap;
+    private Int2ObjectMap<DBEntry<T>> backingMap;
 
     public NaiveLookupLogic(AbstractDatabase<T> abstractDatabase) {
         super(abstractDatabase);
@@ -23,7 +23,7 @@ class NaiveLookupLogic<T> extends LookupLogic<T> {
     @Override
     public List<DBEntry<T>> bulkLookup(int[] keys) {
         if (backingMap == null) {
-            backingMap = new TIntObjectHashMap<>(abstractDatabase.mapDB.size());
+            backingMap = new Int2ObjectOpenHashMap<>(abstractDatabase.mapDB.size());
             for (DBEntry<T> entry : getRefCache()) {
                 backingMap.put(entry.getID(), entry);
             }

--- a/src/main/java/betterquesting/api2/utils/ParticipantInfo.java
+++ b/src/main/java/betterquesting/api2/utils/ParticipantInfo.java
@@ -5,6 +5,7 @@ import betterquesting.api.questing.party.IParty;
 import betterquesting.api2.cache.CapabilityProviderQuestCache;
 import betterquesting.api2.cache.QuestCache;
 import betterquesting.api2.storage.DBEntry;
+import betterquesting.questing.party.PartyInventory;
 import betterquesting.questing.party.PartyManager;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.server.MinecraftServer;
@@ -23,6 +24,8 @@ public class ParticipantInfo {
     public final List<UUID> ACTIVE_UUIDS;
 
     public final DBEntry<IParty> PARTY_INSTANCE;
+
+    private PartyInventory inventory;
 
     public ParticipantInfo(@Nonnull EntityPlayer player) {
         this.PLAYER = player;
@@ -93,4 +96,12 @@ public class ParticipantInfo {
         PartyQuestMerger merger = new PartyQuestMerger(playerQuestLists);
         return merger.getSharedQuests();
     }
+
+    public PartyInventory getPartyInventory() {
+        if (inventory == null) {
+            inventory = new PartyInventory(PLAYER, ACTIVE_PLAYERS);
+        }
+        return inventory;
+    }
+
 }

--- a/src/main/java/betterquesting/api2/utils/ParticipantInfo.java
+++ b/src/main/java/betterquesting/api2/utils/ParticipantInfo.java
@@ -89,7 +89,7 @@ public class ParticipantInfo {
         if (playerQuestLists.isEmpty()) {
             return new int[0];
         }
-        else if (playerQuestLists.size() == 1) {
+        if (playerQuestLists.size() == 1) {
             // No need to merge
             return playerQuestLists.get(0);
         }

--- a/src/main/java/betterquesting/api2/utils/ParticipantInfo.java
+++ b/src/main/java/betterquesting/api2/utils/ParticipantInfo.java
@@ -76,15 +76,21 @@ public class ParticipantInfo {
     @Nonnull
     public int[] getSharedQuests() // Returns an array of all quests which one or more participants have unlocked
     {
-        TreeSet<Integer> active = new TreeSet<>();
-        ACTIVE_PLAYERS.forEach((p) -> {
-            QuestCache qc = p.getCapability(CapabilityProviderQuestCache.CAP_QUEST_CACHE, null);
-            if (qc != null) for (int value : qc.getActiveQuests()) active.add(value);
-        });
-
-        int[] shared = new int[active.size()];
-        int i = 0;
-        for (int value : active) shared[i++] = value;
-        return shared;
+        List<int[]> playerQuestLists = new ArrayList<>(ACTIVE_PLAYERS.size());
+        for (var player : ACTIVE_PLAYERS) {
+            QuestCache qc = player.getCapability(CapabilityProviderQuestCache.CAP_QUEST_CACHE, null);
+            if (qc != null) {
+                playerQuestLists.add(qc.getActiveQuests());
+            }
+        }
+        if (playerQuestLists.isEmpty()) {
+            return new int[0];
+        }
+        else if (playerQuestLists.size() == 1) {
+            // No need to merge
+            return playerQuestLists.get(0);
+        }
+        PartyQuestMerger merger = new PartyQuestMerger(playerQuestLists);
+        return merger.getSharedQuests();
     }
 }

--- a/src/main/java/betterquesting/api2/utils/PartyQuestMerger.java
+++ b/src/main/java/betterquesting/api2/utils/PartyQuestMerger.java
@@ -70,8 +70,7 @@ public class PartyQuestMerger {
                 // Preload the first element
                 bins[i] = playerActiveQuests[0];
                 binIndices[i]++;
-            }
-            else {
+            } else {
                 bins[i] = EMPTY_BIN;
             }
 
@@ -112,19 +111,16 @@ public class PartyQuestMerger {
             // if right is empty, left loses
             winner = right;
             loser = left;
-        }
-        else if (bins[left] == EMPTY_BIN) {
+        } else if (bins[left] == EMPTY_BIN) {
             // if left is empty, right loses
             winner = left;
             loser = right;
-        }
-        else {
+        } else {
             // play the game
             if (bins[right] > bins[left]) {
                 winner = right;
                 loser = left;
-            }
-            else {
+            } else {
                 winner = left;
                 loser = right;
             }
@@ -151,8 +147,7 @@ public class PartyQuestMerger {
             // if there's still elements in the bin, get the next element
             int[] binSource = binSources[curMin];
             bins[curMin] = binSource[binIndices[curMin]++];
-        }
-        else {
+        } else {
             // otherwise the bin is empty
             bins[curMin] = EMPTY_BIN;
             fullBins--;

--- a/src/main/java/betterquesting/api2/utils/PartyQuestMerger.java
+++ b/src/main/java/betterquesting/api2/utils/PartyQuestMerger.java
@@ -1,0 +1,190 @@
+package betterquesting.api2.utils;
+
+import it.unimi.dsi.fastutil.ints.IntArrayList;
+
+import java.util.List;
+
+/**
+ * An optimized party quest merger implementing k-way merge (using a loser tree).
+ * @see <a href="https://www.ahl27.com/posts/2024/12/loser-trees-io/">implementation based on this article</a>
+ */
+public class PartyQuestMerger {
+    private static final int EMPTY_BIN = -1;
+
+    private final int numBins;
+    /** Number of bins with data left */
+    private int fullBins;
+
+    /** The tournament tree */
+    private final int[] values;
+    /** Array of each party member's active quests */
+    private final int[][] binSources;
+    /** Index into each active quest source */
+    private final int[] binIndices;
+    /** Current head quest of each bin */
+    private final int[] bins;
+
+    /** The merged, sorted list of (active) quest ids for this party. */
+    private final IntArrayList merged;
+
+    // Temp values
+    private int oLoser;
+    private int oWinner;
+    private int prevOutput = -1;
+
+    /**
+     * @param activeQuestsPerPlayer a non-empty list of sorted active quests per player
+     */
+    public PartyQuestMerger(List<int[]> activeQuestsPerPlayer) {
+        int numBins = activeQuestsPerPlayer.size();
+        // Ensure number of bins used for tree is a power of 2
+        int actualBins = 1;
+        while (actualBins < numBins) actualBins <<= 1;
+
+        this.numBins = actualBins;
+        this.fullBins = numBins;
+
+        // Initialize tree indices
+        values = new int[actualBins * 2];
+        for (int i = 0; i < actualBins; i++) {
+            // First half are the internal nodes' indices
+            values[i] = -1;
+            // Second half are the leaves, fill with bin indices
+            values[i + actualBins] = i;
+        }
+
+        int maxNumQuests = 0;
+        binSources = new int[actualBins][];
+        binIndices = new int[actualBins];
+        bins = new int[actualBins];
+        for (int i = 0; i < bins.length; i++) {
+            // Init any bins used for padding actualBins to next power of 2
+            if (i >= numBins) {
+                binSources[i] = new int[0];
+                bins[i] = EMPTY_BIN;
+                continue;
+            }
+            int[] playerActiveQuests = activeQuestsPerPlayer.get(i);
+            binSources[i] = playerActiveQuests;
+            if (playerActiveQuests.length > 0) {
+                // Preload the first element
+                bins[i] = playerActiveQuests[0];
+                binIndices[i]++;
+            }
+            else {
+                bins[i] = EMPTY_BIN;
+            }
+
+            maxNumQuests = Math.max(maxNumQuests, playerActiveQuests.length);
+        }
+        // Start with a size of the player with the most quests
+        merged = new IntArrayList(maxNumQuests);
+    }
+
+    /**
+     * Get the combined list of quests unlocked by party members.
+     * @return array of shared quest ids
+     */
+    public int[] getSharedQuests() {
+        buildGame();
+        runGame();
+        return merged.toIntArray();
+    }
+
+    private void playGame() {
+        if (bins[oWinner] == EMPTY_BIN) {
+            return;
+        }
+        if (bins[oLoser] == EMPTY_BIN || bins[oLoser] > bins[oWinner]) {
+            swapOutcome();
+        }
+    }
+
+    private int playRecursiveGameAtNodeI(int i) {
+        if (i >= numBins) {
+            return i - numBins;
+        }
+        int left = playRecursiveGameAtNodeI(2 * i);
+        int right = playRecursiveGameAtNodeI((2 * i) + 1);
+        // The loser of the game is promoted
+        int loser, winner;
+        if (bins[right] == EMPTY_BIN) {
+            // if right is empty, left loses
+            winner = right;
+            loser = left;
+        }
+        else if (bins[left] == EMPTY_BIN) {
+            // if left is empty, right loses
+            winner = left;
+            loser = right;
+        }
+        else {
+            // play the game
+            if (bins[right] > bins[left]) {
+                winner = right;
+                loser = left;
+            }
+            else {
+                winner = left;
+                loser = right;
+            }
+        }
+        // in loser trees, the loser is promoted, winner stays
+        values[i] = winner;
+        return loser;
+    }
+
+    private void buildGame() {
+        values[0] = playRecursiveGameAtNodeI(1);
+    }
+
+    private void popOutput() {
+        int curMin = values[0];
+        // Deduplicate ids before outputting
+        int id = bins[curMin];
+        if (id != prevOutput) {
+            merged.add(id);
+        }
+        prevOutput = id;
+
+        if (binIndices[curMin] < binSources[curMin].length) {
+            // if there's still elements in the bin, get the next element
+            int[] binSource = binSources[curMin];
+            bins[curMin] = binSource[binIndices[curMin]++];
+        }
+        else {
+            // otherwise the bin is empty
+            bins[curMin] = EMPTY_BIN;
+            fullBins--;
+        }
+    }
+
+    private void runGame() {
+        popOutput();
+        while (fullBins > 0) {
+            int lastPopped = values[0];
+            int curNode = lastPopped + numBins;
+            oLoser = lastPopped;
+
+            while (curNode > 0) {
+                oWinner = values[curNode];
+                playGame();
+                // Winner stays at this node
+                values[curNode] = oWinner;
+                // Move to parent node
+                curNode /= 2;
+            }
+
+            // Loser is promoted
+            values[curNode] = oLoser;
+            // Pop the next output
+            popOutput();
+        }
+    }
+
+    private void swapOutcome() {
+        int temp = oLoser;
+        oLoser = oWinner;
+        oWinner = temp;
+    }
+}

--- a/src/main/java/betterquesting/client/gui2/GuiQuest.java
+++ b/src/main/java/betterquesting/client/gui2/GuiQuest.java
@@ -377,7 +377,7 @@ public class GuiQuest extends GuiScreenCanvas implements IPEventListener, INeeds
 
             String taskName = (i + 1) + ". " + QuestTranslation.translate(tsk.getUnlocalisedName());
             if (tsk instanceof TaskRetrieval) {
-                EnumLogic entryLogic = ((TaskRetrieval) tsk).entryLogic;
+                EnumLogic entryLogic = ((TaskRetrieval) tsk).getEntryLogic();
                 if (entryLogic != EnumLogic.AND)
                     taskName += " (" + entryLogic + ")";
             }

--- a/src/main/java/betterquesting/client/gui2/tasks/PanelTaskFluid.java
+++ b/src/main/java/betterquesting/client/gui2/tasks/PanelTaskFluid.java
@@ -39,7 +39,7 @@ public class PanelTaskFluid extends CanvasMinimum {
         int listW = initialRect.getWidth();
 
         UUID uuid = QuestingAPI.getQuestingUUID(Minecraft.getMinecraft().player);
-        int[] progress = task.getUsersProgress(uuid);
+        int[] progress = task.getUserProgress(uuid);
         boolean isComplete = task.isComplete(uuid);
 
         String sCon = (task.consume ? TextFormatting.RED : TextFormatting.GREEN) + QuestTranslation.translate(task.consume ? "gui.yes" : "gui.no");

--- a/src/main/java/betterquesting/client/gui2/tasks/PanelTaskRetrieval.java
+++ b/src/main/java/betterquesting/client/gui2/tasks/PanelTaskRetrieval.java
@@ -34,7 +34,7 @@ public class PanelTaskRetrieval extends CanvasMinimum {
         int listW = initialRect.getWidth();
 
         UUID uuid = QuestingAPI.getQuestingUUID(Minecraft.getMinecraft().player);
-        int[] progress = task.getUsersProgress(uuid);
+        int[] progress = task.getUserProgress(uuid);
         boolean isComplete = task.isComplete(uuid);
 
         String sCon = (task.consume ? TextFormatting.RED : TextFormatting.GREEN) + QuestTranslation.translate(task.consume ? "gui.yes" : "gui.no");

--- a/src/main/java/betterquesting/client/importers/ImportedQuests.java
+++ b/src/main/java/betterquesting/client/importers/ImportedQuests.java
@@ -4,10 +4,12 @@ import betterquesting.api.questing.IQuest;
 import betterquesting.api.questing.IQuestDatabase;
 import betterquesting.api2.storage.DBEntry;
 import betterquesting.api2.storage.SimpleDatabase;
+import betterquesting.api2.utils.ParticipantInfo;
 import betterquesting.questing.QuestInstance;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -18,6 +20,15 @@ public class ImportedQuests extends SimpleDatabase<IQuest> implements IQuestData
     @Override
     public IQuest createNew(int id) {
         return this.add(id, new QuestInstance()).getValue();
+    }
+
+    @Override
+    public List<DBEntry<IQuest>> bulkLookupShared(@Nonnull ParticipantInfo pInfo) {
+        return bulkLookup(pInfo.getSharedQuests());
+    }
+
+    @Override
+    public void invalidateBulkCache(@Nonnull UUID participantId) {
     }
 
     @Override

--- a/src/main/java/betterquesting/handlers/ConfigHandler.java
+++ b/src/main/java/betterquesting/handlers/ConfigHandler.java
@@ -42,6 +42,8 @@ public class ConfigHandler {
 
         BQ_Settings.spawnWithQuestBook = config.getBoolean("Spawn with Quest Book", Configuration.CATEGORY_GENERAL, true, "If true, then the player will spawn with a Quest Book when they first join the world");
         BQ_Settings.saveQuestsWithNames = config.getBoolean("DefaultQuests saves using Names", Configuration.CATEGORY_GENERAL, false, "If true, whenever you save your quests, they will have the first 16 characters of the quest name in the file name, this is useful if you want to be easily able to identify quests in file explorer, however it is less compatible when using version control.");
+
+        BQ_Settings.retrievalDetectionDelay = config.getInt("Retrieval Task Detection Interval", Configuration.CATEGORY_GENERAL, 20, 1, 200, "The delay, in ticks, after which quests with retrieval tasks will detect changes");
         config.save();
     }
 }

--- a/src/main/java/betterquesting/handlers/EventHandler.java
+++ b/src/main/java/betterquesting/handlers/EventHandler.java
@@ -462,7 +462,7 @@ public class EventHandler {
         EntityPlayer player = event.getEntityPlayer();
         ParticipantInfo pInfo = new ParticipantInfo(player);
 
-        List<DBEntry<IQuest>> actQuest = QuestingAPI.getAPI(ApiReference.QUEST_DB).bulkLookup(pInfo.getSharedQuests());
+        List<DBEntry<IQuest>> actQuest = QuestingAPI.getAPI(ApiReference.QUEST_DB).bulkLookupShared(pInfo);
 
         for (DBEntry<IQuest> entry : actQuest) {
             for (DBEntry<ITask> task : entry.getValue().getTasks().getEntries()) {
@@ -479,7 +479,7 @@ public class EventHandler {
         EntityPlayer player = event.getEntityPlayer();
         ParticipantInfo pInfo = new ParticipantInfo(player);
 
-        List<DBEntry<IQuest>> actQuest = QuestingAPI.getAPI(ApiReference.QUEST_DB).bulkLookup(pInfo.getSharedQuests());
+        List<DBEntry<IQuest>> actQuest = QuestingAPI.getAPI(ApiReference.QUEST_DB).bulkLookupShared(pInfo);
 
         IBlockState state = player.world.getBlockState(event.getPos());
 
@@ -498,7 +498,7 @@ public class EventHandler {
         EntityPlayer player = event.getEntityPlayer();
         ParticipantInfo pInfo = new ParticipantInfo(player);
 
-        List<DBEntry<IQuest>> actQuest = QuestingAPI.getAPI(ApiReference.QUEST_DB).bulkLookup(pInfo.getSharedQuests());
+        List<DBEntry<IQuest>> actQuest = QuestingAPI.getAPI(ApiReference.QUEST_DB).bulkLookupShared(pInfo);
 
         IBlockState state = player.world.getBlockState(event.getPos());
 
@@ -532,7 +532,7 @@ public class EventHandler {
         EntityPlayer player = event.getEntityPlayer();
         ParticipantInfo pInfo = new ParticipantInfo(player);
 
-        List<DBEntry<IQuest>> actQuest = QuestingAPI.getAPI(ApiReference.QUEST_DB).bulkLookup(pInfo.getSharedQuests());
+        List<DBEntry<IQuest>> actQuest = QuestingAPI.getAPI(ApiReference.QUEST_DB).bulkLookupShared(pInfo);
 
         for (DBEntry<IQuest> entry : actQuest) {
             for (DBEntry<ITask> task : entry.getValue().getTasks().getEntries()) {
@@ -550,7 +550,7 @@ public class EventHandler {
         EntityPlayer player = event.getEntityPlayer();
         ParticipantInfo pInfo = new ParticipantInfo(player);
 
-        List<DBEntry<IQuest>> actQuest = QuestingAPI.getAPI(ApiReference.QUEST_DB).bulkLookup(pInfo.getSharedQuests());
+        List<DBEntry<IQuest>> actQuest = QuestingAPI.getAPI(ApiReference.QUEST_DB).bulkLookupShared(pInfo);
 
         for (DBEntry<IQuest> entry : actQuest) {
             for (DBEntry<ITask> task : entry.getValue().getTasks().getEntries()) {
@@ -566,7 +566,7 @@ public class EventHandler {
 
         ParticipantInfo pInfo = new ParticipantInfo(event.player);
 
-        List<DBEntry<IQuest>> actQuest = QuestingAPI.getAPI(ApiReference.QUEST_DB).bulkLookup(pInfo.getSharedQuests());
+        List<DBEntry<IQuest>> actQuest = QuestingAPI.getAPI(ApiReference.QUEST_DB).bulkLookupShared(pInfo);
 
         for (DBEntry<IQuest> entry : actQuest) {
             for (DBEntry<ITask> task : entry.getValue().getTasks().getEntries()) {
@@ -582,7 +582,7 @@ public class EventHandler {
 
         ParticipantInfo pInfo = new ParticipantInfo(event.player);
 
-        List<DBEntry<IQuest>> actQuest = QuestingAPI.getAPI(ApiReference.QUEST_DB).bulkLookup(pInfo.getSharedQuests());
+        List<DBEntry<IQuest>> actQuest = QuestingAPI.getAPI(ApiReference.QUEST_DB).bulkLookupShared(pInfo);
 
         for (DBEntry<IQuest> entry : actQuest) {
             for (DBEntry<ITask> task : entry.getValue().getTasks().getEntries()) {
@@ -597,7 +597,7 @@ public class EventHandler {
         if (event.getEntityPlayer() == null || event.getEntityPlayer().world.isRemote || event.getEntityPlayer() instanceof FakePlayer) return;
 
         ParticipantInfo pInfo = new ParticipantInfo(event.getEntityPlayer());
-        List<DBEntry<IQuest>> actQuest = QuestingAPI.getAPI(ApiReference.QUEST_DB).bulkLookup(pInfo.getSharedQuests());
+        List<DBEntry<IQuest>> actQuest = QuestingAPI.getAPI(ApiReference.QUEST_DB).bulkLookupShared(pInfo);
 
         for (DBEntry<IQuest> entry : actQuest) {
             for (DBEntry<ITask> task : entry.getValue().getTasks().getEntries()) {
@@ -613,7 +613,7 @@ public class EventHandler {
             return;
 
         ParticipantInfo pInfo = new ParticipantInfo((EntityPlayer) event.getSource().getTrueSource());
-        List<DBEntry<IQuest>> actQuest = QuestingAPI.getAPI(ApiReference.QUEST_DB).bulkLookup(pInfo.getSharedQuests());
+        List<DBEntry<IQuest>> actQuest = QuestingAPI.getAPI(ApiReference.QUEST_DB).bulkLookupShared(pInfo);
 
         for (DBEntry<IQuest> entry : actQuest) {
             for (DBEntry<ITask> task : entry.getValue().getTasks().getEntries()) {
@@ -630,7 +630,7 @@ public class EventHandler {
         EntityPlayer player = event.getTamer();
         ParticipantInfo pInfo = new ParticipantInfo(player);
 
-        for (DBEntry<IQuest> entry : QuestingAPI.getAPI(ApiReference.QUEST_DB).bulkLookup(pInfo.getSharedQuests())) {
+        for (DBEntry<IQuest> entry : QuestingAPI.getAPI(ApiReference.QUEST_DB).bulkLookupShared(pInfo)) {
             for (DBEntry<ITask> task : entry.getValue().getTasks().getEntries()) {
                 if (task.getValue() instanceof TaskTame)
                     ((TaskTame) task.getValue()).onAnimalTamed(pInfo, entry, event.getEntityLiving());
@@ -644,7 +644,7 @@ public class EventHandler {
 
         ParticipantInfo pInfo = new ParticipantInfo(event.getPlayer());
 
-        for (DBEntry<IQuest> entry : QuestingAPI.getAPI(ApiReference.QUEST_DB).bulkLookup(pInfo.getSharedQuests())) {
+        for (DBEntry<IQuest> entry : QuestingAPI.getAPI(ApiReference.QUEST_DB).bulkLookupShared(pInfo)) {
             for (DBEntry<ITask> task : entry.getValue().getTasks().getEntries()) {
                 if (task.getValue() instanceof TaskBlockBreak)
                     ((TaskBlockBreak) task.getValue()).onBlockBreak(pInfo, entry, event.getState(), event.getPos());
@@ -660,7 +660,7 @@ public class EventHandler {
         EntityPlayer player = (EntityPlayer) event.getEntityLiving();
         ParticipantInfo pInfo = new ParticipantInfo(player);
 
-        List<DBEntry<IQuest>> actQuest = QuestingAPI.getAPI(ApiReference.QUEST_DB).bulkLookup(pInfo.getSharedQuests());
+        List<DBEntry<IQuest>> actQuest = QuestingAPI.getAPI(ApiReference.QUEST_DB).bulkLookupShared(pInfo);
 
         for (DBEntry<IQuest> entry : actQuest) {
             for (DBEntry<ITask> task : entry.getValue().getTasks().getEntries()) {
@@ -679,7 +679,7 @@ public class EventHandler {
 
         ParticipantInfo pInfo = new ParticipantInfo(event.getEntityPlayer());
 
-        for (DBEntry<IQuest> entry : QuestingAPI.getAPI(ApiReference.QUEST_DB).bulkLookup(pInfo.getSharedQuests())) {
+        for (DBEntry<IQuest> entry : QuestingAPI.getAPI(ApiReference.QUEST_DB).bulkLookupShared(pInfo)) {
             for (DBEntry<ITask> task : entry.getValue().getTasks().getEntries()) {
                 if (task.getValue() instanceof TaskAdvancement)
                     ((TaskAdvancement) task.getValue()).onAdvancementGet(entry, pInfo, event.getAdvancement());

--- a/src/main/java/betterquesting/handlers/EventHandler.java
+++ b/src/main/java/betterquesting/handlers/EventHandler.java
@@ -86,7 +86,6 @@ import net.minecraftforge.items.ItemHandlerHelper;
 
 import java.util.ArrayDeque;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.UUID;
 
@@ -420,43 +419,13 @@ public class EventHandler {
     private final ArrayDeque<EntityPlayerMP> opQueue = new ArrayDeque<>();
     private boolean openToLAN = false;
 
-    private static final HashSet<EntityPlayer> playerInventoryUpdates = new HashSet<>();
-    private static boolean processingUpdates = false;
-
-    /**
-     * Schedules checking player's inventory on the next server tick.
-     * Deduplicates requests to avoid scanning it multiple times per tick.
-     */
-    public static void schedulePlayerInventoryCheck(EntityPlayer player) {
-        if (processingUpdates) {
-            return;
-        }
-        synchronized (playerInventoryUpdates) {
-            playerInventoryUpdates.add(player);
-        }
-    }
-
     @SubscribeEvent
     public void onServerTick(ServerTickEvent event) {
         if (event.phase == Phase.START) {
             if (FMLCommonHandler.instance().getMinecraftServerInstance().getTickCounter() % 60 == 0) {
                 AdvListenerManager.INSTANCE.updateAll();
             }
-            processingUpdates = true;
-            for (EntityPlayer player : playerInventoryUpdates) {
-                if (player == null || player.inventory == null) {
-                    continue;
-                }
-                ParticipantInfo pInfo = new ParticipantInfo(player);
-
-                for (DBEntry<IQuest> entry : QuestingAPI.getAPI(ApiReference.QUEST_DB).bulkLookup(pInfo.getSharedQuests())) {
-                    for (DBEntry<ITask> task : entry.getValue().getTasks().getEntries()) {
-                        if (task.getValue() instanceof ITaskInventory) ((ITaskInventory)task.getValue()).onInventoryChange(entry, pInfo);
-                    }
-                }
-            }
-            playerInventoryUpdates.clear();
-            processingUpdates = false;
+            PlayerContainerListener.updateListeners();
         }
 
         if (event.phase != Phase.END) return;

--- a/src/main/java/betterquesting/handlers/PlayerContainerListener.java
+++ b/src/main/java/betterquesting/handlers/PlayerContainerListener.java
@@ -139,8 +139,7 @@ public class PlayerContainerListener implements IContainerListener {
         // 0 & 1 tick delay are effectively the same as the handler runs at the start of next tick
         if (BQ_Settings.retrievalDetectionDelay <= 1) {
             setDirty(true);
-        }
-        else if (!listenersToUpdate.containsKey(playerId)) {
+        } else if (!listenersToUpdate.containsKey(playerId)) {
             listenersToUpdate.put(playerId, System.currentTimeMillis() + BQ_Settings.retrievalDetectionDelay * MILLIS_PER_TICK);
         }
     }

--- a/src/main/java/betterquesting/handlers/PlayerContainerListener.java
+++ b/src/main/java/betterquesting/handlers/PlayerContainerListener.java
@@ -134,6 +134,7 @@ public class PlayerContainerListener implements IContainerListener {
         // Guarantee changes are only scheduled on the main server thread
         if (!FMLCommonHandler.instance().getMinecraftServerInstance().isCallingFromMinecraftThread()) {
             FMLCommonHandler.instance().getMinecraftServerInstance().addScheduledTask(this::scheduleChange);
+            return;
         }
 
         // 0 & 1 tick delay are effectively the same as the handler runs at the start of next tick

--- a/src/main/java/betterquesting/handlers/PlayerContainerListener.java
+++ b/src/main/java/betterquesting/handlers/PlayerContainerListener.java
@@ -85,7 +85,7 @@ public class PlayerContainerListener implements IContainerListener {
     /**
      * Update quest tasks for this player if necessary.
      */
-    @SuppressWarnings({"ForLoopReplaceableByForEach", "ConstantValue"})
+    @SuppressWarnings("ConstantValue")
     private void updateTasks() {
         if (!this.isDirty()) return;
         this.setDirty(false);
@@ -95,12 +95,8 @@ public class PlayerContainerListener implements IContainerListener {
         if (player == null || player.inventory == null) return;
 
         ParticipantInfo pInfo = new ParticipantInfo(player);
-        var quests = QuestingAPI.getAPI(ApiReference.QUEST_DB).bulkLookupShared(pInfo);
-        for (int i = 0, numQuests = quests.size(); i < numQuests; i++) {
-            DBEntry<IQuest> questEntry = quests.get(i);
-            var tasks = questEntry.getValue().getTasks().getEntries();
-            for (int j = 0, numTasks = tasks.size(); j < numTasks; j++) {
-                DBEntry<ITask> taskEntry = tasks.get(j);
+        for (DBEntry<IQuest> questEntry : QuestingAPI.getAPI(ApiReference.QUEST_DB).bulkLookupShared(pInfo)) {
+            for (DBEntry<ITask> taskEntry : questEntry.getValue().getTasks().getEntries()) {
                 if (taskEntry.getValue() instanceof ITaskInventory task) task.onInventoryChange(questEntry, pInfo);
             }
         }
@@ -135,7 +131,7 @@ public class PlayerContainerListener implements IContainerListener {
      * Deduplicates requests to avoid scanning it multiple times per tick.
      */
     private void scheduleChange() {
-        // Sanity check to ensure this only happens on the main server thread
+        // Guarantee changes are only scheduled on the main server thread
         if (!FMLCommonHandler.instance().getMinecraftServerInstance().isCallingFromMinecraftThread()) {
             FMLCommonHandler.instance().getMinecraftServerInstance().addScheduledTask(this::scheduleChange);
         }

--- a/src/main/java/betterquesting/handlers/PlayerContainerListener.java
+++ b/src/main/java/betterquesting/handlers/PlayerContainerListener.java
@@ -4,28 +4,35 @@ import betterquesting.api.api.ApiReference;
 import betterquesting.api.api.QuestingAPI;
 import betterquesting.api.questing.IQuest;
 import betterquesting.api.questing.tasks.ITask;
+import betterquesting.api.storage.BQ_Settings;
 import betterquesting.api2.storage.DBEntry;
 import betterquesting.api2.utils.ParticipantInfo;
 import betterquesting.questing.tasks.ITaskInventory;
+import it.unimi.dsi.fastutil.objects.Object2LongMap;
+import it.unimi.dsi.fastutil.objects.Object2LongOpenHashMap;
+import it.unimi.dsi.fastutil.objects.Object2ObjectLinkedOpenHashMap;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.Container;
 import net.minecraft.inventory.IContainerListener;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.NonNullList;
+import net.minecraftforge.fml.common.FMLCommonHandler;
 
 import javax.annotation.Nonnull;
-import java.util.HashMap;
 import java.util.UUID;
 
 public class PlayerContainerListener implements IContainerListener {
-    private static final HashMap<UUID, PlayerContainerListener> LISTEN_MAP = new HashMap<>();
+    private static final Object2ObjectLinkedOpenHashMap<UUID, PlayerContainerListener> LISTEN_MAP = new Object2ObjectLinkedOpenHashMap<>();
+    private static final Object2LongOpenHashMap<UUID> listenersToUpdate = new Object2LongOpenHashMap<>();
+    private static final long MILLIS_PER_TICK = 50L;
 
     public static void refreshListener(@Nonnull EntityPlayer player) {
         UUID uuid = QuestingAPI.getQuestingUUID(player);
         PlayerContainerListener listener = LISTEN_MAP.get(uuid);
         if (listener != null) {
-            listener.player = player;
+            listener.setDirty(false);
+            listenersToUpdate.removeLong(uuid);
         } else {
             listener = new PlayerContainerListener(player);
             LISTEN_MAP.put(uuid, listener);
@@ -40,24 +47,78 @@ public class PlayerContainerListener implements IContainerListener {
     public static void removeListener(@Nonnull EntityPlayer player) {
         UUID uuid = QuestingAPI.getQuestingUUID(player);
         LISTEN_MAP.remove(uuid);
+        listenersToUpdate.removeLong(uuid);
     }
 
-    private EntityPlayer player;
+    /**
+     * Update all player container listeners, updating their tasks if dirty.
+     */
+    public static void updateListeners() {
+        long now = System.currentTimeMillis();
+
+        // Check listeners to mark dirty
+        if (!listenersToUpdate.isEmpty()) {
+            var itr = listenersToUpdate.object2LongEntrySet().fastIterator();
+            while (itr.hasNext()) {
+                Object2LongMap.Entry<UUID> entry = itr.next();
+                if (now >= entry.getLongValue()) {
+                    var listener = LISTEN_MAP.get(entry.getKey());
+                    listener.setDirty(true);
+                    itr.remove();
+                }
+            }
+        }
+
+        // Update players' tasks
+        for (PlayerContainerListener playerContainerListener : LISTEN_MAP.values()) {
+            playerContainerListener.updateTasks();
+        }
+    }
+
+    private final UUID playerId;
+    private boolean invChanged;
 
     private PlayerContainerListener(@Nonnull EntityPlayer player) {
-        this.player = player;
+        this.playerId = QuestingAPI.getQuestingUUID(player);
+    }
+
+    /**
+     * Update quest tasks for this player if necessary.
+     */
+    @SuppressWarnings({"ForLoopReplaceableByForEach", "ConstantValue"})
+    private void updateTasks() {
+        if (!this.isDirty()) return;
+        this.setDirty(false);
+
+        var server = FMLCommonHandler.instance().getMinecraftServerInstance();
+        EntityPlayer player = server.getPlayerList().getPlayerByUUID(this.playerId);
+        if (player == null || player.inventory == null) return;
+
+        ParticipantInfo pInfo = new ParticipantInfo(player);
+        var quests = QuestingAPI.getAPI(ApiReference.QUEST_DB).bulkLookup(pInfo.getSharedQuests());
+        for (int i = 0, numQuests = quests.size(); i < numQuests; i++) {
+            DBEntry<IQuest> questEntry = quests.get(i);
+            var tasks = questEntry.getValue().getTasks().getEntries();
+            for (int j = 0, numTasks = tasks.size(); j < numTasks; j++) {
+                DBEntry<ITask> taskEntry = tasks.get(j);
+                if (taskEntry.getValue() instanceof ITaskInventory task) task.onInventoryChange(questEntry, pInfo);
+            }
+        }
     }
 
     @Override
-    public void sendAllContents(@Nonnull Container container, @Nonnull NonNullList<ItemStack> nonNullList) {
-        updateTasks();
+    public void sendAllContents(@Nonnull Container container, @Nonnull NonNullList<ItemStack> changedStacks) {
+        if (changedStacks.isEmpty() || changedStacks.stream().allMatch(ItemStack::isEmpty)) {
+            return;
+        }
+        scheduleChange();
     }
 
     @Override
-    public void sendSlotContents(@Nonnull Container container, int i, @Nonnull ItemStack itemStack) {
-        // Ignore changes outside of main inventory (e.g. crafting grid and armor)
-        if (i >= 9 && i <= 44) {
-            updateTasks();
+    public void sendSlotContents(@Nonnull Container container, int i, @Nonnull ItemStack changedStack) {
+        // Ignore changes outside main inventory (e.g. crafting grid and armor)
+        if (i >= 9 && i <= 44 && !changedStack.isEmpty()) {
+            scheduleChange();
         }
     }
 
@@ -69,7 +130,30 @@ public class PlayerContainerListener implements IContainerListener {
     public void sendAllWindowProperties(@Nonnull Container container, @Nonnull IInventory iInventory) {
     }
 
-    private void updateTasks() {
-        EventHandler.schedulePlayerInventoryCheck(player);
+    /**
+     * Schedules checking this player's inventory after the configured delay.
+     * Deduplicates requests to avoid scanning it multiple times per tick.
+     */
+    private void scheduleChange() {
+        // Sanity check to ensure this only happens on the main server thread
+        if (!FMLCommonHandler.instance().getMinecraftServerInstance().isCallingFromMinecraftThread()) {
+            FMLCommonHandler.instance().getMinecraftServerInstance().addScheduledTask(this::scheduleChange);
+        }
+
+        // 0 & 1 tick delay are effectively the same as the handler runs at the start of next tick
+        if (BQ_Settings.retrievalDetectionDelay <= 1) {
+            setDirty(true);
+        }
+        else if (!listenersToUpdate.containsKey(playerId)) {
+            listenersToUpdate.put(playerId, System.currentTimeMillis() + BQ_Settings.retrievalDetectionDelay * MILLIS_PER_TICK);
+        }
+    }
+
+    private void setDirty(boolean isDirty) {
+        invChanged = isDirty;
+    }
+
+    private boolean isDirty() {
+        return invChanged;
     }
 }

--- a/src/main/java/betterquesting/handlers/PlayerContainerListener.java
+++ b/src/main/java/betterquesting/handlers/PlayerContainerListener.java
@@ -95,7 +95,7 @@ public class PlayerContainerListener implements IContainerListener {
         if (player == null || player.inventory == null) return;
 
         ParticipantInfo pInfo = new ParticipantInfo(player);
-        var quests = QuestingAPI.getAPI(ApiReference.QUEST_DB).bulkLookup(pInfo.getSharedQuests());
+        var quests = QuestingAPI.getAPI(ApiReference.QUEST_DB).bulkLookupShared(pInfo);
         for (int i = 0, numQuests = quests.size(); i < numQuests; i++) {
             DBEntry<IQuest> questEntry = quests.get(i);
             var tasks = questEntry.getValue().getTasks().getEntries();

--- a/src/main/java/betterquesting/importers/ftbq/converters/tasks/FtbqTaskItem.java
+++ b/src/main/java/betterquesting/importers/ftbq/converters/tasks/FtbqTaskItem.java
@@ -54,7 +54,7 @@ public class FtbqTaskItem {
                 FTBQQuestImporter.provideQuestIcon(item);
             }
             if (tagList.tagCount() >= 2)
-                task.entryLogic = EnumLogic.OR;
+                task.setEntryLogic(EnumLogic.OR);
         } else {
             BetterQuesting.logger.error("Unable read item tag!");
         }

--- a/src/main/java/betterquesting/questing/QuestDatabase.java
+++ b/src/main/java/betterquesting/questing/QuestDatabase.java
@@ -4,21 +4,55 @@ import betterquesting.api.questing.IQuest;
 import betterquesting.api.questing.IQuestDatabase;
 import betterquesting.api2.storage.DBEntry;
 import betterquesting.api2.storage.RandomIndexDatabase;
+import betterquesting.api2.utils.ParticipantInfo;
+import betterquesting.core.BetterQuesting;
+import betterquesting.questing.party.PartyManager;
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 
 public final class QuestDatabase extends RandomIndexDatabase<IQuest> implements IQuestDatabase {
     public static final QuestDatabase INSTANCE = new QuestDatabase();
+
+    /** A cache for bulk lookups. The key is a party's UUID (each member has the same shared quests),
+     * or if not in a party, the player's UUID.
+     */
+    private final Cache<UUID, List<DBEntry<IQuest>>> bulkCache = CacheBuilder.newBuilder()
+            .expireAfterAccess(1, TimeUnit.MINUTES).build();
 
     @Override
     public synchronized IQuest createNew(int id) {
         IQuest quest = new QuestInstance();
         if (id >= 0) this.add(id, quest);
         return quest;
+    }
+
+    @Override
+    public List<DBEntry<IQuest>> bulkLookupShared(@Nonnull ParticipantInfo pInfo) {
+        var identifier = pInfo.PARTY_INSTANCE == null ? pInfo.UUID : pInfo.PARTY_INSTANCE.getValue().getID();
+        try {
+            return bulkCache.get(identifier,
+                    () -> Collections.unmodifiableList(this.bulkLookup(pInfo.getSharedQuests())));
+        } catch (ExecutionException e) {
+            BetterQuesting.logger.error("Failed to get cached bulkLookup entries: {}", e);
+            return this.bulkLookup(pInfo.getSharedQuests());
+        }
+    }
+
+    @Override
+    public void invalidateBulkCache(@Nonnull UUID participantId) {
+        var party = PartyManager.INSTANCE.getParty(participantId);
+        var identifier = party == null ? participantId : party.getValue().getID();
+        bulkCache.invalidate(identifier);
     }
 
     @Override
@@ -35,6 +69,12 @@ public final class QuestDatabase extends RandomIndexDatabase<IQuest> implements 
         boolean success = this.removeValue(value);
         if (success) for (DBEntry<IQuest> entry : getEntries()) removeReq(entry.getValue(), id);
         return success;
+    }
+
+    @Override
+    public synchronized void reset() {
+        super.reset();
+        bulkCache.invalidateAll();
     }
 
     private void removeReq(IQuest quest, int id) {

--- a/src/main/java/betterquesting/questing/QuestInstance.java
+++ b/src/main/java/betterquesting/questing/QuestInstance.java
@@ -402,10 +402,11 @@ public class QuestInstance implements IQuest {
 
     @Override
     public void setRequirementType(int req, @Nonnull RequirementType kind) {
-        if (kind == RequirementType.NORMAL)
+        if (kind == RequirementType.NORMAL) {
             prereqTypes.remove(req);
-        else
+        } else {
             prereqTypes.put(req, kind);
+        }
     }
 
     @Deprecated

--- a/src/main/java/betterquesting/questing/QuestInstance.java
+++ b/src/main/java/betterquesting/questing/QuestInstance.java
@@ -22,8 +22,9 @@ import betterquesting.questing.rewards.RewardStorage;
 import betterquesting.questing.tasks.TaskStorage;
 import betterquesting.storage.PropertyContainer;
 import betterquesting.storage.QuestSettings;
-import gnu.trove.map.TIntObjectMap;
-import gnu.trove.map.hash.TIntObjectHashMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
+import it.unimi.dsi.fastutil.ints.IntArrayList;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.Items;
 import net.minecraft.nbt.*;
@@ -41,7 +42,7 @@ public class QuestInstance implements IQuest {
 
     private final HashMap<UUID, NBTTagCompound> completeUsers = new HashMap<>();
     private int[] preRequisites = new int[0];
-    private final TIntObjectMap<RequirementType> prereqTypes = new TIntObjectHashMap<>();
+    private final Int2ObjectMap<RequirementType> prereqTypes = new Int2ObjectOpenHashMap<>();
 
     private final PropertyContainer qInfo = new PropertyContainer();
 
@@ -388,7 +389,7 @@ public class QuestInstance implements IQuest {
     }
 
     public void setRequirements(@Nonnull int[] req) {
-        prereqTypes.retainEntries((a, b) -> Arrays.stream(req).anyMatch(i -> i == a));
+        prereqTypes.keySet().retainAll(IntArrayList.wrap(req));
         this.preRequisites = req;
     }
 

--- a/src/main/java/betterquesting/questing/party/PartyInstance.java
+++ b/src/main/java/betterquesting/questing/party/PartyInstance.java
@@ -19,6 +19,7 @@ public class PartyInstance implements IParty {
     private List<UUID> memCache = null;
 
     private final PropertyContainer pInfo = new PropertyContainer();
+    private final UUID partyId = UUID.randomUUID();
 
     public PartyInstance() {
         this.setupProps();
@@ -38,6 +39,11 @@ public class PartyInstance implements IParty {
 
     private void refreshCache() {
         memCache = Collections.unmodifiableList(new ArrayList<>(members.keySet()));
+    }
+
+    @Override
+    public UUID getID() {
+        return partyId;
     }
 
     @Override

--- a/src/main/java/betterquesting/questing/party/PartyInventory.java
+++ b/src/main/java/betterquesting/questing/party/PartyInventory.java
@@ -12,8 +12,10 @@ import net.minecraft.util.NonNullList;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.capability.CapabilityFluidHandler;
 import net.minecraftforge.fluids.capability.IFluidHandlerItem;
+import net.minecraftforge.items.ItemHandlerHelper;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -28,9 +30,9 @@ public class PartyInventory {
     /** The collapsed inventory of all party members, keys are item ids. */
     private final Int2ObjectMap<List<IndexedItemStack>> partyStacks;
     /** The main player's collected fluid containers. */
-    private final List<IndexedFluidHandler> playerFluidContainers;
+    private final List<IndexedFluidContainer> playerFluidContainers;
     /** The collected fluid containers of all party members. */
-    private final List<IndexedFluidHandler> partyFluidContainers;
+    private final List<IndexedFluidContainer> partyFluidContainers;
 
     public PartyInventory(EntityPlayer mainPlayer, List<EntityPlayer> party) {
         // Player inventories should usually all be the same size
@@ -52,11 +54,14 @@ public class PartyInventory {
                 ItemStack stack = mainInventory.get(i);
                 if (stack.isEmpty()) continue;
 
-                var indexedStack = new IndexedItemStack(stack, i, player.inventory);
-                var fluidHandler = stack.getCapability(CapabilityFluidHandler.FLUID_HANDLER_ITEM_CAPABILITY, null);
-                IndexedFluidHandler indexedFluidHandler = null;
-                if (fluidHandler != null) {
-                    indexedFluidHandler = new IndexedFluidHandler(fluidHandler, i, player.inventory);
+                IndexedItemStack indexedStack;
+                IndexedFluidContainer indexedFluidContainer;
+                if (stack.hasCapability(CapabilityFluidHandler.FLUID_HANDLER_ITEM_CAPABILITY, null)) {
+                    indexedStack = indexedFluidContainer = new IndexedFluidContainer(stack, i, player.inventory);
+                }
+                else {
+                    indexedStack = new IndexedItemStack(stack, i, player.inventory);
+                    indexedFluidContainer = null;
                 }
 
                 int itemHash = getHashKey(stack);
@@ -67,8 +72,8 @@ public class PartyInventory {
                         playerStacks.put(itemHash, subStacks);
                     }
                     subStacks.add(indexedStack);
-                    if (indexedFluidHandler != null) {
-                        playerFluidContainers.add(indexedFluidHandler);
+                    if (indexedFluidContainer != null) {
+                        playerFluidContainers.add(indexedFluidContainer);
                     }
                 }
                 // Don't put duplicates in solo parties
@@ -79,8 +84,8 @@ public class PartyInventory {
                         partyStacks.put(itemHash, subStacks);
                     }
                     subStacks.add(indexedStack);
-                    if (indexedFluidHandler != null) {
-                        partyFluidContainers.add(indexedFluidHandler);
+                    if (indexedFluidContainer != null) {
+                        partyFluidContainers.add(indexedFluidContainer);
                     }
                 }
             }
@@ -135,59 +140,26 @@ public class PartyInventory {
         }
 
         int amount = 0;
-        var handlers = new ArrayList<IndexedFluidHandler>();
+        var handlers = new ArrayList<IndexedFluidContainer>();
         for (var indexedHandler : gatheredHandlers) {
-            int numContainers = indexedHandler.handler.getContainer().getCount();
             // Even though we're simulating, make a defensive copy
             FluidStack toDrain = req.copy();
             if (ignoreNBT) {
                 toDrain.tag = null;
             }
-            toDrain.amount /= numContainers; // Must be a multiple of the stack size to drain evenly
-            if (toDrain.amount <= 0) continue;
 
             // Simulate the drain
-            FluidStack drained = indexedHandler.handler().drain(toDrain, false);
-            if (drained == null || drained.amount <= 0) continue;
+            var handler = indexedHandler.handler(true);
+            if (handler == null) continue;
+            FluidStack drainable = handler.drain(toDrain, false);
+            if (drainable == null || drainable.amount <= 0) continue;
 
-            int drainedAmount = drained.amount * numContainers; // Multiply back the number of containers drained
-            amount += Math.min(indexedHandler.getAvailableAmount(drained), drainedAmount);
+            // The handler is for a single stack, so multiply the actual stack count
+            drainable.amount *= indexedHandler.count;
+            amount += indexedHandler.getAvailableAmount(drainable);
             handlers.add(indexedHandler);
         }
         return handlers.isEmpty() ? FluidMatchContext.EMPTY : new FluidMatchContext(amount, handlers);
-    }
-
-    /**
-     * Update any cached item stacks with a corresponding fluid handler. Must be called after any non-simulated drains
-     * of a fluid handler from the context.
-     *
-     * @param context the fluid match context
-     * @param taskConsumes if true, will only update the main player's cached stacks
-     * @see net.minecraftforge.fluids.FluidUtil#getFluidHandler(ItemStack) the contract this fulfills
-     */
-    public void updateFluidContainers(FluidMatchContext context, boolean taskConsumes) {
-        // Consume tasks for parties aren't currently supported.
-        if (!taskConsumes) return;
-
-        int toUpdate = 0;
-        for (List<IndexedItemStack> possibleStacks : playerStacks.values()) {
-            for (IndexedItemStack iStack : possibleStacks) {
-                for (IndexedFluidHandler iContainerStack : context.indexedFluidHandlers()) {
-                    if (iContainerStack.slot == iStack.slot && iContainerStack.sourceInv == iStack.sourceInv) {
-                        ItemStack container = iContainerStack.handler.getContainer();
-                        if (container == iStack.stack) break;
-
-                        // Update the player's inventory
-                        iContainerStack.sourceInv.setInventorySlotContents(iStack.slot, container);
-                        // As well as the cached stack
-                        iStack.updateCachedStack(container);
-                        toUpdate++;
-                        break;
-                    }
-                }
-                if (toUpdate >= context.indexedFluidHandlers.size()) return;
-            }
-        }
     }
 
     /**
@@ -216,18 +188,18 @@ public class PartyInventory {
         }
     }
 
-    public static final class IndexedItemStack {
-        /** The cached stack */
-        private ItemStack stack;
+    public static class IndexedItemStack {
+        /** The actual stack belonging to a player's inventory */
+        protected final ItemStack stack;
         /**
          * The cached stack count.
-         * This should always be resynced by the start of any item task detection (the caller is responsible to reset).
+         * This should be used over the direct stack count, in order to support split stack detection within one task.
          */
-        private int count;
+        protected int count;
         /** The slot index of the stack */
-        private final int slot;
+        protected final int slot;
         /** The player inventory this stack belongs to */
-        private final InventoryPlayer sourceInv;
+        protected final InventoryPlayer sourceInv;
 
         private IndexedItemStack(ItemStack stack, int slot, InventoryPlayer sourceInv) {
             this.stack = stack;
@@ -240,18 +212,12 @@ public class PartyInventory {
             return slot;
         }
 
-        /** @see #updateFluidContainers(FluidMatchContext, boolean) */
-        private void updateCachedStack(ItemStack stack) {
-            this.stack = stack;
-            resetCount();
-        }
-
         private void shrink(int amount) {
             count -= amount;
         }
 
         /** Resync the cached count to the actual stack's count. Call this at the end of task detection if needed. */
-        private void resetCount() {
+        protected void resetCount() {
             count = stack.getCount();
         }
 
@@ -288,38 +254,84 @@ public class PartyInventory {
     }
 
     /**
-     * A fluid handler associated with a fluid container belonging to a certain player's inventory
+     * A fluid container belonging to a certain player's inventory
      */
-    public static final class IndexedFluidHandler {
-        /** The fluid handler */
-        @Nonnull
-        private final IFluidHandlerItem handler;
-        /** The slot index of the handler's container */
-        private final int slot;
-        /** The player inventory this stack belongs to */
-        private final InventoryPlayer sourceInv;
+    public static final class IndexedFluidContainer extends IndexedItemStack {
+        /** A fluid handler only to be used for simulated drains. */
+        private IFluidHandlerItem simulatedHandler;
         /**
-         * A list of fluid stacks and their amounts that were matched for this fluid handler.
+         * A list of fluid stacks and their amounts that were matched for this fluid container.
          * This should always be empty at the start of any fluid task detection (the caller is responsible to reset).
          */
         @Nonnull
         private final List<FluidStack> cachedFluidAmounts;
 
         /**
-         * @param handler   the fluid container's handler
+         * @param container   the fluid container
          * @param slot      the associated container's slot in the inventory
          * @param sourceInv the player's inventory this fluid handler belongs to
          */
-        public IndexedFluidHandler(@Nonnull IFluidHandlerItem handler, int slot, InventoryPlayer sourceInv) {
-            this.handler = handler;
-            this.slot = slot;
-            this.sourceInv = sourceInv;
+        public IndexedFluidContainer(@Nonnull ItemStack container, int slot, InventoryPlayer sourceInv) {
+            super(container, slot, sourceInv);
             cachedFluidAmounts = new ArrayList<>();
         }
 
-        @Nonnull
-        public IFluidHandlerItem handler() {
-            return handler;
+        @Nullable
+        public IFluidHandlerItem handler(boolean simulated) {
+            ItemStack source;
+            if (simulated) {
+                if (simulatedHandler == null) {
+                    source = determineHandlerSource();
+                    simulatedHandler = source.getCapability(CapabilityFluidHandler.FLUID_HANDLER_ITEM_CAPABILITY, null);
+                }
+                return simulatedHandler;
+            }
+            source = determineHandlerSource();
+            return source.getCapability(CapabilityFluidHandler.FLUID_HANDLER_ITEM_CAPABILITY, null);
+        }
+
+        private ItemStack determineHandlerSource() {
+            ItemStack containerCopy;
+            if (stack.getCount() == 1) {
+                containerCopy = stack;
+            }
+            else {
+                // Some IFluidHandlerItems require the stack count to be 1.
+                containerCopy = ItemHandlerHelper.copyStackWithSize(stack, 1);
+            }
+            return containerCopy;
+        }
+
+        /** The stack count of the fluid container. */
+        public int stackCount() {
+            return count;
+        }
+
+        /**
+         * Update the inventory and cached item stack with the fluid handler's result.
+         * Must be called after any real drains.
+         * Similar to {@link net.minecraftforge.fluids.FluidUtil#tryEmptyContainerAndStow}.
+         *
+         * @param handler the fluid handler that the actual drain happened with
+         * @param itemsToConsume the number of containers to consume from the stack
+         * @param taskConsumes if true, will only update the main player's cached stacks
+         * @see net.minecraftforge.fluids.FluidUtil#getFluidHandler(ItemStack) the contract this fulfills
+         */
+        public void updateFluidContainer(IFluidHandlerItem handler, int itemsToConsume, boolean taskConsumes) {
+            // Consume tasks for parties aren't currently supported.
+            if (!taskConsumes) return;
+
+            ItemStack container = handler.getContainer();
+            if (container != this.stack) {
+                // Stow the resulting containers
+                if (!container.isEmpty()) {
+                    container.setCount(itemsToConsume);
+                    ItemHandlerHelper.giveItemToPlayer(sourceInv.player, container);
+                }
+                // And consume the appropriate amount
+                stack.shrink(itemsToConsume);
+                this.resetCount();
+            }
         }
 
         /**
@@ -357,9 +369,11 @@ public class PartyInventory {
         @Override
         public String toString() {
             return "IndexedFluidHandler[" +
-                    "handler=" + handler + ", " +
+                    "stack=" + stack + ", " +
+                    "count=" + count + ", " +
                     "slot=" + slot + ", " +
-                    "sourceInv=" + sourceInv + ", " +
+                    "sourceInv=" + sourceInv +
+                    "handler=" + simulatedHandler + ", " +
                     "cachedFluidAmounts=" + cachedFluidAmounts + ']';
         }
     }
@@ -367,10 +381,10 @@ public class PartyInventory {
     /**
      * Fluid stack context with available fluid amount and the matched slots of the applicable fluid handlers
      * @param drainableAmount total amount of the fluid that can be drained
-     * @param indexedFluidHandlers applicable fluid handlers
+     * @param indexedFluidContainers applicable fluid handlers
      */
     @Desugar
-    public record FluidMatchContext(int drainableAmount, List<IndexedFluidHandler> indexedFluidHandlers) {
+    public record FluidMatchContext(int drainableAmount, List<IndexedFluidContainer> indexedFluidContainers) {
         public static final FluidMatchContext EMPTY = new FluidMatchContext(0, Collections.emptyList());
 
         /**
@@ -382,9 +396,9 @@ public class PartyInventory {
         public void shrink(FluidStack reqFluid, int amount) {
             int remaining = amount;
             FluidStack fluid = new FluidStack(reqFluid.getFluid(), amount, reqFluid.tag);
-            for (var iHandler : indexedFluidHandlers) {
-                int amountShrunk = Math.min(iHandler.getAvailableAmount(fluid), remaining);
-                iHandler.shrink(fluid, amountShrunk);
+            for (var iFluidContainer : indexedFluidContainers) {
+                int amountShrunk = Math.min(iFluidContainer.getAvailableAmount(fluid), remaining);
+                iFluidContainer.shrink(fluid, amountShrunk);
                 remaining -= amountShrunk;
                 if (remaining <= 0) {
                     return;

--- a/src/main/java/betterquesting/questing/party/PartyInventory.java
+++ b/src/main/java/betterquesting/questing/party/PartyInventory.java
@@ -21,8 +21,6 @@ import java.util.Objects;
 
 /**
  * A snapshot of a party's inventories, accumulating counts of all item stacks.
- * Take caution when modifying any ItemStacks from this class,
- * they are direct references to the actual stacks in the inventory, not a copy!
  */
 public class PartyInventory {
     /** The main player's collected inventory, keys are item ids. */
@@ -35,7 +33,8 @@ public class PartyInventory {
     private final List<IndexedFluidHandler> partyFluidContainers;
 
     public PartyInventory(EntityPlayer mainPlayer, List<EntityPlayer> party) {
-        int maxSize = party.stream().mapToInt(player -> player.inventory.mainInventory.size()).sum();
+        // Player inventories should usually all be the same size
+        int maxSize = mainPlayer.inventory.mainInventory.size() * party.size();
         this.playerStacks = new Int2ObjectOpenHashMap<>(maxSize);
         this.playerFluidContainers = new ArrayList<>();
         if (party.size() <= 1) {
@@ -60,12 +59,12 @@ public class PartyInventory {
                     indexedFluidHandler = new IndexedFluidHandler(fluidHandler, i, player.inventory);
                 }
 
-                int hash = getHashKey(stack);
+                int itemHash = getHashKey(stack);
                 if (player == mainPlayer) {
-                    var subStacks = playerStacks.get(hash);
+                    var subStacks = playerStacks.get(itemHash);
                     if (subStacks == null) {
                         subStacks = new ArrayList<>();
-                        playerStacks.put(hash, subStacks);
+                        playerStacks.put(itemHash, subStacks);
                     }
                     subStacks.add(indexedStack);
                     if (indexedFluidHandler != null) {
@@ -74,10 +73,10 @@ public class PartyInventory {
                 }
                 // Don't put duplicates in solo parties
                 if (playerStacks != partyStacks) {
-                    var subStacks = partyStacks.get(hash);
+                    var subStacks = partyStacks.get(itemHash);
                     if (subStacks == null) {
                         subStacks = new ArrayList<>();
-                        partyStacks.put(hash, subStacks);
+                        partyStacks.put(itemHash, subStacks);
                     }
                     subStacks.add(indexedStack);
                     if (indexedFluidHandler != null) {
@@ -98,37 +97,38 @@ public class PartyInventory {
      * @param taskConsumes if true, will only count from the main player's inventory
      * @param ignoreNBT if matching should ignore NBT
      * @param partialMatch if partially matching NBT is allowed
-     * @return the total amount of the stack the party has, up to the required amount
+     * @return the total amount of the stack the party has
      */
-    public int getItemCountFor(BigItemStack req, boolean taskConsumes, boolean ignoreNBT, boolean partialMatch) {
+    public ItemMatchContext getItemCountFor(BigItemStack req, boolean taskConsumes, boolean ignoreNBT, boolean partialMatch) {
         var gatheredStacks = taskConsumes ? playerStacks : partyStacks;
 
         // The stacks matched by Item
         var subStacks = gatheredStacks.get(req.getHashKey());
         if (subStacks == null || subStacks.isEmpty()) {
-            return 0;
+            return ItemMatchContext.EMPTY;
         }
 
-        // Collect count of the specific stack
+        // Collect matched stacks and total count
+        var matchedStacks = new ArrayList<IndexedItemStack>();
         int count = 0;
         for (var indexedStack : subStacks) {
             ItemStack stack = indexedStack.stack;
             if (ItemComparison.BigStackMatch(req, stack, ignoreNBT, partialMatch)) {
-                count += stack.getCount();
-                if (count >= req.stackSize) break;
+                matchedStacks.add(indexedStack);
+                count += indexedStack.count;
             }
         }
-        return Math.min(count, req.stackSize);
+        return matchedStacks.isEmpty() ? ItemMatchContext.EMPTY : new ItemMatchContext(count, matchedStacks);
     }
 
     /**
      * Get all fluid handlers from the party's inventory that can handle the given fluid stack.
-     * @param inputStack the fluid stack
+     * @param req the required fluid stack
      * @param taskConsumes if true, will only search the main player's inventory
      * @param ignoreNBT if matching should ignore NBT
-     * @return the context wrapping the applicable fluid handlers and max fluid amount available
+     * @return the context wrapping the max fluid amount available and applicable fluid handlers
      */
-    public FluidMatchContext getFluidHandlersFor(FluidStack inputStack, boolean taskConsumes, boolean ignoreNBT) {
+    public FluidMatchContext getFluidHandlersFor(FluidStack req, boolean taskConsumes, boolean ignoreNBT) {
         var gatheredHandlers = taskConsumes ? playerFluidContainers : partyFluidContainers;
         if (gatheredHandlers.isEmpty()) {
             return FluidMatchContext.EMPTY;
@@ -138,7 +138,8 @@ public class PartyInventory {
         var handlers = new ArrayList<IndexedFluidHandler>();
         for (var indexedHandler : gatheredHandlers) {
             int numContainers = indexedHandler.handler.getContainer().getCount();
-            FluidStack toDrain = inputStack.copy();
+            // Even though we're simulating, make a defensive copy
+            FluidStack toDrain = req.copy();
             if (ignoreNBT) {
                 toDrain.tag = null;
             }
@@ -149,7 +150,8 @@ public class PartyInventory {
             FluidStack drained = indexedHandler.handler().drain(toDrain, false);
             if (drained == null || drained.amount <= 0) continue;
 
-            amount += drained.amount * numContainers; // Multiply back the number of containers drained
+            int drainedAmount = drained.amount * numContainers; // Multiply back the number of containers drained
+            amount += Math.min(indexedHandler.getAvailableAmount(drained), drainedAmount);
             handlers.add(indexedHandler);
         }
         return handlers.isEmpty() ? FluidMatchContext.EMPTY : new FluidMatchContext(amount, handlers);
@@ -188,9 +190,40 @@ public class PartyInventory {
         }
     }
 
-    private static final class IndexedItemStack {
+    /**
+     * Resets the cached counts for the party's stacks.
+     * Call this after any call to {@link ItemMatchContext#shrink(int)}.
+     * @param taskConsumes if true, will only reset the cached stacks for the main player
+     */
+    public void resetItemCounts(boolean taskConsumes) {
+        var stacksToReset = taskConsumes ? playerStacks : partyStacks;
+        for (var iStacks : stacksToReset.values()) {
+            for (var iStack : iStacks) {
+                iStack.resetCount();
+            }
+        }
+    }
+
+    /**
+     * The fluid variant of {@link #resetItemCounts(boolean)}.
+     * Call this after any call to {@link FluidMatchContext#shrink(FluidStack, int)}.
+     * @param taskConsumes if true, will only reset the cached fluid amounts for the main player
+     */
+    public void resetFluidAmounts(boolean taskConsumes) {
+        var handlersToReset = taskConsumes ? playerFluidContainers : partyFluidContainers;
+        for (var iHandler : handlersToReset) {
+            iHandler.resetAmounts();
+        }
+    }
+
+    public static final class IndexedItemStack {
         /** The cached stack */
         private ItemStack stack;
+        /**
+         * The cached stack count.
+         * This should always be resynced by the start of any item task detection (the caller is responsible to reset).
+         */
+        private int count;
         /** The slot index of the stack */
         private final int slot;
         /** The player inventory this stack belongs to */
@@ -200,21 +233,136 @@ public class PartyInventory {
             this.stack = stack;
             this.slot = slot;
             this.sourceInv = sourceInv;
+            this.count = stack.getCount();
         }
 
-        public void updateCachedStack(ItemStack stack) {
+        public int slot() {
+            return slot;
+        }
+
+        /** @see #updateFluidContainers(FluidMatchContext, boolean) */
+        private void updateCachedStack(ItemStack stack) {
             this.stack = stack;
+            resetCount();
+        }
+
+        private void shrink(int amount) {
+            count -= amount;
+        }
+
+        /** Resync the cached count to the actual stack's count. Call this at the end of task detection if needed. */
+        private void resetCount() {
+            count = stack.getCount();
+        }
+
+        @Override
+        public String toString() {
+            return "IndexedItemStack[" +
+                    "stack=" + stack + ", " +
+                    "count=" + count + ", " +
+                    "slot=" + slot + ", " +
+                    "sourceInv=" + sourceInv + ']';
+        }
+    }
+
+    @Desugar
+    public record ItemMatchContext(int availableAmount, List<IndexedItemStack> indexedItemStacks) {
+        public static final ItemMatchContext EMPTY = new ItemMatchContext(0, Collections.emptyList());
+
+        /**
+         * Shrink a total amount from the indexed stacks.
+         * Call this for any detection of this item, even if it wasn't actually consumed.
+         * @param amount the amount to shrink by
+         */
+        public void shrink(int amount) {
+            int remaining = amount;
+            for (var iStack : indexedItemStacks) {
+                int amountShrunk = Math.min(iStack.count, remaining);
+                iStack.shrink(amountShrunk);
+                remaining -= amountShrunk;
+                if (remaining <= 0) {
+                    return;
+                }
+            }
         }
     }
 
     /**
      * A fluid handler associated with a fluid container belonging to a certain player's inventory
-     * @param handler the fluid container's handler
-     * @param slot the associated container's slot in the inventory
-     * @param sourceInv the player's inventory this fluid handler belongs to
      */
-    @Desugar
-    public record IndexedFluidHandler(@Nonnull IFluidHandlerItem handler, int slot, InventoryPlayer sourceInv) {}
+    public static final class IndexedFluidHandler {
+        /** The fluid handler */
+        @Nonnull
+        private final IFluidHandlerItem handler;
+        /** The slot index of the handler's container */
+        private final int slot;
+        /** The player inventory this stack belongs to */
+        private final InventoryPlayer sourceInv;
+        /**
+         * A list of fluid stacks and their amounts that were matched for this fluid handler.
+         * This should always be empty at the start of any fluid task detection (the caller is responsible to reset).
+         */
+        @Nonnull
+        private final List<FluidStack> cachedFluidAmounts;
+
+        /**
+         * @param handler   the fluid container's handler
+         * @param slot      the associated container's slot in the inventory
+         * @param sourceInv the player's inventory this fluid handler belongs to
+         */
+        public IndexedFluidHandler(@Nonnull IFluidHandlerItem handler, int slot, InventoryPlayer sourceInv) {
+            this.handler = handler;
+            this.slot = slot;
+            this.sourceInv = sourceInv;
+            cachedFluidAmounts = new ArrayList<>();
+        }
+
+        @Nonnull
+        public IFluidHandlerItem handler() {
+            return handler;
+        }
+
+        /**
+         * Get the extractable amount of the given fluid stack from this fluid handler.
+         */
+        private int getAvailableAmount(FluidStack fluidIn) {
+            FluidStack cached = null;
+            // Look for the cached amount
+            for (var fluid : cachedFluidAmounts) {
+                if (fluid.isFluidEqual(fluidIn)) {
+                    cached = fluid;
+                    break;
+                }
+            }
+            // Cache if not found
+            if (cached == null) {
+                cached = fluidIn;
+                cachedFluidAmounts.add(cached);
+            }
+
+            return cached.amount;
+        }
+
+        private void shrink(FluidStack fluidToMatch, int amount) {
+            for (var fluid : cachedFluidAmounts) {
+                if (fluid.isFluidEqual(fluidToMatch)) fluid.amount -= amount;
+            }
+        }
+
+        /** Reset the cached fluid amounts. Call this at the end of task detection if needed. */
+        private void resetAmounts() {
+            cachedFluidAmounts.clear();
+        }
+
+        @Override
+        public String toString() {
+            return "IndexedFluidHandler[" +
+                    "handler=" + handler + ", " +
+                    "slot=" + slot + ", " +
+                    "sourceInv=" + sourceInv + ", " +
+                    "cachedFluidAmounts=" + cachedFluidAmounts + ']';
+        }
+    }
 
     /**
      * Fluid stack context with available fluid amount and the matched slots of the applicable fluid handlers
@@ -224,5 +372,24 @@ public class PartyInventory {
     @Desugar
     public record FluidMatchContext(int drainableAmount, List<IndexedFluidHandler> indexedFluidHandlers) {
         public static final FluidMatchContext EMPTY = new FluidMatchContext(0, Collections.emptyList());
+
+        /**
+         * Shrink a total amount of a given fluid from the indexed handlers.
+         * Call this for any detection of this fluid, even if it wasn't actually consumed.
+         * @param reqFluid the required fluid stack, only used for its fluid and tag
+         * @param amount the amount to shrink by
+         */
+        public void shrink(FluidStack reqFluid, int amount) {
+            int remaining = amount;
+            FluidStack fluid = new FluidStack(reqFluid.getFluid(), amount, reqFluid.tag);
+            for (var iHandler : indexedFluidHandlers) {
+                int amountShrunk = Math.min(iHandler.getAvailableAmount(fluid), remaining);
+                iHandler.shrink(fluid, amountShrunk);
+                remaining -= amountShrunk;
+                if (remaining <= 0) {
+                    return;
+                }
+            }
+        }
     }
 }

--- a/src/main/java/betterquesting/questing/party/PartyInventory.java
+++ b/src/main/java/betterquesting/questing/party/PartyInventory.java
@@ -19,7 +19,6 @@ import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 
 /**
  * A snapshot of a party's inventories, accumulating counts of all item stacks.
@@ -64,7 +63,7 @@ public class PartyInventory {
                     indexedFluidContainer = null;
                 }
 
-                int itemHash = getHashKey(stack);
+                int itemHash = BigItemStack.getHashKey(stack);
                 if (player == mainPlayer) {
                     var subStacks = playerStacks.get(itemHash);
                     if (subStacks == null) {
@@ -90,10 +89,6 @@ public class PartyInventory {
                 }
             }
         }
-    }
-
-    public static int getHashKey(ItemStack stack) {
-        return Objects.requireNonNull(stack.getItem().getRegistryName()).hashCode();
     }
 
     /**

--- a/src/main/java/betterquesting/questing/party/PartyInventory.java
+++ b/src/main/java/betterquesting/questing/party/PartyInventory.java
@@ -323,13 +323,13 @@ public class PartyInventory {
 
             ItemStack container = handler.getContainer();
             if (container != this.stack) {
-                // Stow the resulting containers
+                // Consume the appropriate amount
+                stack.shrink(itemsToConsume);
+                // Then stow the resulting containers
                 if (!container.isEmpty()) {
                     container.setCount(itemsToConsume);
                     ItemHandlerHelper.giveItemToPlayer(sourceInv.player, container);
                 }
-                // And consume the appropriate amount
-                stack.shrink(itemsToConsume);
                 this.resetCount();
             }
         }

--- a/src/main/java/betterquesting/questing/party/PartyInventory.java
+++ b/src/main/java/betterquesting/questing/party/PartyInventory.java
@@ -41,8 +41,7 @@ public class PartyInventory {
         if (party.size() <= 1) {
             this.partyStacks = this.playerStacks;
             this.partyFluidContainers = this.playerFluidContainers;
-        }
-        else {
+        } else {
             this.partyStacks = new Int2ObjectOpenHashMap<>(maxSize);
             this.partyFluidContainers = new ArrayList<>();
         }
@@ -57,8 +56,7 @@ public class PartyInventory {
                 IndexedFluidContainer indexedFluidContainer;
                 if (stack.hasCapability(CapabilityFluidHandler.FLUID_HANDLER_ITEM_CAPABILITY, null)) {
                     indexedStack = indexedFluidContainer = new IndexedFluidContainer(stack, i, player.inventory);
-                }
-                else {
+                } else {
                     indexedStack = new IndexedItemStack(stack, i, player.inventory);
                     indexedFluidContainer = null;
                 }
@@ -289,8 +287,7 @@ public class PartyInventory {
             ItemStack containerCopy;
             if (stack.getCount() == 1) {
                 containerCopy = stack;
-            }
-            else {
+            } else {
                 // Some IFluidHandlerItems require the stack count to be 1.
                 containerCopy = ItemHandlerHelper.copyStackWithSize(stack, 1);
             }

--- a/src/main/java/betterquesting/questing/party/PartyInventory.java
+++ b/src/main/java/betterquesting/questing/party/PartyInventory.java
@@ -1,0 +1,228 @@
+package betterquesting.questing.party;
+
+import betterquesting.api.utils.BigItemStack;
+import betterquesting.api.utils.ItemComparison;
+import com.github.bsideup.jabel.Desugar;
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.entity.player.InventoryPlayer;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.NonNullList;
+import net.minecraftforge.fluids.FluidStack;
+import net.minecraftforge.fluids.capability.CapabilityFluidHandler;
+import net.minecraftforge.fluids.capability.IFluidHandlerItem;
+
+import javax.annotation.Nonnull;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * A snapshot of a party's inventories, accumulating counts of all item stacks.
+ * Take caution when modifying any ItemStacks from this class,
+ * they are direct references to the actual stacks in the inventory, not a copy!
+ */
+public class PartyInventory {
+    /** The main player's collected inventory, keys are item ids. */
+    private final Int2ObjectMap<List<IndexedItemStack>> playerStacks;
+    /** The collapsed inventory of all party members, keys are item ids. */
+    private final Int2ObjectMap<List<IndexedItemStack>> partyStacks;
+    /** The main player's collected fluid containers. */
+    private final List<IndexedFluidHandler> playerFluidContainers;
+    /** The collected fluid containers of all party members. */
+    private final List<IndexedFluidHandler> partyFluidContainers;
+
+    public PartyInventory(EntityPlayer mainPlayer, List<EntityPlayer> party) {
+        int maxSize = party.stream().mapToInt(player -> player.inventory.mainInventory.size()).sum();
+        this.playerStacks = new Int2ObjectOpenHashMap<>(maxSize);
+        this.playerFluidContainers = new ArrayList<>();
+        if (party.size() <= 1) {
+            this.partyStacks = this.playerStacks;
+            this.partyFluidContainers = this.playerFluidContainers;
+        }
+        else {
+            this.partyStacks = new Int2ObjectOpenHashMap<>(maxSize);
+            this.partyFluidContainers = new ArrayList<>();
+        }
+
+        for (EntityPlayer player : party) {
+            NonNullList<ItemStack> mainInventory = player.inventory.mainInventory;
+            for (int i = 0; i < mainInventory.size(); i++) {
+                ItemStack stack = mainInventory.get(i);
+                if (stack.isEmpty()) continue;
+
+                var indexedStack = new IndexedItemStack(stack, i, player.inventory);
+                var fluidHandler = stack.getCapability(CapabilityFluidHandler.FLUID_HANDLER_ITEM_CAPABILITY, null);
+                IndexedFluidHandler indexedFluidHandler = null;
+                if (fluidHandler != null) {
+                    indexedFluidHandler = new IndexedFluidHandler(fluidHandler, i, player.inventory);
+                }
+
+                int hash = getHashKey(stack);
+                if (player == mainPlayer) {
+                    var subStacks = playerStacks.get(hash);
+                    if (subStacks == null) {
+                        subStacks = new ArrayList<>();
+                        playerStacks.put(hash, subStacks);
+                    }
+                    subStacks.add(indexedStack);
+                    if (indexedFluidHandler != null) {
+                        playerFluidContainers.add(indexedFluidHandler);
+                    }
+                }
+                // Don't put duplicates in solo parties
+                if (playerStacks != partyStacks) {
+                    var subStacks = partyStacks.get(hash);
+                    if (subStacks == null) {
+                        subStacks = new ArrayList<>();
+                        partyStacks.put(hash, subStacks);
+                    }
+                    subStacks.add(indexedStack);
+                    if (indexedFluidHandler != null) {
+                        partyFluidContainers.add(indexedFluidHandler);
+                    }
+                }
+            }
+        }
+    }
+
+    public static int getHashKey(ItemStack stack) {
+        return Objects.requireNonNull(stack.getItem().getRegistryName()).hashCode();
+    }
+
+    /**
+     * Get the combined count of an item stack in the party's inventory.
+     * @param req the requirement stack
+     * @param taskConsumes if true, will only count from the main player's inventory
+     * @param ignoreNBT if matching should ignore NBT
+     * @param partialMatch if partially matching NBT is allowed
+     * @return the total amount of the stack the party has, up to the required amount
+     */
+    public int getItemCountFor(BigItemStack req, boolean taskConsumes, boolean ignoreNBT, boolean partialMatch) {
+        var gatheredStacks = taskConsumes ? playerStacks : partyStacks;
+
+        // The stacks matched by Item
+        var subStacks = gatheredStacks.get(req.getHashKey());
+        if (subStacks == null || subStacks.isEmpty()) {
+            return 0;
+        }
+
+        // Collect count of the specific stack
+        int count = 0;
+        for (var indexedStack : subStacks) {
+            ItemStack stack = indexedStack.stack;
+            if (ItemComparison.BigStackMatch(req, stack, ignoreNBT, partialMatch)) {
+                count += stack.getCount();
+                if (count >= req.stackSize) break;
+            }
+        }
+        return Math.min(count, req.stackSize);
+    }
+
+    /**
+     * Get all fluid handlers from the party's inventory that can handle the given fluid stack.
+     * @param inputStack the fluid stack
+     * @param taskConsumes if true, will only search the main player's inventory
+     * @param ignoreNBT if matching should ignore NBT
+     * @return the context wrapping the applicable fluid handlers and max fluid amount available
+     */
+    public FluidMatchContext getFluidHandlersFor(FluidStack inputStack, boolean taskConsumes, boolean ignoreNBT) {
+        var gatheredHandlers = taskConsumes ? playerFluidContainers : partyFluidContainers;
+        if (gatheredHandlers.isEmpty()) {
+            return FluidMatchContext.EMPTY;
+        }
+
+        int amount = 0;
+        var handlers = new ArrayList<IndexedFluidHandler>();
+        for (var indexedHandler : gatheredHandlers) {
+            int numContainers = indexedHandler.handler.getContainer().getCount();
+            FluidStack toDrain = inputStack.copy();
+            if (ignoreNBT) {
+                toDrain.tag = null;
+            }
+            toDrain.amount /= numContainers; // Must be a multiple of the stack size to drain evenly
+            if (toDrain.amount <= 0) continue;
+
+            // Simulate the drain
+            FluidStack drained = indexedHandler.handler().drain(toDrain, false);
+            if (drained == null || drained.amount <= 0) continue;
+
+            amount += drained.amount * numContainers; // Multiply back the number of containers drained
+            handlers.add(indexedHandler);
+        }
+        return handlers.isEmpty() ? FluidMatchContext.EMPTY : new FluidMatchContext(amount, handlers);
+    }
+
+    /**
+     * Update any cached item stacks with a corresponding fluid handler. Must be called after any non-simulated drains
+     * of a fluid handler from the context.
+     *
+     * @param context the fluid match context
+     * @param taskConsumes if true, will only update the main player's cached stacks
+     * @see net.minecraftforge.fluids.FluidUtil#getFluidHandler(ItemStack) the contract this fulfills
+     */
+    public void updateFluidContainers(FluidMatchContext context, boolean taskConsumes) {
+        // Consume tasks for parties aren't currently supported.
+        if (!taskConsumes) return;
+
+        int toUpdate = 0;
+        for (List<IndexedItemStack> possibleStacks : playerStacks.values()) {
+            for (IndexedItemStack iStack : possibleStacks) {
+                for (IndexedFluidHandler iContainerStack : context.indexedFluidHandlers()) {
+                    if (iContainerStack.slot == iStack.slot && iContainerStack.sourceInv == iStack.sourceInv) {
+                        ItemStack container = iContainerStack.handler.getContainer();
+                        if (container == iStack.stack) break;
+
+                        // Update the player's inventory
+                        iContainerStack.sourceInv.setInventorySlotContents(iStack.slot, container);
+                        // As well as the cached stack
+                        iStack.updateCachedStack(container);
+                        toUpdate++;
+                        break;
+                    }
+                }
+                if (toUpdate >= context.indexedFluidHandlers.size()) return;
+            }
+        }
+    }
+
+    private static final class IndexedItemStack {
+        /** The cached stack */
+        private ItemStack stack;
+        /** The slot index of the stack */
+        private final int slot;
+        /** The player inventory this stack belongs to */
+        private final InventoryPlayer sourceInv;
+
+        private IndexedItemStack(ItemStack stack, int slot, InventoryPlayer sourceInv) {
+            this.stack = stack;
+            this.slot = slot;
+            this.sourceInv = sourceInv;
+        }
+
+        public void updateCachedStack(ItemStack stack) {
+            this.stack = stack;
+        }
+    }
+
+    /**
+     * A fluid handler associated with a fluid container belonging to a certain player's inventory
+     * @param handler the fluid container's handler
+     * @param slot the associated container's slot in the inventory
+     * @param sourceInv the player's inventory this fluid handler belongs to
+     */
+    @Desugar
+    public record IndexedFluidHandler(@Nonnull IFluidHandlerItem handler, int slot, InventoryPlayer sourceInv) {}
+
+    /**
+     * Fluid stack context with available fluid amount and the matched slots of the applicable fluid handlers
+     * @param drainableAmount total amount of the fluid that can be drained
+     * @param indexedFluidHandlers applicable fluid handlers
+     */
+    @Desugar
+    public record FluidMatchContext(int drainableAmount, List<IndexedFluidHandler> indexedFluidHandlers) {
+        public static final FluidMatchContext EMPTY = new FluidMatchContext(0, Collections.emptyList());
+    }
+}

--- a/src/main/java/betterquesting/questing/party/PartyManager.java
+++ b/src/main/java/betterquesting/questing/party/PartyManager.java
@@ -1,6 +1,8 @@
 package betterquesting.questing.party;
 
 import betterquesting.api.enums.EnumPartyStatus;
+import betterquesting.api.properties.IPropertyListener;
+import betterquesting.api.properties.IPropertyType;
 import betterquesting.api.properties.NativeProps;
 import betterquesting.api.questing.party.IParty;
 import betterquesting.api.questing.party.IPartyDatabase;
@@ -9,6 +11,8 @@ import betterquesting.api2.storage.SimpleDatabase;
 import betterquesting.storage.QuestSettings;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
+import net.minecraftforge.fml.common.FMLCommonHandler;
+import net.minecraftforge.fml.relauncher.Side;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -16,10 +20,17 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.UUID;
 
-public class PartyManager extends SimpleDatabase<IParty> implements IPartyDatabase {
-    public static final PartyManager INSTANCE = new PartyManager();
+public class PartyManager extends SimpleDatabase<IParty> implements IPartyDatabase, IPropertyListener<Boolean> {
+    public static final PartyManager INSTANCE;
+
+    static {
+        INSTANCE = new PartyManager();
+        NativeProps.PARTY_ENABLE.addListener(INSTANCE);
+    }
 
     private final HashMap<UUID, Integer> partyCache = new HashMap<>();
+    // Cache PARTY_ENABLED prop due to frequent checks when creating ParticipantInfo in tick handler.
+    private boolean partyEnabled;
 
     @Override
     public synchronized IParty createNew(int id) {
@@ -31,7 +42,7 @@ public class PartyManager extends SimpleDatabase<IParty> implements IPartyDataba
     @Nullable
     @Override
     public synchronized DBEntry<IParty> getParty(@Nonnull UUID uuid) {
-        if (!QuestSettings.INSTANCE.getProperty(NativeProps.PARTY_ENABLE))
+        if (!partyEnabled)
             return null; // We're merely preventing access. Not erasing data
 
         Integer cachedID = partyCache.get(uuid);
@@ -95,5 +106,12 @@ public class PartyManager extends SimpleDatabase<IParty> implements IPartyDataba
     public synchronized void reset() {
         super.reset();
         partyCache.clear();
+    }
+
+    @Override
+    public void propertyChanged(IPropertyType<Boolean> prop, Boolean newValue) {
+        if (prop == NativeProps.PARTY_ENABLE && FMLCommonHandler.instance().getEffectiveSide() == Side.SERVER) {
+            partyEnabled = newValue;
+        }
     }
 }

--- a/src/main/java/betterquesting/questing/tasks/TaskCrafting.java
+++ b/src/main/java/betterquesting/questing/tasks/TaskCrafting.java
@@ -107,7 +107,7 @@ public class TaskCrafting implements ITask {
             final BigItemStack rStack = requiredItems.get(i);
             final int index = i;
 
-            if (ItemComparison.StackMatch(rStack.getBaseStack(), stack, !ignoreNBT, partialMatch) || ItemComparison.OreDictionaryMatch(rStack.getOreIngredient(), rStack.GetTagCompound(), stack, !ignoreNBT, partialMatch)) {
+            if (ItemComparison.BigStackMatch(rStack, stack, ignoreNBT, partialMatch)) {
                 progress.forEach((entry) -> {
                     if (entry.getSecond()[index] >= rStack.stackSize) return;
                     entry.getSecond()[index] = Math.min(entry.getSecond()[index] + stack.getCount(), rStack.stackSize);

--- a/src/main/java/betterquesting/questing/tasks/TaskFluid.java
+++ b/src/main/java/betterquesting/questing/tasks/TaskFluid.java
@@ -111,7 +111,7 @@ public class TaskFluid implements ITaskInventory, IFluidTask, IItemTask {
             }
 
             int progressAmount = Math.min(reqRemaining, fluidHandlerContext.drainableAmount());
-            progressAmount = consumeRequired(rStack, partyInv, progressAmount, fluidHandlerContext);
+            progressAmount = consumeRequired(rStack, progressAmount, fluidHandlerContext);
             if (progressAmount > 0) {
                 invProgress[reqI] += progressAmount;
                 // Allows the fluid detection to split across multiple requirements.
@@ -133,13 +133,11 @@ public class TaskFluid implements ITaskInventory, IFluidTask, IItemTask {
      * Consume the given amount from the player's inventory if necessary.
      *
      * @param rStack          the required fluid stack
-     * @param partyInv        the party inventory
      * @param amountToConsume the amount to try to consume
      * @param context         the context with compatible fluid handlers
      * @return how much was actually consumed, or amountToConsume if this is not a consume task
      */
-    private int consumeRequired(FluidStack rStack, PartyInventory partyInv, int amountToConsume,
-                                PartyInventory.FluidMatchContext context) {
+    private int consumeRequired(FluidStack rStack, int amountToConsume, PartyInventory.FluidMatchContext context) {
         // Theoretically this could work in consume mode for parties but the priority order and manual submission code would need changing
         if (!consume) return amountToConsume;
 
@@ -147,23 +145,45 @@ public class TaskFluid implements ITaskInventory, IFluidTask, IItemTask {
         int remaining = drain.amount;
         int totalDrained = 0;
         for (var indexedContainer : context.indexedFluidContainers()) {
-            IFluidHandlerItem handler = indexedContainer.handler(false);
+            final IFluidHandlerItem handler = indexedContainer.handler(false);
             if (handler == null) continue;
             int numContainers = indexedContainer.stackCount();
 
-            FluidStack toDrain = drain.copy();
+            final FluidStack toDrain = drain.copy();
             // The context did the simulation, so do the actual drain.
-            FluidStack drained = handler.drain(toDrain, true);
+            final FluidStack drained = handler.drain(toDrain, true);
             if (drained == null || drained.amount <= 0) continue;
 
             int itemsNeeded = MathHelper.ceil((double) remaining / drained.amount);
             int itemsToConsume = Math.min(numContainers, itemsNeeded);
-            int amountDrained = drained.amount * itemsToConsume;
+            // Amount of items that were drained fully
+            int amountFullDrained = drained.amount * itemsToConsume;
 
-            // Make sure to update the inventory and cached container
+            if (amountFullDrained > remaining) {
+                // Handle partial drain for last needed container
+                int partialAmount = remaining % drained.amount;
+                IFluidHandlerItem partialHandler = indexedContainer.handler(false);
+                if (partialHandler != null) {
+                    // Build the handler's state after partial drain
+                    FluidStack toDrainPartial = drain.copy();
+                    toDrainPartial.amount = partialAmount;
+                    FluidStack drainedPartial = partialHandler.drain(toDrainPartial, true);
+                    if (drainedPartial != null && drainedPartial.amount > 0) {
+                        // Update the single, partially drained container
+                        indexedContainer.updateFluidContainer(partialHandler, 1, consume);
+                        totalDrained += drainedPartial.amount;
+                        remaining -= drainedPartial.amount;
+                        // Partial drain succeeded and updated, so don't count it with the other full drains
+                        amountFullDrained -= drained.amount;
+                        itemsToConsume--;
+                    }
+                }
+            }
+
+            // Make sure to update the inventory and cached container (fully drained ones only)
             indexedContainer.updateFluidContainer(handler, itemsToConsume, consume);
-            totalDrained += amountDrained;
-            remaining -= amountDrained;
+            totalDrained += amountFullDrained;
+            remaining -= amountFullDrained;
             if (remaining <= 0) {
                 break;
             }

--- a/src/main/java/betterquesting/questing/tasks/TaskFluid.java
+++ b/src/main/java/betterquesting/questing/tasks/TaskFluid.java
@@ -54,6 +54,7 @@ public class TaskFluid implements ITaskInventory, IFluidTask, IItemTask {
     public boolean consume = DEFAULT_CONSUME;
     public boolean groupDetect = DEFAULT_GROUP_DETECT;
     public boolean autoConsume = DEFAULT_AUTO_CONSUME;
+    private boolean progressChanged = false;
 
     @Override
     public ResourceLocation getFactoryID() {
@@ -195,6 +196,7 @@ public class TaskFluid implements ITaskInventory, IFluidTask, IItemTask {
                             && progressToMerge.length == requiredFluids.size(),
                     "Lengths of user's known progress and new detected progress to merge don't match!");
             if (groupDetect) {
+                progressChanged = true;
                 return progressToMerge;
             }
 
@@ -205,8 +207,12 @@ public class TaskFluid implements ITaskInventory, IFluidTask, IItemTask {
                 if (consume) {
                     // Make sure we keep the progress that has already consumed stuff before
                     existingProgress[i] += progressToMerge[i];
+                    progressChanged = true;
                 }
                 else {
+                    if (existingProgress[i] != progressToMerge[i]) {
+                        progressChanged = true;
+                    }
                     // Otherwise the progressIn overwrites the current progress
                     existingProgress[i] = progressToMerge[i];
                 }
@@ -227,6 +233,16 @@ public class TaskFluid implements ITaskInventory, IFluidTask, IItemTask {
      * @param progress the updated progress
      */
     private void checkAndComplete(ParticipantInfo pInfo, DBEntry<IQuest> quest, int[] progress) {
+        if (progressChanged) {
+            progressChanged = false;
+            var questID = Collections.singletonList(quest.getID());
+            if (consume) {
+                pInfo.markDirty(questID);
+            }
+            else {
+                pInfo.markDirtyParty(questID);
+            }
+        }
         // Check all requirements are complete
         for (int i = 0; i < progress.length; i++) {
             if (progress[i] < requiredFluids.get(i).amount) {
@@ -234,14 +250,11 @@ public class TaskFluid implements ITaskInventory, IFluidTask, IItemTask {
             }
         }
 
-        var questID = Collections.singletonList(quest.getID());
         if (consume) {
             setComplete(pInfo.UUID);
-            pInfo.markDirty(questID);
         }
         else {
             pInfo.ALL_UUIDS.forEach(this::setComplete);
-            pInfo.markDirtyParty(questID);
         }
     }
 

--- a/src/main/java/betterquesting/questing/tasks/TaskFluid.java
+++ b/src/main/java/betterquesting/questing/tasks/TaskFluid.java
@@ -149,7 +149,9 @@ public class TaskFluid implements ITaskInventory, IFluidTask, IItemTask {
             if (handler == null) continue;
             int numContainers = indexedContainer.stackCount();
 
+            // Amount remaining to drain
             final FluidStack toDrain = drain.copy();
+            toDrain.amount = remaining;
             // The context did the simulation, so do the actual drain.
             final FluidStack drained = handler.drain(toDrain, true);
             if (drained == null || drained.amount <= 0) continue;

--- a/src/main/java/betterquesting/questing/tasks/TaskFluid.java
+++ b/src/main/java/betterquesting/questing/tasks/TaskFluid.java
@@ -26,6 +26,7 @@ import net.minecraft.nbt.NBTTagString;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.util.NonNullList;
 import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.math.MathHelper;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.FluidUtil;
 import net.minecraftforge.fluids.capability.IFluidHandlerItem;
@@ -144,28 +145,28 @@ public class TaskFluid implements ITaskInventory, IFluidTask, IItemTask {
         FluidStack drain = new FluidStack(rStack.getFluid(), amountToConsume, ignoreNbt ? null : rStack.tag);
         int remaining = drain.amount;
         int totalDrained = 0;
-        for (var indexedContainer : context.indexedFluidHandlers()) {
-            IFluidHandlerItem handler = indexedContainer.handler();
-            int numContainers = indexedContainer.handler().getContainer().getCount();
+        for (var indexedContainer : context.indexedFluidContainers()) {
+            IFluidHandlerItem handler = indexedContainer.handler(false);
+            if (handler == null) continue;
+            int numContainers = indexedContainer.stackCount();
 
             FluidStack toDrain = drain.copy();
-            toDrain.amount = remaining / numContainers; // Must be a multiple of the stack size to drain evenly
-            if (toDrain.amount <= 0) continue;
-
             // The context did the simulation, so do the actual drain.
             FluidStack drained = handler.drain(toDrain, true);
             if (drained == null || drained.amount <= 0) continue;
 
-            int amountDrained = drained.amount * numContainers; // Multiply back the number of containers drained
+            int itemsNeeded = MathHelper.ceil((double) remaining / drained.amount);
+            int itemsToConsume = Math.min(numContainers, itemsNeeded);
+            int amountDrained = drained.amount * itemsToConsume;
+
+            // Make sure to update the inventory and cached container
+            indexedContainer.updateFluidContainer(handler, itemsToConsume, consume);
             totalDrained += amountDrained;
             remaining -= amountDrained;
             if (remaining <= 0) {
                 break;
             }
         }
-
-        // Make sure to update the inventory and cached containers
-        partyInv.updateFluidContainers(context, consume);
         return totalDrained;
     }
 

--- a/src/main/java/betterquesting/questing/tasks/TaskFluid.java
+++ b/src/main/java/betterquesting/questing/tasks/TaskFluid.java
@@ -13,6 +13,9 @@ import betterquesting.client.gui2.tasks.PanelTaskFluid;
 import betterquesting.core.BetterQuesting;
 import betterquesting.questing.party.PartyInventory;
 import betterquesting.questing.tasks.factory.FactoryTaskFluid;
+import com.google.common.base.Preconditions;
+import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
+import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.item.ItemStack;
@@ -23,7 +26,6 @@ import net.minecraft.nbt.NBTTagString;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.util.NonNullList;
 import net.minecraft.util.ResourceLocation;
-import net.minecraft.util.Tuple;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.FluidUtil;
 import net.minecraftforge.fluids.capability.IFluidHandlerItem;
@@ -43,9 +45,9 @@ public class TaskFluid implements ITaskInventory, IFluidTask, IItemTask {
     private static final boolean DEFAULT_CONSUME = false;
     private static final boolean DEFAULT_GROUP_DETECT = false;
     private static final boolean DEFAULT_AUTO_CONSUME = false;
-    private final Set<UUID> completeUsers = new TreeSet<>();
+    private final Set<UUID> completeUsers = new ObjectOpenHashSet<>();
     public final NonNullList<FluidStack> requiredFluids = NonNullList.create();
-    public final TreeMap<UUID, int[]> userProgress = new TreeMap<>();
+    public final Map<UUID, int[]> userProgress = new Object2ObjectOpenHashMap<>();
     //public boolean partialMatch = true; // Not many ideal ways of implementing this with fluid handlers
     public boolean ignoreNbt = DEFAULT_IGNORE_NBT;
     public boolean consume = DEFAULT_CONSUME;
@@ -84,69 +86,69 @@ public class TaskFluid implements ITaskInventory, IFluidTask, IItemTask {
         if (isComplete(pInfo.UUID)) {
             return;
         }
-        boolean updated = false;
-
-        // Removing the consume check here would make the task cheaper on groups and for that reason sharing is restricted to detect only
-        final List<Tuple<UUID, int[]>> progress = getBulkProgress(consume ? Collections.singletonList(pInfo.UUID) : pInfo.ALL_UUIDS);
-        if (!consume) {
-            if (groupDetect) // Reset all detect progress
-            {
-                progress.forEach((value) -> Arrays.fill(value.getSecond(), 0));
-            } else {
-                for (int i = 0; i < requiredFluids.size(); i++) {
-                    final int r = requiredFluids.get(i).amount;
-                    for (Tuple<UUID, int[]> value : progress) {
-                        int n = value.getSecond()[i];
-                        if (n != 0 && n < r) {
-                            value.getSecond()[i] = 0;
-                            updated = true;
-                        }
-                    }
-                }
-            }
-        }
-
+        int updatedReqs = 0;
         PartyInventory partyInv = pInfo.getPartyInventory();
 
-        for (int reqI = 0, reqSize = requiredFluids.size(); reqI < reqSize; reqI++) {
+        // The current progress so far for the player
+        int[] currentProgress = consume ? getUserProgress(pInfo.UUID) : null;
+        int reqSize = requiredFluids.size();
+        // The progress to fill based on current PartyInventory snapshot
+        int[] invProgress = new int[reqSize];
+
+        for (int reqI = 0; reqI < reqSize; reqI++) {
             final FluidStack rStack = requiredFluids.get(reqI);
 
             var fluidHandlerContext = partyInv.getFluidHandlersFor(rStack, consume, ignoreNbt);
             if (fluidHandlerContext == PartyInventory.FluidMatchContext.EMPTY) continue;
 
-            // Theoretically this could work in consume mode for parties but the priority order and manual submission code would need changing
-            for (Tuple<UUID, int[]> value : progress) {
-                // Skip if already fulfilled
-                if (value.getSecond()[reqI] >= rStack.amount) continue;
+            int reqRemaining = rStack.amount;
+            if (consume) {
+                // Account for already consumed progress
+                assert currentProgress != null && currentProgress.length > reqI;
+                reqRemaining -= currentProgress[reqI];
+            }
 
-                int reqRemaining = rStack.amount - value.getSecond()[reqI];
-                int progressAmount = Math.min(reqRemaining, fluidHandlerContext.drainableAmount());
-                if (consume) {
-                    FluidStack drain = new FluidStack(rStack.getFluid(), progressAmount, ignoreNbt ? null : rStack.tag);
-                    value.getSecond()[reqI] += consumeRequired(drain, partyInv, fluidHandlerContext);
-                }
-                else {
-                    value.getSecond()[reqI] += progressAmount;
-                }
-                updated = true;
+            int progressAmount = Math.min(reqRemaining, fluidHandlerContext.drainableAmount());
+            progressAmount = consumeRequired(rStack, partyInv, progressAmount, fluidHandlerContext);
+            if (progressAmount > 0) {
+                invProgress[reqI] += progressAmount;
+                // Allows the fluid detection to split across multiple requirements.
+                fluidHandlerContext.shrink(rStack, progressAmount);
+                updatedReqs++;
             }
         }
 
-        if (updated) {
-            setBulkProgress(progress);
+        if (updatedReqs > 0) {
+            // Reset counts used for split stack detection
+            partyInv.resetFluidAmounts(consume);
+            // Update cached progress and check completion
+            int[] updatedProgress = updateBulkProgress(invProgress, pInfo);
+            checkAndComplete(pInfo, quest, updatedProgress);
         }
-        // Reuse progress
-        checkAndComplete(pInfo, quest, updated, progress);
     }
 
-    private int consumeRequired(FluidStack req, PartyInventory partyInv, PartyInventory.FluidMatchContext context) {
-        int remaining = req.amount;
+    /**
+     * Consume the given amount from the player's inventory if necessary.
+     *
+     * @param rStack          the required fluid stack
+     * @param partyInv        the party inventory
+     * @param amountToConsume the amount to try to consume
+     * @param context         the context with compatible fluid handlers
+     * @return how much was actually consumed, or amountToConsume if this is not a consume task
+     */
+    private int consumeRequired(FluidStack rStack, PartyInventory partyInv, int amountToConsume,
+                                PartyInventory.FluidMatchContext context) {
+        // Theoretically this could work in consume mode for parties but the priority order and manual submission code would need changing
+        if (!consume) return amountToConsume;
+
+        FluidStack drain = new FluidStack(rStack.getFluid(), amountToConsume, ignoreNbt ? null : rStack.tag);
+        int remaining = drain.amount;
         int totalDrained = 0;
         for (var indexedContainer : context.indexedFluidHandlers()) {
             IFluidHandlerItem handler = indexedContainer.handler();
             int numContainers = indexedContainer.handler().getContainer().getCount();
 
-            FluidStack toDrain = req.copy();
+            FluidStack toDrain = drain.copy();
             toDrain.amount = remaining / numContainers; // Must be a multiple of the stack size to drain evenly
             if (toDrain.amount <= 0) continue;
 
@@ -167,38 +169,98 @@ public class TaskFluid implements ITaskInventory, IFluidTask, IItemTask {
         return totalDrained;
     }
 
-    private void checkAndComplete(ParticipantInfo pInfo, DBEntry<IQuest> quest, boolean resync) {
-        checkAndComplete(pInfo, quest, resync, getBulkProgress(consume ? Collections.singletonList(pInfo.UUID) : pInfo.ALL_UUIDS));
+    @Nonnull
+    private int[] updateBulkProgress(int[] playerProgress, ParticipantInfo pInfo) {
+        List<UUID> uuidsToUpdate = consume ? Collections.singletonList(pInfo.UUID) : pInfo.ALL_UUIDS;
+
+        int[] updatedProgress = updateUserProgress(pInfo.UUID, playerProgress);
+        for (UUID uuid : uuidsToUpdate) {
+            if (uuid == pInfo.UUID) continue;
+            updateUserProgress(uuid, playerProgress);
+        }
+        return updatedProgress;
     }
 
-    private void checkAndComplete(ParticipantInfo pInfo, DBEntry<IQuest> quest, boolean resync, List<Tuple<UUID, int[]>> progress) {
-        boolean updated = resync;
-
-        topLoop:
-        for (Tuple<UUID, int[]> value : progress) {
-            for (int j = 0; j < requiredFluids.size(); j++) {
-                if (value.getSecond()[j] >= requiredFluids.get(j).amount) continue;
-                continue topLoop;
+    /**
+     * Update the task progress for given user
+     *
+     * @param userUUID      the user's id
+     * @param progressIn    the progress to merge, treated as immutable
+     * @return the updated task progress
+     */
+    private int[] updateUserProgress(UUID userUUID, int[] progressIn) {
+        return userProgress.merge(userUUID, progressIn, (existingProgress, progressToMerge) -> {
+            Preconditions.checkArgument(existingProgress.length == progressToMerge.length
+                            && progressToMerge.length == requiredFluids.size(),
+                    "Lengths of user's known progress and new detected progress to merge don't match!");
+            if (groupDetect) {
+                return progressToMerge;
             }
 
-            updated = true;
+            for (int i = 0; i < existingProgress.length; i++) {
+                // Skip if already fulfilled
+                if (existingProgress[i] >= requiredFluids.get(i).amount) continue;
 
-            if (consume) {
-                setComplete(value.getFirst());
-            } else {
-                progress.forEach((pair) -> setComplete(pair.getFirst()));
-                break;
+                if (consume) {
+                    // Make sure we keep the progress that has already consumed stuff before
+                    existingProgress[i] += progressToMerge[i];
+                }
+                else {
+                    // Otherwise the progressIn overwrites the current progress
+                    existingProgress[i] = progressToMerge[i];
+                }
+            }
+            return existingProgress;
+        });
+    }
+
+    public int[] getUserProgress(UUID uuidIn) {
+        return userProgress.compute(uuidIn, (uuid, progress) ->
+                progress == null || progress.length != requiredFluids.size() ? new int[requiredFluids.size()] : progress);
+    }
+
+    /**
+     * Check if the detected progress allows completion of the task's quest.
+     * @param pInfo the participant's info
+     * @param quest the quest to possibly complete
+     * @param progress the updated progress
+     */
+    private void checkAndComplete(ParticipantInfo pInfo, DBEntry<IQuest> quest, int[] progress) {
+        // Check all requirements are complete
+        for (int i = 0; i < progress.length; i++) {
+            if (progress[i] < requiredFluids.get(i).amount) {
+                return;
             }
         }
 
-        if (updated) {
-            if (consume) {
-                pInfo.markDirty(Collections.singletonList(quest.getID()));
-            } else {
-                pInfo.markDirtyParty(Collections.singletonList(quest.getID()));
-            }
+        var questID = Collections.singletonList(quest.getID());
+        if (consume) {
+            setComplete(pInfo.UUID);
+            pInfo.markDirty(questID);
+        }
+        else {
+            pInfo.ALL_UUIDS.forEach(this::setComplete);
+            pInfo.markDirtyParty(questID);
         }
     }
+
+    /**
+     * Check if the given progress for a single player would complete the quest.
+     * @param uuid the UUID of the player
+     * @param progress the updated progress
+     */
+    private void checkAndComplete(UUID uuid, int[] progress) {
+        // Check all requirements are complete
+        for (int i = 0; i < progress.length; i++) {
+            if (progress[i] < requiredFluids.get(i).amount) {
+                return;
+            }
+        }
+
+        setComplete(uuid);
+    }
+
+    /* NBT handling */
 
     @Deprecated
     @Override
@@ -281,22 +343,30 @@ public class TaskFluid implements ITaskInventory, IFluidTask, IItemTask {
 
         if (users != null) {
             users.forEach((uuid) -> {
-                if (completeUsers.contains(uuid)) jArray.appendTag(new NBTTagString(uuid.toString()));
+                if (completeUsers.contains(uuid)) {
+                    jArray.appendTag(new NBTTagString(uuid.toString()));
+                }
 
                 int[] data = userProgress.get(uuid);
                 if (data != null) {
                     NBTTagCompound pJson = new NBTTagCompound();
                     pJson.setString("uuid", uuid.toString());
                     NBTTagList pArray = new NBTTagList(); // TODO: Why the heck isn't this just an int array?!
-                    for (int i : data) pArray.appendTag(new NBTTagInt(i));
+                    for (int i : data) {
+                        pArray.appendTag(new NBTTagInt(i));
+                    }
                     pJson.setTag("data", pArray);
                     progArray.appendTag(pJson);
                 }
             });
         } else {
-            completeUsers.forEach((uuid) -> jArray.appendTag(new NBTTagString(uuid.toString())));
+            // Ensure consistent order when writing
+            TreeSet<UUID> sortedCompleteUsers = new TreeSet<>(completeUsers);
+            TreeMap<UUID, int[]> sortedProgress = new TreeMap<>(userProgress);
 
-            userProgress.forEach((uuid, data) -> {
+            sortedCompleteUsers.forEach((uuid) -> jArray.appendTag(new NBTTagString(uuid.toString())));
+
+            sortedProgress.forEach((uuid, data) -> {
                 NBTTagCompound pJson = new NBTTagCompound();
                 pJson.setString("uuid", uuid.toString());
                 NBTTagList pArray = new NBTTagList(); // TODO: Why the heck isn't this just an int array?!
@@ -341,7 +411,7 @@ public class TaskFluid implements ITaskInventory, IFluidTask, IItemTask {
             return false;
         }
 
-        int[] progress = getUsersProgress(owner);
+        int[] progress = getUserProgress(owner);
 
         for (int j = 0; j < requiredFluids.size(); j++) {
             FluidStack rStack = requiredFluids.get(j).copy();
@@ -378,12 +448,15 @@ public class TaskFluid implements ITaskInventory, IFluidTask, IItemTask {
         return submitFluidInternal(owner, quest, fluid, true);
     }
 
-    private FluidStack submitFluidInternal(UUID owner, DBEntry<IQuest> quest, FluidStack fluid, boolean doFill) {
-        if (owner == null || fluid == null || fluid.amount <= 0 || !consume || isComplete(owner) || requiredFluids.size() <= 0) {
-            return fluid;
+    private FluidStack submitFluidInternal(UUID owner, DBEntry<IQuest> quest, FluidStack fluidIn, boolean doFill) {
+        if (owner == null || fluidIn == null || fluidIn.amount <= 0 || !consume || isComplete(owner) || requiredFluids.size() <= 0) {
+            return fluidIn;
         }
 
-        int[] progress = getUsersProgress(owner).clone();
+        FluidStack fluid = fluidIn.copy();
+
+        // Direct reference to value in userProgress
+        int[] progress = getUserProgress(owner);
         boolean updated = false;
 
         for (int j = 0; j < requiredFluids.size(); j++) {
@@ -407,24 +480,13 @@ public class TaskFluid implements ITaskInventory, IFluidTask, IItemTask {
         }
 
         if (updated && doFill) {
-            setUserProgress(owner, progress);
-
             MinecraftServer server = FMLCommonHandler.instance().getMinecraftServerInstance();
             EntityPlayerMP player = server == null ? null : server.getPlayerList().getPlayerByUUID(owner);
 
             if (player != null) {
-                checkAndComplete(new ParticipantInfo(player), quest, true);
+                checkAndComplete(new ParticipantInfo(player), quest, progress);
             } else {
-                // It's implied to be a consume task so no need to lookup the party
-                boolean hasAll = true;
-                for (int j = 0; j < requiredFluids.size(); j++) {
-                    if (progress[j] >= requiredFluids.get(j).amount) continue;
-
-                    hasAll = false;
-                    break;
-                }
-
-                if (hasAll) setComplete(owner);
+                checkAndComplete(owner, progress);
             }
         }
 
@@ -458,26 +520,6 @@ public class TaskFluid implements ITaskInventory, IFluidTask, IItemTask {
         }
 
         return hasDrained ? handler.getContainer() : item;
-    }
-
-    private void setUserProgress(UUID uuid, int[] progress) {
-        userProgress.put(uuid, progress);
-    }
-
-    public int[] getUsersProgress(UUID uuid) {
-        int[] progress = userProgress.get(uuid);
-        return progress == null || progress.length != requiredFluids.size() ? new int[requiredFluids.size()] : progress;
-    }
-
-    private List<Tuple<UUID, int[]>> getBulkProgress(@Nonnull List<UUID> uuids) {
-        if (uuids.size() <= 0) return Collections.emptyList();
-        List<Tuple<UUID, int[]>> list = new ArrayList<>();
-        uuids.forEach((key) -> list.add(new Tuple<>(key, getUsersProgress(key))));
-        return list;
-    }
-
-    private void setBulkProgress(@Nonnull List<Tuple<UUID, int[]>> list) {
-        list.forEach((entry) -> setUserProgress(entry.getFirst(), entry.getSecond()));
     }
 
     @Override

--- a/src/main/java/betterquesting/questing/tasks/TaskFluid.java
+++ b/src/main/java/betterquesting/questing/tasks/TaskFluid.java
@@ -234,8 +234,7 @@ public class TaskFluid implements ITaskInventory, IFluidTask, IItemTask {
                     // Make sure we keep the progress that has already consumed stuff before
                     existingProgress[i] += progressToMerge[i];
                     progressChanged = true;
-                }
-                else if (existingProgress[i] != progressToMerge[i]) {
+                } else if (existingProgress[i] != progressToMerge[i]) {
                     // Otherwise the progressIn overwrites the current progress
                     existingProgress[i] = progressToMerge[i];
                     progressChanged = true;
@@ -263,8 +262,7 @@ public class TaskFluid implements ITaskInventory, IFluidTask, IItemTask {
             var questID = Collections.singletonList(quest.getID());
             if (consume) {
                 pInfo.markDirty(questID);
-            }
-            else {
+            } else {
                 pInfo.markDirtyParty(questID);
             }
         }
@@ -277,8 +275,7 @@ public class TaskFluid implements ITaskInventory, IFluidTask, IItemTask {
 
         if (consume) {
             setComplete(pInfo.UUID);
-        }
-        else {
+        } else {
             pInfo.ALL_UUIDS.forEach(this::setComplete);
         }
     }

--- a/src/main/java/betterquesting/questing/tasks/TaskFluid.java
+++ b/src/main/java/betterquesting/questing/tasks/TaskFluid.java
@@ -91,8 +91,9 @@ public class TaskFluid implements ITaskInventory, IFluidTask, IItemTask {
         int updatedReqs = 0;
         PartyInventory partyInv = pInfo.getPartyInventory();
 
+        boolean taskConsumes = consume;
         // The current progress so far for the player
-        int[] currentProgress = consume ? getUserProgress(pInfo.UUID) : null;
+        int[] currentProgress = taskConsumes ? getUserProgress(pInfo.UUID) : null;
         int reqSize = requiredFluids.size();
         // The progress to fill based on current PartyInventory snapshot
         int[] invProgress = new int[reqSize];
@@ -100,13 +101,12 @@ public class TaskFluid implements ITaskInventory, IFluidTask, IItemTask {
         for (int reqI = 0; reqI < reqSize; reqI++) {
             final FluidStack rStack = requiredFluids.get(reqI);
 
-            var fluidHandlerContext = partyInv.getFluidHandlersFor(rStack, consume, ignoreNbt);
+            var fluidHandlerContext = partyInv.getFluidHandlersFor(rStack, taskConsumes, ignoreNbt);
             if (fluidHandlerContext == PartyInventory.FluidMatchContext.EMPTY) continue;
 
             int reqRemaining = rStack.amount;
-            if (consume) {
+            if (taskConsumes) {
                 // Account for already consumed progress
-                assert currentProgress != null && currentProgress.length > reqI;
                 reqRemaining -= currentProgress[reqI];
             }
 
@@ -122,7 +122,7 @@ public class TaskFluid implements ITaskInventory, IFluidTask, IItemTask {
 
         if (updatedReqs > 0) {
             // Reset counts used for split stack detection
-            partyInv.resetFluidAmounts(consume);
+            partyInv.resetFluidAmounts(taskConsumes);
             // Update cached progress and check completion
             int[] updatedProgress = updateBulkProgress(invProgress, pInfo);
             checkAndComplete(pInfo, quest, updatedProgress);
@@ -193,12 +193,13 @@ public class TaskFluid implements ITaskInventory, IFluidTask, IItemTask {
 
     @Nonnull
     private int[] updateBulkProgress(int[] playerProgress, ParticipantInfo pInfo) {
-        List<UUID> uuidsToUpdate = consume ? Collections.singletonList(pInfo.UUID) : pInfo.ALL_UUIDS;
-
         int[] updatedProgress = updateUserProgress(pInfo.UUID, playerProgress);
-        for (UUID uuid : uuidsToUpdate) {
-            if (uuid == pInfo.UUID) continue;
-            updateUserProgress(uuid, playerProgress);
+        if (!consume) {
+            // Update all other party member's progress with playerProgress
+            for (UUID uuid : pInfo.ALL_UUIDS) {
+                if (uuid == pInfo.UUID) continue;
+                updateUserProgress(uuid, playerProgress);
+            }
         }
         return updatedProgress;
     }
@@ -229,18 +230,17 @@ public class TaskFluid implements ITaskInventory, IFluidTask, IItemTask {
                     existingProgress[i] += progressToMerge[i];
                     progressChanged = true;
                 }
-                else {
-                    if (existingProgress[i] != progressToMerge[i]) {
-                        progressChanged = true;
-                    }
+                else if (existingProgress[i] != progressToMerge[i]) {
                     // Otherwise the progressIn overwrites the current progress
                     existingProgress[i] = progressToMerge[i];
+                    progressChanged = true;
                 }
             }
             return existingProgress;
         });
     }
 
+    @Nonnull
     public int[] getUserProgress(UUID uuidIn) {
         return userProgress.compute(uuidIn, (uuid, progress) ->
                 progress == null || progress.length != requiredFluids.size() ? new int[requiredFluids.size()] : progress);

--- a/src/main/java/betterquesting/questing/tasks/TaskFluid.java
+++ b/src/main/java/betterquesting/questing/tasks/TaskFluid.java
@@ -11,10 +11,10 @@ import betterquesting.api2.storage.DBEntry;
 import betterquesting.api2.utils.ParticipantInfo;
 import betterquesting.client.gui2.tasks.PanelTaskFluid;
 import betterquesting.core.BetterQuesting;
+import betterquesting.questing.party.PartyInventory;
 import betterquesting.questing.tasks.factory.FactoryTaskFluid;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.entity.player.EntityPlayerMP;
-import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagInt;
@@ -81,12 +81,13 @@ public class TaskFluid implements ITaskInventory, IFluidTask, IItemTask {
 
     @Override
     public void detect(ParticipantInfo pInfo, DBEntry<IQuest> quest) {
-        if (isComplete(pInfo.UUID)) return;
+        if (isComplete(pInfo.UUID)) {
+            return;
+        }
+        boolean updated = false;
 
         // Removing the consume check here would make the task cheaper on groups and for that reason sharing is restricted to detect only
         final List<Tuple<UUID, int[]>> progress = getBulkProgress(consume ? Collections.singletonList(pInfo.UUID) : pInfo.ALL_UUIDS);
-        boolean updated = false;
-
         if (!consume) {
             if (groupDetect) // Reset all detect progress
             {
@@ -105,63 +106,72 @@ public class TaskFluid implements ITaskInventory, IFluidTask, IItemTask {
             }
         }
 
-        final List<InventoryPlayer> invoList;
-        if (consume) {
-            // We do not support consuming resources from other member's invetories.
-            // This could otherwise be abused to siphon items/fluids unknowingly
-            invoList = Collections.singletonList(pInfo.PLAYER.inventory);
-        } else {
-            invoList = new ArrayList<>();
-            pInfo.ACTIVE_PLAYERS.forEach((p) -> invoList.add(p.inventory));
-        }
+        PartyInventory partyInv = pInfo.getPartyInventory();
 
-        for (InventoryPlayer invo : invoList) {
-            for (int i = 0; i < invo.getSizeInventory(); i++) {
-                ItemStack stack = invo.getStackInSlot(i);
-                if (stack.isEmpty()) continue;
-                IFluidHandlerItem handler = FluidUtil.getFluidHandler(stack);
-                if (handler == null) continue;
+        for (int reqI = 0, reqSize = requiredFluids.size(); reqI < reqSize; reqI++) {
+            final FluidStack rStack = requiredFluids.get(reqI);
 
-                boolean hasDrained = false;
+            var fluidHandlerContext = partyInv.getFluidHandlersFor(rStack, consume, ignoreNbt);
+            if (fluidHandlerContext == PartyInventory.FluidMatchContext.EMPTY) continue;
 
-                for (int j = 0; j < requiredFluids.size(); j++) {
-                    final FluidStack rStack = requiredFluids.get(j);
-                    FluidStack drainOG = rStack.copy();
-                    if (ignoreNbt) drainOG.tag = null;
+            // Theoretically this could work in consume mode for parties but the priority order and manual submission code would need changing
+            for (Tuple<UUID, int[]> value : progress) {
+                // Skip if already fulfilled
+                if (value.getSecond()[reqI] >= rStack.amount) continue;
 
-                    // Pre-check
-                    FluidStack sample = handler.drain(drainOG, false);
-                    if (sample == null || sample.amount <= 0) continue;
-
-                    // Theoretically this could work in consume mode for parties but the priority order and manual submission code would need changing
-                    for (Tuple<UUID, int[]> value : progress) {
-                        if (value.getSecond()[j] >= rStack.amount) continue;
-                        int remaining = rStack.amount - value.getSecond()[j];
-
-                        FluidStack drain = rStack.copy();
-                        drain.amount = remaining / stack.getCount(); // Must be a multiple of the stack size
-                        if (ignoreNbt) drain.tag = null;
-                        if (drain.amount <= 0) continue;
-
-                        FluidStack fluid = handler.drain(drain, consume); // TODO: Look into reducing this to a single call if possible
-                        if (fluid == null || fluid.amount <= 0) continue;
-
-                        value.getSecond()[j] += fluid.amount * stack.getCount();
-                        hasDrained = true;
-                        updated = true;
-                    }
+                int reqRemaining = rStack.amount - value.getSecond()[reqI];
+                int progressAmount = Math.min(reqRemaining, fluidHandlerContext.drainableAmount());
+                if (consume) {
+                    FluidStack drain = new FluidStack(rStack.getFluid(), progressAmount, ignoreNbt ? null : rStack.tag);
+                    value.getSecond()[reqI] += consumeRequired(drain, partyInv, fluidHandlerContext);
                 }
-
-                if (hasDrained && consume) invo.setInventorySlotContents(i, handler.getContainer());
+                else {
+                    value.getSecond()[reqI] += progressAmount;
+                }
+                updated = true;
             }
         }
 
-        if (updated) setBulkProgress(progress);
-        checkAndComplete(pInfo, quest, updated);
+        if (updated) {
+            setBulkProgress(progress);
+        }
+        // Reuse progress
+        checkAndComplete(pInfo, quest, updated, progress);
+    }
+
+    private int consumeRequired(FluidStack req, PartyInventory partyInv, PartyInventory.FluidMatchContext context) {
+        int remaining = req.amount;
+        int totalDrained = 0;
+        for (var indexedContainer : context.indexedFluidHandlers()) {
+            IFluidHandlerItem handler = indexedContainer.handler();
+            int numContainers = indexedContainer.handler().getContainer().getCount();
+
+            FluidStack toDrain = req.copy();
+            toDrain.amount = remaining / numContainers; // Must be a multiple of the stack size to drain evenly
+            if (toDrain.amount <= 0) continue;
+
+            // The context did the simulation, so do the actual drain.
+            FluidStack drained = handler.drain(toDrain, true);
+            if (drained == null || drained.amount <= 0) continue;
+
+            int amountDrained = drained.amount * numContainers; // Multiply back the number of containers drained
+            totalDrained += amountDrained;
+            remaining -= amountDrained;
+            if (remaining <= 0) {
+                break;
+            }
+        }
+
+        // Make sure to update the inventory and cached containers
+        partyInv.updateFluidContainers(context, consume);
+        return totalDrained;
     }
 
     private void checkAndComplete(ParticipantInfo pInfo, DBEntry<IQuest> quest, boolean resync) {
-        final List<Tuple<UUID, int[]>> progress = getBulkProgress(consume ? Collections.singletonList(pInfo.UUID) : pInfo.ALL_UUIDS);
+        checkAndComplete(pInfo, quest, resync, getBulkProgress(consume ? Collections.singletonList(pInfo.UUID) : pInfo.ALL_UUIDS));
+    }
+
+    private void checkAndComplete(ParticipantInfo pInfo, DBEntry<IQuest> quest, boolean resync, List<Tuple<UUID, int[]>> progress) {
         boolean updated = resync;
 
         topLoop:

--- a/src/main/java/betterquesting/questing/tasks/TaskFluid.java
+++ b/src/main/java/betterquesting/questing/tasks/TaskFluid.java
@@ -213,9 +213,12 @@ public class TaskFluid implements ITaskInventory, IFluidTask, IItemTask {
      */
     private int[] updateUserProgress(UUID userUUID, int[] progressIn) {
         return userProgress.merge(userUUID, progressIn, (existingProgress, progressToMerge) -> {
-            Preconditions.checkArgument(existingProgress.length == progressToMerge.length
-                            && progressToMerge.length == requiredFluids.size(),
-                    "Lengths of user's known progress and new detected progress to merge don't match!");
+            // Somehow the existing progress doesn't reflect current requirements, only use new progress.
+            if (existingProgress.length != requiredFluids.size()) {
+                progressChanged = true;
+                return progressToMerge;
+            }
+            // Group-detect requires all requirements to be met within this single detection.
             if (groupDetect) {
                 progressChanged = true;
                 return progressToMerge;

--- a/src/main/java/betterquesting/questing/tasks/TaskInteractEntity.java
+++ b/src/main/java/betterquesting/questing/tasks/TaskInteractEntity.java
@@ -90,10 +90,9 @@ public class TaskInteractEntity implements ITask {
             if (!ItemComparison.CompareNBTTag(entityTags, subjectTags, true)) return;
         }
 
+        // Check that we're interacting using the correct item (if one is needed)
         if (targetItem.getBaseStack().getItem() != Items.AIR) {
-            if (targetItem.hasOreDict() && !ItemComparison.OreDictionaryMatch(targetItem.getOreIngredient(), targetItem.GetTagCompound(), item, !ignoreItemNBT, partialItemMatch)) {
-                return;
-            } else if (!ItemComparison.StackMatch(targetItem.getBaseStack(), item, !ignoreItemNBT, partialItemMatch)) {
+            if (!ItemComparison.BigStackMatch(targetItem, item, ignoreItemNBT, partialItemMatch)) {
                 return;
             }
         }

--- a/src/main/java/betterquesting/questing/tasks/TaskInteractItem.java
+++ b/src/main/java/betterquesting/questing/tasks/TaskInteractItem.java
@@ -84,10 +84,9 @@ public class TaskInteractItem implements ITask {
             }
         }
 
+        // Check that we're interacting using the correct item (if one is needed)
         if (targetItem.getBaseStack().getItem() != Items.AIR) {
-            if (targetItem.hasOreDict() && !ItemComparison.OreDictionaryMatch(targetItem.getOreIngredient(), targetItem.GetTagCompound(), item, !ignoreNBT, partialMatch)) {
-                return;
-            } else if (!ItemComparison.StackMatch(targetItem.getBaseStack(), item, !ignoreNBT, partialMatch)) {
+            if (!ItemComparison.BigStackMatch(targetItem, item, ignoreNBT, partialMatch)) {
                 return;
             }
         }

--- a/src/main/java/betterquesting/questing/tasks/TaskRetrieval.java
+++ b/src/main/java/betterquesting/questing/tasks/TaskRetrieval.java
@@ -14,10 +14,11 @@ import betterquesting.api2.utils.ParticipantInfo;
 import betterquesting.client.gui2.editors.tasks.GuiEditTaskRetrieval;
 import betterquesting.client.gui2.tasks.PanelTaskRetrieval;
 import betterquesting.core.BetterQuesting;
+import betterquesting.questing.party.PartyInventory;
 import betterquesting.questing.tasks.factory.FactoryTaskRetrieval;
 import net.minecraft.client.gui.GuiScreen;
+import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
-import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagInt;
@@ -30,6 +31,9 @@ import net.minecraft.util.Tuple;
 import net.minecraftforge.fml.common.FMLCommonHandler;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
+import net.minecraftforge.items.IItemHandler;
+import net.minecraftforge.items.wrapper.EmptyHandler;
+import net.minecraftforge.items.wrapper.PlayerInvWrapper;
 import org.apache.logging.log4j.Level;
 
 import javax.annotation.Nonnull;
@@ -84,13 +88,14 @@ public class TaskRetrieval implements ITaskInventory, IItemTask {
 
     @Override
     public void detect(ParticipantInfo pInfo, DBEntry<IQuest> quest) {
-        if (isComplete(pInfo.UUID))
+        if (isComplete(pInfo.UUID)) {
             return;
-
-        // List of (player uuid, [progress per required item])
-        final List<Tuple<UUID, int[]>> progress = getBulkProgress(consume ? Collections.singletonList(pInfo.UUID) : pInfo.ALL_UUIDS);
+        }
         boolean updated = false;
 
+        // TODO: rewrite progress retrieval/updating
+        // List of (player uuid, [progress per required item])
+        final List<Tuple<UUID, int[]>> progress = getBulkProgress(consume ? Collections.singletonList(pInfo.UUID) : pInfo.ALL_UUIDS);
         if (!consume) {
             if (groupDetect) // Reset all detect progress
             {
@@ -109,57 +114,66 @@ public class TaskRetrieval implements ITaskInventory, IItemTask {
             }
         }
 
-        final List<InventoryPlayer> invoList;
-        if (consume) {
-            invoList = Collections.singletonList(pInfo.PLAYER.inventory);
-        } else {
-            invoList = new ArrayList<>(pInfo.ACTIVE_PLAYERS.size());
-            pInfo.ACTIVE_PLAYERS.forEach((p) -> invoList.add(p.inventory));
-        }
+        IItemHandler playerInv = consume ? new PlayerInvWrapper(pInfo.PLAYER.inventory) : EmptyHandler.INSTANCE;
+        PartyInventory partyInv = pInfo.getPartyInventory();
 
-        int[] remCounts = new int[progress.size()];
-        for (InventoryPlayer invo : invoList) {
-            for (int i = 0; i < invo.getSizeInventory(); i++) {
-                ItemStack stack = invo.getStackInSlot(i);
-                if (stack.isEmpty())
-                    continue;
-                // Allows the stack detection to split across multiple requirements. Counts may vary per person
-                Arrays.fill(remCounts, stack.getCount());
+        for (int reqI = 0, reqSize = requiredItems.size(); reqI < reqSize; reqI++) {
+            BigItemStack rStack = requiredItems.get(reqI);
 
-                for (int j = 0; j < requiredItems.size(); j++) {
-                    BigItemStack rStack = requiredItems.get(j);
+            int partyStackCount = partyInv.getItemCountFor(rStack, consume, ignoreNBT, partialMatch);
+            if (partyStackCount <= 0) continue;
 
-                    if (!ItemComparison.StackMatch(rStack.getBaseStack(), stack, !ignoreNBT, partialMatch) && !ItemComparison.OreDictionaryMatch(rStack.getOreIngredient(), rStack.GetTagCompound(), stack, !ignoreNBT, partialMatch)) {
-                        continue;
-                    }
+            // Theoretically this could work in consume mode for parties but the priority order and manual submission code would need changing
+            for (Tuple<UUID, int[]> value : progress) {
+                // Skip if already fulfilled
+                if (value.getSecond()[reqI] >= rStack.stackSize) continue;
 
-                    // Theoretically this could work in consume mode for parties but the priority order and manual submission code would need changing
-                    for (int n = 0; n < progress.size(); n++) {
-                        Tuple<UUID, int[]> value = progress.get(n);
-                        if (value.getSecond()[j] >= rStack.stackSize)
-                            continue;
-
-                        int remaining = rStack.stackSize - value.getSecond()[j];
-
-                        if (consume) {
-                            ItemStack removed = invo.decrStackSize(i, remaining);
-                            value.getSecond()[j] += removed.getCount();
-                        } else {
-                            int temp = Math.min(remaining, remCounts[n]);
-                            remCounts[n] -= temp;
-                            value.getSecond()[j] += temp;
-                        }
-
-                        updated = true;
-                    }
+                int reqRemaining = rStack.stackSize - value.getSecond()[reqI];
+                int progressAmount = Math.min(reqRemaining, partyStackCount);
+                if (consume) {
+                    value.getSecond()[reqI] += consumeRequired(rStack, playerInv, pInfo.PLAYER, progressAmount);
                 }
+                else {
+                    value.getSecond()[reqI] += progressAmount;
+                }
+
+                updated = true;
             }
         }
 
-        if (updated)
+        if (updated) {
             setBulkProgress(progress);
+        }
         // Reuse progress
         checkAndComplete(pInfo, quest, updated, progress);
+    }
+
+    private int consumeRequired(BigItemStack req, IItemHandler inv, EntityPlayer player, int amountToConsume) {
+        int remaining = amountToConsume;
+        int totalConsumed = 0;
+        // Just scan the whole inventory, this shouldn't be called often
+        for (int slot = 0, numSlots = inv.getSlots(); slot < numSlots; slot++) {
+            ItemStack simulated = inv.extractItem(slot, remaining, true);
+            // Must match and be extractable
+            if (simulated.isEmpty() || !ItemComparison.BigStackMatch(req, simulated, ignoreNBT, partialMatch)) {
+                continue;
+            }
+
+            int toExtract = Math.min(simulated.getCount(), remaining);
+            ItemStack extracted = inv.extractItem(slot, toExtract, false);
+            if (!extracted.isEmpty()) {
+                int amountExtracted = extracted.getCount();
+                totalConsumed += amountExtracted;
+                remaining -= amountExtracted;
+                if (remaining <= 0) {
+                    break;
+                }
+            }
+        }
+        if (totalConsumed > 0) {
+            player.openContainer.detectAndSendChanges();
+        }
+        return totalConsumed;
     }
 
     private void checkAndComplete(ParticipantInfo pInfo, DBEntry<IQuest> quest, boolean resync) {
@@ -421,10 +435,13 @@ public class TaskRetrieval implements ITaskInventory, IItemTask {
     }
 
     private List<Tuple<UUID, int[]>> getBulkProgress(@Nonnull List<UUID> uuids) {
-        if (uuids.size() <= 0)
+        if (uuids.isEmpty()) {
             return Collections.emptyList();
+        }
         List<Tuple<UUID, int[]>> list = new ArrayList<>(uuids.size());
-        uuids.forEach((key) -> list.add(new Tuple<>(key, getUsersProgress(key))));
+        for (var uuid : uuids) {
+            list.add(new Tuple<>(uuid, getUsersProgress(uuid)));
+        }
         return list;
     }
 

--- a/src/main/java/betterquesting/questing/tasks/TaskRetrieval.java
+++ b/src/main/java/betterquesting/questing/tasks/TaskRetrieval.java
@@ -16,6 +16,9 @@ import betterquesting.client.gui2.tasks.PanelTaskRetrieval;
 import betterquesting.core.BetterQuesting;
 import betterquesting.questing.party.PartyInventory;
 import betterquesting.questing.tasks.factory.FactoryTaskRetrieval;
+import com.google.common.base.Preconditions;
+import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
+import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
@@ -27,7 +30,6 @@ import net.minecraft.nbt.NBTTagString;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.util.NonNullList;
 import net.minecraft.util.ResourceLocation;
-import net.minecraft.util.Tuple;
 import net.minecraftforge.fml.common.FMLCommonHandler;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
@@ -39,7 +41,6 @@ import org.apache.logging.log4j.Level;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.*;
-import java.util.stream.IntStream;
 
 public class TaskRetrieval implements ITaskInventory, IItemTask {
 
@@ -49,15 +50,29 @@ public class TaskRetrieval implements ITaskInventory, IItemTask {
     private static final boolean DEFAULT_GROUP_DETECT = false;
     private static final boolean DEFAULT_AUTO_CONSUME = false;
     private static final EnumLogic DEFAULT_ENTRY_LOGIC = EnumLogic.AND;
-    private final Set<UUID> completeUsers = new TreeSet<>();
+
+    private final Set<UUID> completeUsers = new ObjectOpenHashSet<>();
     public final NonNullList<BigItemStack> requiredItems = NonNullList.create();
-    private final TreeMap<UUID, int[]> userProgress = new TreeMap<>();
+    private final Map<UUID, int[]> userProgress = new Object2ObjectOpenHashMap<>();
     public boolean partialMatch = DEFAULT_PARTIAL_MATCH;
     public boolean ignoreNBT = DEFAULT_IGNORE_NBT;
     public boolean consume = DEFAULT_CONSUME;
     public boolean groupDetect = DEFAULT_GROUP_DETECT;
     public boolean autoConsume = DEFAULT_AUTO_CONSUME;
-    public EnumLogic entryLogic = DEFAULT_ENTRY_LOGIC;
+    private EnumLogic entryLogic = DEFAULT_ENTRY_LOGIC;
+    private boolean resync = false;
+
+    public EnumLogic getEntryLogic() {
+        return entryLogic;
+    }
+
+    public void setEntryLogic(EnumLogic entryLogic) {
+        this.resync = switch (entryLogic) {
+            case AND, NAND, OR -> false;
+            default -> true;
+        };
+        this.entryLogic = entryLogic;
+    }
 
     @Override
     public String getUnlocalisedName() {
@@ -91,71 +106,81 @@ public class TaskRetrieval implements ITaskInventory, IItemTask {
         if (isComplete(pInfo.UUID)) {
             return;
         }
-        boolean updated = false;
-
-        // TODO: rewrite progress retrieval/updating
-        // List of (player uuid, [progress per required item])
-        final List<Tuple<UUID, int[]>> progress = getBulkProgress(consume ? Collections.singletonList(pInfo.UUID) : pInfo.ALL_UUIDS);
-        if (!consume) {
-            if (groupDetect) // Reset all detect progress
-            {
-                progress.forEach((value) -> Arrays.fill(value.getSecond(), 0));
-            } else {
-                for (int i = 0; i < requiredItems.size(); i++) {
-                    final int r = requiredItems.get(i).stackSize;
-                    for (Tuple<UUID, int[]> value : progress) {
-                        int n = value.getSecond()[i];
-                        if (n != 0 && n < r) {
-                            value.getSecond()[i] = 0;
-                            updated = true;
-                        }
-                    }
-                }
-            }
-        }
-
-        IItemHandler playerInv = consume ? new PlayerInvWrapper(pInfo.PLAYER.inventory) : EmptyHandler.INSTANCE;
+        int updatedReqs = 0;
         PartyInventory partyInv = pInfo.getPartyInventory();
 
-        for (int reqI = 0, reqSize = requiredItems.size(); reqI < reqSize; reqI++) {
+        // The current progress so far for the player
+        int[] currentProgress;
+        // For easier interfacing with the player's inventory when consuming
+        IItemHandler playerInv;
+        if (consume) {
+            currentProgress = getUserProgress(pInfo.UUID);
+            playerInv = new PlayerInvWrapper(pInfo.PLAYER.inventory);
+        }
+        else {
+            currentProgress = null;
+            playerInv = EmptyHandler.INSTANCE;
+        }
+        int reqSize = requiredItems.size();
+        // The progress to fill based on current PartyInventory snapshot
+        int[] invProgress = new int[reqSize];
+
+        for (int reqI = 0; reqI < reqSize; reqI++) {
             BigItemStack rStack = requiredItems.get(reqI);
 
-            int partyStackCount = partyInv.getItemCountFor(rStack, consume, ignoreNBT, partialMatch);
-            if (partyStackCount <= 0) continue;
+            // Check the party has the required stack
+            var itemStackContext = partyInv.getItemCountFor(rStack, consume, ignoreNBT, partialMatch);
+            if (itemStackContext == PartyInventory.ItemMatchContext.EMPTY) continue;
 
-            // Theoretically this could work in consume mode for parties but the priority order and manual submission code would need changing
-            for (Tuple<UUID, int[]> value : progress) {
-                // Skip if already fulfilled
-                if (value.getSecond()[reqI] >= rStack.stackSize) continue;
+            int reqRemaining = rStack.stackSize;
+            if (consume) {
+                // Account for already consumed progress
+                assert currentProgress != null && currentProgress.length > reqI;
+                reqRemaining -= currentProgress[reqI];
+            }
 
-                int reqRemaining = rStack.stackSize - value.getSecond()[reqI];
-                int progressAmount = Math.min(reqRemaining, partyStackCount);
-                if (consume) {
-                    value.getSecond()[reqI] += consumeRequired(rStack, playerInv, pInfo.PLAYER, progressAmount);
-                }
-                else {
-                    value.getSecond()[reqI] += progressAmount;
-                }
-
-                updated = true;
+            int progressAmount = Math.min(reqRemaining, itemStackContext.availableAmount());
+            progressAmount = consumeRequired(playerInv, pInfo.PLAYER, progressAmount, itemStackContext);
+            if (progressAmount > 0) {
+                invProgress[reqI] += progressAmount;
+                // Allows the stack detection to split across multiple requirements.
+                itemStackContext.shrink(progressAmount);
+                updatedReqs++;
             }
         }
-
-        if (updated) {
-            setBulkProgress(progress);
+        // Reset counts used for split stack detection
+        if (updatedReqs > 0) {
+            partyInv.resetItemCounts(consume);
         }
-        // Reuse progress
-        checkAndComplete(pInfo, quest, updated, progress);
+
+        // Update cached progress and check completion
+        if (updatedReqs > 0 || resync) {
+            int[] updatedProgress = updateBulkProgress(invProgress, pInfo);
+            checkAndComplete(pInfo, quest, updatedProgress);
+        }
     }
 
-    private int consumeRequired(BigItemStack req, IItemHandler inv, EntityPlayer player, int amountToConsume) {
+    /**
+     * Consume the given amount from the player's inventory if necessary.
+     *
+     * @param inv              the item handler wrapping the player inventory
+     * @param player           the player
+     * @param amountToConsume  the amount to try to consume
+     * @param itemStackContext the context with matching item stacks
+     * @return how much was actually consumed, or amountToConsume if this is not a consume task
+     */
+    private int consumeRequired(IItemHandler inv, EntityPlayer player, int amountToConsume,
+                                PartyInventory.ItemMatchContext itemStackContext) {
+        // Theoretically this could work in consume mode for parties but the priority order and manual submission code would need changing
+        if (!consume) return amountToConsume;
+
         int remaining = amountToConsume;
         int totalConsumed = 0;
-        // Just scan the whole inventory, this shouldn't be called often
-        for (int slot = 0, numSlots = inv.getSlots(); slot < numSlots; slot++) {
+        // Scan each matching stack for their slot to extract from
+        for (PartyInventory.IndexedItemStack iStack : itemStackContext.indexedItemStacks()) {
+            int slot = iStack.slot();
             ItemStack simulated = inv.extractItem(slot, remaining, true);
-            // Must match and be extractable
-            if (simulated.isEmpty() || !ItemComparison.BigStackMatch(req, simulated, ignoreNBT, partialMatch)) {
+            if (simulated.isEmpty()) {
                 continue;
             }
 
@@ -176,40 +201,106 @@ public class TaskRetrieval implements ITaskInventory, IItemTask {
         return totalConsumed;
     }
 
-    private void checkAndComplete(ParticipantInfo pInfo, DBEntry<IQuest> quest, boolean resync) {
-        checkAndComplete(pInfo, quest, resync, getBulkProgress(consume ? Collections.singletonList(pInfo.UUID) : pInfo.ALL_UUIDS));
+    @Nonnull
+    private int[] updateBulkProgress(int[] playerProgress, ParticipantInfo pInfo) {
+        List<UUID> uuidsToUpdate = consume ? Collections.singletonList(pInfo.UUID) : pInfo.ALL_UUIDS;
+
+        int[] updatedProgress = updateUserProgress(pInfo.UUID, playerProgress);
+        for (UUID uuid : uuidsToUpdate) {
+            if (uuid == pInfo.UUID) continue;
+            updateUserProgress(uuid, playerProgress);
+        }
+        return updatedProgress;
     }
 
-    private void checkAndComplete(ParticipantInfo pInfo, DBEntry<IQuest> quest, boolean resync, List<Tuple<UUID, int[]>> progress) {
-        boolean updated = resync;
-
-        for (Tuple<UUID, int[]> value : progress) {
-            int count = 0;
-            for (int j = 0; j < requiredItems.size(); j++) {
-                if (value.getSecond()[j] >= requiredItems.get(j).stackSize)
-                    count++;
+    /**
+     * Update the task progress for given user
+     *
+     * @param userUUID      the user's id
+     * @param progressIn    the progress to merge, treated as immutable
+     * @return the updated task progress
+     */
+    private int[] updateUserProgress(UUID userUUID, int[] progressIn) {
+        return userProgress.merge(userUUID, progressIn, (existingProgress, progressToMerge) -> {
+            Preconditions.checkArgument(existingProgress.length == progressToMerge.length
+                            && progressToMerge.length == requiredItems.size(),
+                    "Lengths of user's known progress and new detected progress to merge don't match!");
+            if (groupDetect) {
+                return progressToMerge;
             }
-            if (!entryLogic.getResult(count, requiredItems.size()))
-                continue;
 
-            updated = true;
+            for (int i = 0; i < existingProgress.length; i++) {
+                // Skip if already fulfilled
+                if (existingProgress[i] >= requiredItems.get(i).stackSize) continue;
 
-            if (consume) {
-                setComplete(value.getFirst());
-            } else {
-                progress.forEach((pair) -> setComplete(pair.getFirst()));
-                break;
+                if (consume) {
+                    // Make sure we keep the progress that has already consumed stuff before
+                    existingProgress[i] += progressToMerge[i];
+                }
+                else {
+                    // Otherwise the progressIn overwrites the current progress
+                    existingProgress[i] = progressToMerge[i];
+                }
+            }
+            return existingProgress;
+        });
+    }
+
+    /**
+     * Check if the detected progress would complete the quest.
+     * @param pInfo the participant's info
+     * @param quest the quest to possibly complete
+     * @param progress the updated progress
+     */
+    private void checkAndComplete(ParticipantInfo pInfo, DBEntry<IQuest> quest, int[] progress) {
+        int completedReqs = 0;
+        // Count up completed requirements
+        for (int i = 0; i < progress.length; i++) {
+            if (progress[i] >= requiredItems.get(i).stackSize) {
+                completedReqs++;
             }
         }
+        if (!entryLogic.getResult(completedReqs, requiredItems.size())) {
+            return;
+        }
 
-        if (updated) {
-            if (consume) {
-                pInfo.markDirty(Collections.singletonList(quest.getID()));
-            } else {
-                pInfo.markDirtyParty(Collections.singletonList(quest.getID()));
-            }
+        var questID = Collections.singletonList(quest.getID());
+        if (consume) {
+            setComplete(pInfo.UUID);
+            pInfo.markDirty(questID);
+        }
+        else {
+            pInfo.ALL_UUIDS.forEach(this::setComplete);
+            pInfo.markDirtyParty(questID);
         }
     }
+
+    /**
+     * Check if the given progress for a single player would complete the quest.
+     * @param uuid the UUID of the player
+     * @param progress the updated progress
+     */
+    private void checkAndComplete(UUID uuid, int[] progress) {
+        int completedReqs = 0;
+        // Count up completed requirements
+        for (int i = 0; i < progress.length; i++) {
+            if (progress[i] >= requiredItems.get(i).stackSize) {
+                completedReqs++;
+            }
+        }
+        if (!entryLogic.getResult(completedReqs, requiredItems.size())) {
+            return;
+        }
+
+        setComplete(uuid);
+    }
+
+    public int[] getUserProgress(UUID uuidIn) {
+        return userProgress.compute(uuidIn, (uuid, progress) ->
+                progress == null || progress.length != requiredItems.size() ? new int[requiredItems.size()] : progress);
+    }
+
+    /* NBT handling */
 
     @Deprecated
     @Override
@@ -242,7 +333,7 @@ public class TaskRetrieval implements ITaskInventory, IItemTask {
         consume = NBTUtil.getBoolean(nbt, "consume", DEFAULT_CONSUME);
         groupDetect = NBTUtil.getBoolean(nbt, "groupDetect", DEFAULT_GROUP_DETECT);
         autoConsume = NBTUtil.getBoolean(nbt, "autoConsume", DEFAULT_AUTO_CONSUME);
-        entryLogic = NBTUtil.getEnum(nbt, "entryLogic", EnumLogic.class, true, DEFAULT_ENTRY_LOGIC);
+        setEntryLogic(NBTUtil.getEnum(nbt, "entryLogic", EnumLogic.class, true, DEFAULT_ENTRY_LOGIC));
 
         requiredItems.clear();
         NBTTagList iList = nbt.getTagList("requiredItems", 10);
@@ -294,8 +385,9 @@ public class TaskRetrieval implements ITaskInventory, IItemTask {
 
         if (users != null) {
             users.forEach((uuid) -> {
-                if (completeUsers.contains(uuid))
+                if (completeUsers.contains(uuid)) {
                     jArray.appendTag(new NBTTagString(uuid.toString()));
+                }
 
                 int[] data = userProgress.get(uuid);
                 if (data != null) {
@@ -310,9 +402,13 @@ public class TaskRetrieval implements ITaskInventory, IItemTask {
                 }
             });
         } else {
-            completeUsers.forEach((uuid) -> jArray.appendTag(new NBTTagString(uuid.toString())));
+            // Ensure consistent order when writing
+            TreeSet<UUID> sortedCompleteUsers = new TreeSet<>(completeUsers);
+            TreeMap<UUID, int[]> sortedProgress = new TreeMap<>(userProgress);
 
-            userProgress.forEach((uuid, data) -> {
+            sortedCompleteUsers.forEach((uuid) -> jArray.appendTag(new NBTTagString(uuid.toString())));
+
+            sortedProgress.forEach((uuid, data) -> {
                 NBTTagCompound pJson = new NBTTagCompound();
                 pJson.setString("uuid", uuid.toString());
                 NBTTagList pArray = new NBTTagList(); // TODO: Why the heck isn't this just an int array?!
@@ -352,7 +448,7 @@ public class TaskRetrieval implements ITaskInventory, IItemTask {
             return false;
         }
 
-        int[] progress = getUsersProgress(owner);
+        int[] progress = getUserProgress(owner);
 
         for (int j = 0; j < requiredItems.size(); j++) {
             BigItemStack rStack = requiredItems.get(j);
@@ -375,7 +471,8 @@ public class TaskRetrieval implements ITaskInventory, IItemTask {
 
         ItemStack stack = input.copy();
 
-        int[] progress = getUsersProgress(owner);
+        // Direct reference to value in userProgress
+        int[] progress = getUserProgress(owner);
         boolean updated = false;
 
         for (int j = 0; j < requiredItems.size(); j++) {
@@ -400,19 +497,13 @@ public class TaskRetrieval implements ITaskInventory, IItemTask {
         }
 
         if (updated) {
-            setUserProgress(owner, progress);
-
             MinecraftServer server = FMLCommonHandler.instance().getMinecraftServerInstance();
             EntityPlayerMP player = server == null ? null : server.getPlayerList().getPlayerByUUID(owner);
 
             if (player != null) {
-                checkAndComplete(new ParticipantInfo(player), quest, true);
+                checkAndComplete(new ParticipantInfo(player), quest, progress);
             } else {
-                // It's implied to be a consume task so no need to lookup the party
-                int count = (int) IntStream.range(0, requiredItems.size()).filter(j -> progress[j] >= requiredItems.get(j).stackSize).count();
-
-                if (entryLogic.getResult(count, requiredItems.size()))
-                    setComplete(owner);
+                checkAndComplete(owner, progress);
             }
         }
 
@@ -423,30 +514,6 @@ public class TaskRetrieval implements ITaskInventory, IItemTask {
     @SideOnly(Side.CLIENT)
     public GuiScreen getTaskEditor(GuiScreen parent, DBEntry<IQuest> quest) {
         return new GuiEditTaskRetrieval(parent, quest, this);
-    }
-
-    private void setUserProgress(UUID uuid, int[] progress) {
-        userProgress.put(uuid, progress);
-    }
-
-    public int[] getUsersProgress(UUID uuid) {
-        int[] progress = userProgress.get(uuid);
-        return progress == null || progress.length != requiredItems.size() ? new int[requiredItems.size()] : progress;
-    }
-
-    private List<Tuple<UUID, int[]>> getBulkProgress(@Nonnull List<UUID> uuids) {
-        if (uuids.isEmpty()) {
-            return Collections.emptyList();
-        }
-        List<Tuple<UUID, int[]>> list = new ArrayList<>(uuids.size());
-        for (var uuid : uuids) {
-            list.add(new Tuple<>(uuid, getUsersProgress(uuid)));
-        }
-        return list;
-    }
-
-    private void setBulkProgress(@Nonnull List<Tuple<UUID, int[]>> list) {
-        list.forEach((entry) -> setUserProgress(entry.getFirst(), entry.getSecond()));
     }
 
     @Override

--- a/src/main/java/betterquesting/questing/tasks/TaskRetrieval.java
+++ b/src/main/java/betterquesting/questing/tasks/TaskRetrieval.java
@@ -110,11 +110,12 @@ public class TaskRetrieval implements ITaskInventory, IItemTask {
         int updatedReqs = 0;
         PartyInventory partyInv = pInfo.getPartyInventory();
 
+        boolean taskConsumes = consume;
         // The current progress so far for the player
         int[] currentProgress;
         // For easier interfacing with the player's inventory when consuming
         IItemHandler playerInv;
-        if (consume) {
+        if (taskConsumes) {
             currentProgress = getUserProgress(pInfo.UUID);
             playerInv = new PlayerInvWrapper(pInfo.PLAYER.inventory);
         }
@@ -130,13 +131,12 @@ public class TaskRetrieval implements ITaskInventory, IItemTask {
             BigItemStack rStack = requiredItems.get(reqI);
 
             // Check the party has the required stack
-            var itemStackContext = partyInv.getItemCountFor(rStack, consume, ignoreNBT, partialMatch);
+            var itemStackContext = partyInv.getItemCountFor(rStack, taskConsumes, ignoreNBT, partialMatch);
             if (itemStackContext == PartyInventory.ItemMatchContext.EMPTY) continue;
 
             int reqRemaining = rStack.stackSize;
-            if (consume) {
+            if (taskConsumes) {
                 // Account for already consumed progress
-                assert currentProgress != null && currentProgress.length > reqI;
                 reqRemaining -= currentProgress[reqI];
             }
 
@@ -151,7 +151,7 @@ public class TaskRetrieval implements ITaskInventory, IItemTask {
         }
         // Reset counts used for split stack detection
         if (updatedReqs > 0) {
-            partyInv.resetItemCounts(consume);
+            partyInv.resetItemCounts(taskConsumes);
         }
 
         // Update cached progress and check completion
@@ -204,12 +204,13 @@ public class TaskRetrieval implements ITaskInventory, IItemTask {
 
     @Nonnull
     private int[] updateBulkProgress(int[] playerProgress, ParticipantInfo pInfo) {
-        List<UUID> uuidsToUpdate = consume ? Collections.singletonList(pInfo.UUID) : pInfo.ALL_UUIDS;
-
         int[] updatedProgress = updateUserProgress(pInfo.UUID, playerProgress);
-        for (UUID uuid : uuidsToUpdate) {
-            if (uuid == pInfo.UUID) continue;
-            updateUserProgress(uuid, playerProgress);
+        if (!consume) {
+            // Update all other party member's progress with playerProgress
+            for (UUID uuid : pInfo.ALL_UUIDS) {
+                if (uuid == pInfo.UUID) continue;
+                updateUserProgress(uuid, playerProgress);
+            }
         }
         return updatedProgress;
     }
@@ -240,12 +241,10 @@ public class TaskRetrieval implements ITaskInventory, IItemTask {
                     existingProgress[i] += progressToMerge[i];
                     progressChanged = true;
                 }
-                else {
-                    if (existingProgress[i] != progressToMerge[i]) {
-                        progressChanged = true;
-                    }
+                else if (existingProgress[i] != progressToMerge[i]) {
                     // Otherwise the progressIn overwrites the current progress
                     existingProgress[i] = progressToMerge[i];
+                    progressChanged = true;
                 }
             }
             return existingProgress;
@@ -308,6 +307,7 @@ public class TaskRetrieval implements ITaskInventory, IItemTask {
         setComplete(uuid);
     }
 
+    @Nonnull
     public int[] getUserProgress(UUID uuidIn) {
         return userProgress.compute(uuidIn, (uuid, progress) ->
                 progress == null || progress.length != requiredItems.size() ? new int[requiredItems.size()] : progress);

--- a/src/main/java/betterquesting/questing/tasks/TaskRetrieval.java
+++ b/src/main/java/betterquesting/questing/tasks/TaskRetrieval.java
@@ -118,8 +118,7 @@ public class TaskRetrieval implements ITaskInventory, IItemTask {
         if (taskConsumes) {
             currentProgress = getUserProgress(pInfo.UUID);
             playerInv = new PlayerInvWrapper(pInfo.PLAYER.inventory);
-        }
-        else {
+        } else {
             currentProgress = null;
             playerInv = EmptyHandler.INSTANCE;
         }
@@ -243,8 +242,7 @@ public class TaskRetrieval implements ITaskInventory, IItemTask {
                     // Make sure we keep the progress that has already consumed stuff before
                     existingProgress[i] += progressToMerge[i];
                     progressChanged = true;
-                }
-                else if (existingProgress[i] != progressToMerge[i]) {
+                } else if (existingProgress[i] != progressToMerge[i]) {
                     // Otherwise the progressIn overwrites the current progress
                     existingProgress[i] = progressToMerge[i];
                     progressChanged = true;
@@ -266,8 +264,7 @@ public class TaskRetrieval implements ITaskInventory, IItemTask {
             var questID = Collections.singletonList(quest.getID());
             if (consume) {
                 pInfo.markDirty(questID);
-            }
-            else {
+            } else {
                 pInfo.markDirtyParty(questID);
             }
         }
@@ -284,8 +281,7 @@ public class TaskRetrieval implements ITaskInventory, IItemTask {
 
         if (consume) {
             setComplete(pInfo.UUID);
-        }
-        else {
+        } else {
             pInfo.ALL_UUIDS.forEach(this::setComplete);
         }
     }

--- a/src/main/java/betterquesting/questing/tasks/TaskRetrieval.java
+++ b/src/main/java/betterquesting/questing/tasks/TaskRetrieval.java
@@ -61,6 +61,7 @@ public class TaskRetrieval implements ITaskInventory, IItemTask {
     public boolean autoConsume = DEFAULT_AUTO_CONSUME;
     private EnumLogic entryLogic = DEFAULT_ENTRY_LOGIC;
     private boolean resync = false;
+    private boolean progressChanged = false;
 
     public EnumLogic getEntryLogic() {
         return entryLogic;
@@ -226,6 +227,7 @@ public class TaskRetrieval implements ITaskInventory, IItemTask {
                             && progressToMerge.length == requiredItems.size(),
                     "Lengths of user's known progress and new detected progress to merge don't match!");
             if (groupDetect) {
+                progressChanged = true;
                 return progressToMerge;
             }
 
@@ -236,8 +238,12 @@ public class TaskRetrieval implements ITaskInventory, IItemTask {
                 if (consume) {
                     // Make sure we keep the progress that has already consumed stuff before
                     existingProgress[i] += progressToMerge[i];
+                    progressChanged = true;
                 }
                 else {
+                    if (existingProgress[i] != progressToMerge[i]) {
+                        progressChanged = true;
+                    }
                     // Otherwise the progressIn overwrites the current progress
                     existingProgress[i] = progressToMerge[i];
                 }
@@ -253,6 +259,16 @@ public class TaskRetrieval implements ITaskInventory, IItemTask {
      * @param progress the updated progress
      */
     private void checkAndComplete(ParticipantInfo pInfo, DBEntry<IQuest> quest, int[] progress) {
+        if (progressChanged) {
+            progressChanged = false;
+            var questID = Collections.singletonList(quest.getID());
+            if (consume) {
+                pInfo.markDirty(questID);
+            }
+            else {
+                pInfo.markDirtyParty(questID);
+            }
+        }
         int completedReqs = 0;
         // Count up completed requirements
         for (int i = 0; i < progress.length; i++) {
@@ -264,14 +280,11 @@ public class TaskRetrieval implements ITaskInventory, IItemTask {
             return;
         }
 
-        var questID = Collections.singletonList(quest.getID());
         if (consume) {
             setComplete(pInfo.UUID);
-            pInfo.markDirty(questID);
         }
         else {
             pInfo.ALL_UUIDS.forEach(this::setComplete);
-            pInfo.markDirtyParty(questID);
         }
     }
 

--- a/src/main/java/betterquesting/questing/tasks/TaskRetrieval.java
+++ b/src/main/java/betterquesting/questing/tasks/TaskRetrieval.java
@@ -224,9 +224,12 @@ public class TaskRetrieval implements ITaskInventory, IItemTask {
      */
     private int[] updateUserProgress(UUID userUUID, int[] progressIn) {
         return userProgress.merge(userUUID, progressIn, (existingProgress, progressToMerge) -> {
-            Preconditions.checkArgument(existingProgress.length == progressToMerge.length
-                            && progressToMerge.length == requiredItems.size(),
-                    "Lengths of user's known progress and new detected progress to merge don't match!");
+            // Somehow the existing progress doesn't reflect current requirements, only use new progress.
+            if (existingProgress.length != requiredItems.size()) {
+                progressChanged = true;
+                return progressToMerge;
+            }
+            // Group-detect requires all requirements to be met within this single detection.
             if (groupDetect) {
                 progressChanged = true;
                 return progressToMerge;

--- a/src/main/java/betterquesting/questing/tasks/TaskRetrieval.java
+++ b/src/main/java/betterquesting/questing/tasks/TaskRetrieval.java
@@ -472,7 +472,7 @@ public class TaskRetrieval implements ITaskInventory, IItemTask {
             if (progress[j] >= rStack.stackSize)
                 continue;
 
-            if (ItemComparison.StackMatch(rStack.getBaseStack(), stack, !ignoreNBT, partialMatch) || ItemComparison.OreDictionaryMatch(rStack.getOreIngredient(), rStack.GetTagCompound(), stack, !ignoreNBT, partialMatch)) {
+            if (ItemComparison.BigStackMatch(rStack, stack, ignoreNBT, partialMatch)) {
                 return true;
             }
         }
@@ -502,7 +502,7 @@ public class TaskRetrieval implements ITaskInventory, IItemTask {
 
             int remaining = rStack.stackSize - progress[j];
 
-            if (ItemComparison.StackMatch(rStack.getBaseStack(), stack, !ignoreNBT, partialMatch) || ItemComparison.OreDictionaryMatch(rStack.getOreIngredient(), rStack.GetTagCompound(), stack, !ignoreNBT, partialMatch)) {
+            if (ItemComparison.BigStackMatch(rStack, stack, ignoreNBT, partialMatch)) {
                 int removed = Math.min(stack.getCount(), remaining);
                 stack.shrink(removed);
                 progress[j] += removed;

--- a/src/main/java/betterquesting/storage/PropertyContainer.java
+++ b/src/main/java/betterquesting/storage/PropertyContainer.java
@@ -64,6 +64,8 @@ public class PropertyContainer implements IPropertyContainer, INBTSaveLoad<NBTTa
         if (prop == null || value == null) return;
         id2PropertyMap.put(prop.getKey(), prop);
         NBTTagCompound dom = getDomain(prop.getKey());
+
+        prop.notifyListeners(value);
         dom.setTag(prop.getKey().getPath(), prop.writeValue(value));
         nbtInfo.setTag(prop.getKey().getNamespace(), dom);
     }

--- a/src/test/java/betterquesting/api2/utils/PartyQuestMergerTest.java
+++ b/src/test/java/betterquesting/api2/utils/PartyQuestMergerTest.java
@@ -1,0 +1,60 @@
+package betterquesting.api2.utils;
+
+import it.unimi.dsi.fastutil.ints.IntRBTreeSet;
+import it.unimi.dsi.fastutil.ints.IntSortedSet;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class PartyQuestMergerTest {
+    private static final int ELEMENTS_PER_SET = 1_000;
+
+    private final Random random = new Random(100);
+    private List<int[]> intSets;
+    private int[] expected;
+
+    public void init(int numSets, int... numElementsPerSet) {
+        IntSortedSet verifySet = new IntRBTreeSet();
+        intSets = new ArrayList<>();
+
+        for (int i = 0; i < numSets; i++) {
+            IntSortedSet intSet = new IntRBTreeSet();
+            int numElements = numElementsPerSet[i % numElementsPerSet.length];
+
+            for (int j = 0; j < numElements; j++) {
+                int value = random.nextInt(10_000);
+                verifySet.add(value);
+                intSet.add(value);
+            }
+
+            intSets.add(intSet.toIntArray());
+        }
+        this.expected = verifySet.toIntArray();
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {
+        1, // single player
+        4, // power of 2
+        5, // non-power of 2
+    })
+    public void mergeQuestsForVaryingPlayers(int numPlayers) {
+        init(numPlayers, ELEMENTS_PER_SET);
+        PartyQuestMerger merger = new PartyQuestMerger(intSets);
+        Assertions.assertArrayEquals(expected, merger.getSharedQuests());
+    }
+
+    @Test
+    public void mergeQuestsForVaryingActiveQuests() {
+        init(4, 1, ELEMENTS_PER_SET, ELEMENTS_PER_SET * 2, ELEMENTS_PER_SET / 2);
+        PartyQuestMerger merger = new PartyQuestMerger(intSets);
+        Assertions.assertArrayEquals(expected, merger.getSharedQuests());
+    }
+}


### PR DESCRIPTION
This PR aims to improve inventory detection for retrieval and fluid task requirements, mainly for better performance when player's inventory changes often, as well as fixing/implementing fluid detection for stacked containers.
Notable changes:
- Cache global setting check for parties when getting a party from the `PartyManager`
- Cache `IDatabase#bulkLookup()` for the quest database per-party, as it's used often for inventory detection
- Change various `QuestCache` caches from `TreeSet`s to array lists. The order of the elements are not important outside of internal usage within the class, so the elements are now only sorted when updating the caches. This allows for faster copying of the caches when getting them, most notably for active quests.
- Throttle updates to retrieval task detection according to new config value (default 20 ticks). Under the default value, this means player's inventory changes will be checked once a second.
- Build a snapshot of a party's inventory *before* checking each retrieval/fluid task. There is no need to scan the inventory for every single task.
- Rewrite retrieval/fluid task detection logic to be more performant. Here's the rough outline of how the new detection works:
  1) Get existing progress for the user *only* if this is a consume task. Non-consume tasks will just overwrite incomplete, existing progress (respecting group detection if needed).
  2) For each requirement, get a context of matching stacks from the party's inventory. The context holds info on the specific stacks that match the requirement and the total amount available.
  3) Consume the necessary amount for the requirement from the party's inventory.
  4) Populate an array of tracked progress for the requirements for this specific detection.
  5) If there were any relevant changes tracked, update bulk progress for all members in the party based on this tracked progress, checking and completing the quest for the player(s).
- Use k-way merge to get a party's shared quests instead of the naive approach. This probably isn't as necessary with all the above optimizations, but I already wrote it and a few tests to verify its correctness, so just left it in. 
- Allow fluid tasks to detect/consume fluid containers that are stackable (i.e. Forestry capsules, GT cells). Previously, these tasks wouldn't be able to detect such stacked containers at all, even though the code suggests this was an intended use-case.
  - If it's a consume task, stacked containers will smartly be partially consumed as you would expect. 
  - For example, if a task requires 3000mB, and you have a 2x cell with 2000mB each, then exactly 3000mB is consumed, returning a stack of 1x empty cell, and another stack of 1x cell of 1000mB.
  - Supersedes #125, improving upon the limitation mentioned in that PR as in the above example.

Edit:
- Fixed a bug with interact tasks not properly allowing items based on ore-dict.

I have tested some basic quests with the following cases and verified detection works:
- Retrieval/fluid single task
- Retrieval/fluid multiple task, different item/fluid requirements
- Retrieval/fluid multiple task, but all requirements are the same item, just different quantity (to test split stack detection)

Still, as this has sizable changes, some extra testing and review is welcome.