### PR TITLE
Fix Notification and add auto-update config

### DIFF
--- a/src/main/java/betterquesting/api/storage/BQ_Settings.java
+++ b/src/main/java/betterquesting/api/storage/BQ_Settings.java
@@ -38,6 +38,7 @@ public class BQ_Settings {
 
     public static boolean spawnWithQuestBook = true;
     public static boolean saveQuestsWithNames = false;
+    public static boolean updateDefaultQuestsOnStartup = true;
 
     public static int retrievalDetectionDelay = 20;
 }

--- a/src/main/java/betterquesting/client/gui2/GuiHome.java
+++ b/src/main/java/betterquesting/client/gui2/GuiHome.java
@@ -5,8 +5,6 @@ import betterquesting.api.api.QuestingAPI;
 import betterquesting.api.properties.NativeProps;
 import betterquesting.api.questing.party.IParty;
 import betterquesting.api.storage.BQ_Settings;
-import betterquesting.api.utils.JsonHelper;
-import betterquesting.api.utils.NBTConverter;
 import betterquesting.api2.client.gui.GuiScreenCanvas;
 import betterquesting.api2.client.gui.controls.IPanelButton;
 import betterquesting.api2.client.gui.controls.PanelButton;
@@ -30,25 +28,22 @@ import betterquesting.client.gui2.editors.nbt.GuiNbtEditor;
 import betterquesting.client.gui2.party.GuiPartyCreate;
 import betterquesting.client.gui2.party.GuiPartyManage;
 import betterquesting.client.gui3.GuiStatus;
+import betterquesting.commands.admin.QuestCommandDefaults;
 import betterquesting.handlers.ConfigHandler;
 import betterquesting.handlers.SaveLoadHandler;
-import betterquesting.network.handlers.NetChapterSync;
-import betterquesting.network.handlers.NetQuestSync;
 import betterquesting.network.handlers.NetSettingSync;
-import betterquesting.questing.QuestDatabase;
-import betterquesting.questing.QuestLineDatabase;
 import betterquesting.questing.party.PartyManager;
 import betterquesting.storage.QuestSettings;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.launchwrapper.Launch;
 import net.minecraft.nbt.NBTTagCompound;
-import net.minecraft.nbt.NBTTagList;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.common.config.Configuration;
 import net.minecraftforge.fml.common.FMLCommonHandler;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
+import org.apache.logging.log4j.Level;
 import org.lwjgl.util.vector.Vector4f;
 
 import java.io.File;
@@ -179,33 +174,23 @@ public class GuiHome extends GuiScreenCanvas {
             }));
         } else if (btn.getButtonID() == 5) // Update me
         {
-            final File qFile = new File(BQ_Settings.defaultDir, "DefaultQuests.json");
+            final File dir = new File(BQ_Settings.defaultDir, QuestCommandDefaults.DEFAULT_FILE);
+            final File file = new File(BQ_Settings.defaultDir, QuestCommandDefaults.DEFAULT_FILE + ".json");
 
-            if (qFile.exists()) {
+            if (dir.exists()) {
                 FMLCommonHandler.instance().getMinecraftServerInstance().addScheduledTask(() -> {
-                    boolean editMode = QuestSettings.INSTANCE.getProperty(NativeProps.EDIT_MODE);
-                    boolean hardMode = QuestSettings.INSTANCE.getProperty(NativeProps.HARDCORE);
-
-                    NBTTagList jsonP = QuestDatabase.INSTANCE.writeProgressToNBT(new NBTTagList(), null);
-                    NBTTagCompound j1 = NBTConverter.JSONtoNBT_Object(JsonHelper.ReadFromFile(qFile), new NBTTagCompound(), true);
-                    QuestSettings.INSTANCE.readFromNBT(j1.getCompoundTag("questSettings"));
-                    QuestDatabase.INSTANCE.readFromNBT(j1.getTagList("questDatabase", 10), false);
-                    QuestLineDatabase.INSTANCE.readFromNBT(j1.getTagList("questLines", 10), false);
-                    QuestDatabase.INSTANCE.readProgressFromNBT(jsonP, false);
-
-                    QuestSettings.INSTANCE.setProperty(NativeProps.EDIT_MODE, editMode);
-                    QuestSettings.INSTANCE.setProperty(NativeProps.HARDCORE, hardMode);
-
-                    NetSettingSync.sendSync(null);
-                    NetQuestSync.quickSync(-1, true, true);
-                    NetChapterSync.sendSync(null, null);
-
+                    QuestCommandDefaults.load(null, null, dir, false);
                     SaveLoadHandler.INSTANCE.resetUpdate();
-                    SaveLoadHandler.INSTANCE.markDirty();
+                    mc.displayGuiScreen(null);
                 });
-
-                //this.initGui(); // Reset the whole thing
-                mc.displayGuiScreen(null);
+            } else if (file.exists()) {
+                FMLCommonHandler.instance().getMinecraftServerInstance().addScheduledTask(() -> {
+                    QuestCommandDefaults.loadLegacy(null, null, file, false);
+                    SaveLoadHandler.INSTANCE.resetUpdate();
+                    mc.displayGuiScreen(null);
+                });
+            } else {
+                QuestingAPI.getLogger().log(Level.WARN, "Could not update the quest database, as neither directory nor file exists");
             }
         }
     }

--- a/src/main/java/betterquesting/client/gui2/GuiHome.java
+++ b/src/main/java/betterquesting/client/gui2/GuiHome.java
@@ -181,14 +181,14 @@ public class GuiHome extends GuiScreenCanvas {
                 FMLCommonHandler.instance().getMinecraftServerInstance().addScheduledTask(() -> {
                     QuestCommandDefaults.load(null, null, dir, false);
                     SaveLoadHandler.INSTANCE.resetUpdate();
-                    mc.displayGuiScreen(null);
                 });
+                mc.displayGuiScreen(null);
             } else if (file.exists()) {
                 FMLCommonHandler.instance().getMinecraftServerInstance().addScheduledTask(() -> {
                     QuestCommandDefaults.loadLegacy(null, null, file, false);
                     SaveLoadHandler.INSTANCE.resetUpdate();
-                    mc.displayGuiScreen(null);
                 });
+                mc.displayGuiScreen(null);
             } else {
                 QuestingAPI.getLogger().log(Level.WARN, "Could not update the quest database, as neither directory nor file exists");
             }

--- a/src/main/java/betterquesting/handlers/ConfigHandler.java
+++ b/src/main/java/betterquesting/handlers/ConfigHandler.java
@@ -42,6 +42,7 @@ public class ConfigHandler {
 
         BQ_Settings.spawnWithQuestBook = config.getBoolean("Spawn with Quest Book", Configuration.CATEGORY_GENERAL, true, "If true, then the player will spawn with a Quest Book when they first join the world");
         BQ_Settings.saveQuestsWithNames = config.getBoolean("DefaultQuests saves using Names", Configuration.CATEGORY_GENERAL, false, "If true, whenever you save your quests, they will have the first 16 characters of the quest name in the file name, this is useful if you want to be easily able to identify quests in file explorer, however it is less compatible when using version control.");
+        BQ_Settings.updateDefaultQuestsOnStartup = config.getBoolean("Load DefaultQuests when an Update is Available", Configuration.CATEGORY_GENERAL, true, "When the pack version of the DefaultQuests config is higher than the current version, attempt to load the config");
 
         BQ_Settings.retrievalDetectionDelay = config.getInt("Retrieval Task Detection Interval", Configuration.CATEGORY_GENERAL, 20, 1, 200, "The delay, in ticks, after which quests with retrieval tasks will detect changes");
         config.save();

--- a/src/main/java/betterquesting/handlers/SaveLoadHandler.java
+++ b/src/main/java/betterquesting/handlers/SaveLoadHandler.java
@@ -1,5 +1,6 @@
 package betterquesting.handlers;
 
+import betterquesting.api.api.QuestingAPI;
 import betterquesting.api.events.DatabaseEvent;
 import betterquesting.api.events.DatabaseEvent.DBType;
 import betterquesting.api.properties.NativeProps;
@@ -13,7 +14,6 @@ import betterquesting.commands.admin.QuestCommandDefaults;
 import betterquesting.core.BetterQuesting;
 import betterquesting.core.ModReference;
 import betterquesting.legacy.ILegacyLoader;
-import betterquesting.legacy.LegacyLoaderRegistry;
 import betterquesting.questing.QuestDatabase;
 import betterquesting.questing.QuestLineDatabase;
 import betterquesting.questing.party.PartyInvitations;
@@ -28,6 +28,7 @@ import net.minecraft.nbt.NBTTagList;
 import net.minecraft.server.MinecraftServer;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.fml.common.Loader;
+import org.apache.logging.log4j.Level;
 
 import java.io.File;
 import java.util.*;
@@ -237,9 +238,29 @@ public class SaveLoadHandler {
             QuestSettings.INSTANCE.setProperty(NativeProps.EDIT_MODE, false); // Force edit off
         }
 
+        if (packName.equals(QuestSettings.INSTANCE.getProperty(NativeProps.PACK_NAME)) && packVer > QuestSettings.INSTANCE.getProperty(NativeProps.PACK_VER)) {
+            if (BQ_Settings.updateDefaultQuestsOnStartup) {
+                attemptUpdate();
+                // mark it as having an update if the new pack version doesn't match that from the settings.
+                hasUpdate = packVer != QuestSettings.INSTANCE.getProperty(NativeProps.PACK_VER);
+            } else {
+                hasUpdate = true;
+            }
+        }
+    }
 
+    private void attemptUpdate() {
+        final File dir = new File(BQ_Settings.defaultDir, QuestCommandDefaults.DEFAULT_FILE);
+        final File file = new File(BQ_Settings.defaultDir, QuestCommandDefaults.DEFAULT_FILE + ".json");
 
-        hasUpdate = packName.equals(QuestSettings.INSTANCE.getProperty(NativeProps.PACK_NAME)) && packVer > QuestSettings.INSTANCE.getProperty(NativeProps.PACK_VER);
+        QuestingAPI.getLogger().log(Level.INFO, "Attempting to load quest data...");
+        if (dir.exists()) {
+            QuestCommandDefaults.load(null, null, dir, false);
+        } else if (file.exists()) {
+            QuestCommandDefaults.loadLegacy(null, null, file, false);
+        } else {
+            QuestingAPI.getLogger().log(Level.WARN, "Could not update the quest database, as neither directory nor file exists");
+        }
     }
 
     private void loadProgress() {


### PR DESCRIPTION
changes in this PR:
- fix the notification button not working with the new quest database format.
- add a config (default: `true`) that makes it so if the DefaultQuests has an updated version, BQu attempts to update the pack.

the latter change is related to https://github.com/GTNewHorizons/BetterQuesting/pull/110
