### PR TITLE
 Apply some quick updates

### DIFF
--- a/src/main/java/betterquesting/api/storage/BQ_Settings.java
+++ b/src/main/java/betterquesting/api/storage/BQ_Settings.java
@@ -34,6 +34,7 @@ public class BQ_Settings {
     public static boolean claimAllConfirmation = true;
     public static boolean lockTray = true;
     public static boolean viewMode = false;
+    public static boolean limitBack = false;
     public static String defaultVisibility = "NORMAL";
 
     public static boolean spawnWithQuestBook = true;

--- a/src/main/java/betterquesting/api/storage/BQ_Settings.java
+++ b/src/main/java/betterquesting/api/storage/BQ_Settings.java
@@ -21,7 +21,7 @@ public class BQ_Settings {
     public static String curTheme = new ResourceLocation(ModReference.MODID, "light").toString();
     public static int guiWidth = -1;
     public static int guiHeight = -1;
-    public static boolean separateDescriptionEditor = true;
+    public static boolean separateDescriptionEditor = false;
     public static boolean questNotices = true;
 
     public static float scrollMultiplier = 0.1F;

--- a/src/main/java/betterquesting/api/storage/BQ_Settings.java
+++ b/src/main/java/betterquesting/api/storage/BQ_Settings.java
@@ -21,6 +21,7 @@ public class BQ_Settings {
     public static String curTheme = new ResourceLocation(ModReference.MODID, "light").toString();
     public static int guiWidth = -1;
     public static int guiHeight = -1;
+    public static boolean separateDescriptionEditor = true;
     public static boolean questNotices = true;
 
     public static float scrollMultiplier = 0.1F;

--- a/src/main/java/betterquesting/api2/client/gui/GuiScreenCanvas.java
+++ b/src/main/java/betterquesting/api2/client/gui/GuiScreenCanvas.java
@@ -9,6 +9,7 @@ import betterquesting.api2.client.gui.popups.PopChoice;
 import betterquesting.api2.client.gui.themes.presets.PresetIcon;
 import betterquesting.api2.utils.QuestTranslation;
 import betterquesting.client.BQ_Keybindings;
+import betterquesting.client.gui2.GuiHome;
 import it.unimi.dsi.fastutil.ints.Int2BooleanArrayMap;
 import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.gui.GuiButton;
@@ -201,8 +202,7 @@ public class GuiScreenCanvas extends GuiScreen implements IScene {
             return;
         }
         if (keyCode == BQ_Keybindings.backPage.getKeyCode()) {
-            if (this.mc.currentScreen instanceof GuiScreenCanvas) {
-                GuiScreenCanvas canvas = (GuiScreenCanvas) mc.currentScreen;
+            if (this.mc.currentScreen instanceof GuiScreenCanvas canvas) {
                 boolean hasKeyAction = false;
                 for (IGuiPanel panel : canvas.getChildren()) {
                     if (panel.isEnabled() && panel.onKeyTyped(c, keyCode)) {
@@ -210,9 +210,7 @@ public class GuiScreenCanvas extends GuiScreen implements IScene {
                         break;
                     }
                 }
-                if (!hasKeyAction && canvas.parent != null) {
-                    mc.displayGuiScreen(canvas.parent);
-                }
+                if (!hasKeyAction) returnToParent(canvas);
                 return;
             }
         }
@@ -253,9 +251,8 @@ public class GuiScreenCanvas extends GuiScreen implements IScene {
             }
         }
 
-        if (!used && mc.currentScreen instanceof GuiScreenCanvas && GameSettings.isKeyDown(BQ_Keybindings.backPage)) {
-            mc.displayGuiScreen(((GuiScreenCanvas) mc.currentScreen).parent);
-            used = true;
+        if (!used && mc.currentScreen instanceof GuiScreenCanvas canvas && GameSettings.isKeyDown(BQ_Keybindings.backPage)) {
+            used = returnToParent(canvas);
         }
 
         return used;
@@ -334,6 +331,13 @@ public class GuiScreenCanvas extends GuiScreen implements IScene {
         }
 
         return used;
+    }
+
+    private boolean returnToParent(GuiScreenCanvas canvas) {
+        if (canvas.parent == null) return false;
+        if (BQ_Settings.limitBack && canvas.parent instanceof GuiHome) return false;
+        mc.displayGuiScreen(canvas.parent);
+        return true;
     }
 
     private void confirmVolatileClose() {

--- a/src/main/java/betterquesting/api2/client/gui/GuiScreenCanvas.java
+++ b/src/main/java/betterquesting/api2/client/gui/GuiScreenCanvas.java
@@ -13,6 +13,7 @@ import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.gui.GuiButton;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.client.renderer.GlStateManager;
+import net.minecraft.client.settings.GameSettings;
 import net.minecraft.item.ItemStack;
 import org.lwjgl.input.Keyboard;
 import org.lwjgl.input.Mouse;
@@ -198,7 +199,7 @@ public class GuiScreenCanvas extends GuiScreen implements IScene {
             confirmVolatileClose();
             return;
         }
-        if (keyCode == BQ_Keybindings.backPage.getKeyCode()) { // BACKSPACE
+        if (keyCode == BQ_Keybindings.backPage.getKeyCode()) {
             if (this.mc.currentScreen instanceof GuiScreenCanvas) {
                 GuiScreenCanvas canvas = (GuiScreenCanvas) mc.currentScreen;
                 boolean hasKeyAction = false;
@@ -249,6 +250,11 @@ public class GuiScreenCanvas extends GuiScreen implements IScene {
                 used = true;
                 break;
             }
+        }
+
+        if (!used && mc.currentScreen instanceof GuiScreenCanvas && GameSettings.isKeyDown(BQ_Keybindings.backPage)) {
+            mc.displayGuiScreen(((GuiScreenCanvas) mc.currentScreen).parent);
+            used = true;
         }
 
         return used;

--- a/src/main/java/betterquesting/api2/client/gui/GuiScreenCanvas.java
+++ b/src/main/java/betterquesting/api2/client/gui/GuiScreenCanvas.java
@@ -9,6 +9,7 @@ import betterquesting.api2.client.gui.popups.PopChoice;
 import betterquesting.api2.client.gui.themes.presets.PresetIcon;
 import betterquesting.api2.utils.QuestTranslation;
 import betterquesting.client.BQ_Keybindings;
+import it.unimi.dsi.fastutil.ints.Int2BooleanArrayMap;
 import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.gui.GuiButton;
 import net.minecraft.client.gui.GuiScreen;
@@ -115,7 +116,7 @@ public class GuiScreenCanvas extends GuiScreen implements IScene {
         }
 
         this.guiPanels.clear();
-        Arrays.fill(mBtnState, false); // Reset mouse states // TODO: See if I can just make this static across all GUIs
+        mBtnState.clear(); // Reset mouse states // TODO: See if I can just make this static across all GUIs
 
         if (popup != null) {
             popup = null;
@@ -167,7 +168,7 @@ public class GuiScreenCanvas extends GuiScreen implements IScene {
     }
 
     // Remembers the last mouse buttons states. Required to fire release events
-    private boolean[] mBtnState = new boolean[3];
+    private final Int2BooleanArrayMap mBtnState = new Int2BooleanArrayMap();
 
     @Override
     public void handleMouseInput() throws IOException {
@@ -179,13 +180,13 @@ public class GuiScreenCanvas extends GuiScreen implements IScene {
         int SDX = (int) -Math.signum(Mouse.getEventDWheel());
         boolean flag = Mouse.getEventButtonState();
 
-        if (k >= 0 && k < 3 && mBtnState[k] != flag) {
+        if (k >= 0 && mBtnState.get(k) != flag) {
             if (flag) {
                 this.onMouseClick(i, j, k);
             } else {
                 this.onMouseRelease(i, j, k);
             }
-            mBtnState[k] = flag;
+            mBtnState.put(k, flag);
         }
 
         if (SDX != 0) {

--- a/src/main/java/betterquesting/api2/client/gui/panels/lists/CanvasQuestLine.java
+++ b/src/main/java/betterquesting/api2/client/gui/panels/lists/CanvasQuestLine.java
@@ -63,6 +63,19 @@ public class CanvasQuestLine extends CanvasScrolling {
         return null;
     }
 
+    public void centerOn(PanelButtonQuest btn) {
+        if (!btnList.contains(btn)) return; // button not on in questline
+        final int x = btn.rect.x;
+        final int y = btn.rect.y;
+        final int width = btn.rect.w;
+        final int height = btn.rect.h;
+        final int btnCenterX = x + width / 2;
+        final int btnCenterY = y + height / 2;
+
+        this.setScrollX(btnCenterX - scrollWindow.w / 2);
+        this.setScrollY(btnCenterY - scrollWindow.h / 2);
+    }
+
     public IQuestLine getQuestLine() {
         return lastQL;
     }

--- a/src/main/java/betterquesting/api2/client/gui/panels/lists/CanvasScrolling.java
+++ b/src/main/java/betterquesting/api2/client/gui/panels/lists/CanvasScrolling.java
@@ -25,7 +25,7 @@ public class CanvasScrolling implements IGuiCanvas {
 
     // Scrolling bounds
     protected final GuiRectangle scrollBounds = new GuiRectangle(0, 0, 0, 0);
-    private final GuiRectangle scrollWindow = new GuiRectangle(0, 0, 0, 0);
+    protected final GuiRectangle scrollWindow = new GuiRectangle(0, 0, 0, 0);
     protected boolean extendedScroll = false;
     protected boolean zoomMode = false;
     protected int margin = 0;

--- a/src/main/java/betterquesting/client/BQ_Keybindings.java
+++ b/src/main/java/betterquesting/client/BQ_Keybindings.java
@@ -2,6 +2,7 @@ package betterquesting.client;
 
 import betterquesting.core.ModReference;
 import net.minecraft.client.settings.KeyBinding;
+import net.minecraftforge.client.settings.KeyConflictContext;
 import net.minecraftforge.fml.client.registry.ClientRegistry;
 import org.lwjgl.input.Keyboard;
 
@@ -12,6 +13,7 @@ public class BQ_Keybindings {
     public static void RegisterKeys() {
         openQuests = new KeyBinding("key.betterquesting.quests", Keyboard.KEY_GRAVE, ModReference.NAME);
         backPage = new KeyBinding("key.betterquesting.back", Keyboard.KEY_BACK, ModReference.NAME);
+        backPage.setKeyConflictContext(KeyConflictContext.GUI);
 
         ClientRegistry.registerKeyBinding(openQuests);
         ClientRegistry.registerKeyBinding(backPage);

--- a/src/main/java/betterquesting/client/gui2/GuiQuest.java
+++ b/src/main/java/betterquesting/client/gui2/GuiQuest.java
@@ -26,6 +26,7 @@ import betterquesting.api2.client.gui.panels.content.PanelTextBox;
 import betterquesting.api2.client.gui.panels.lists.CanvasScrolling;
 import betterquesting.api2.client.gui.popups.PopContextMenu;
 import betterquesting.api2.client.gui.themes.presets.PresetColor;
+import betterquesting.api2.client.gui.themes.presets.PresetIcon;
 import betterquesting.api2.client.gui.themes.presets.PresetLine;
 import betterquesting.api2.client.gui.themes.presets.PresetTexture;
 import betterquesting.api2.storage.DBEntry;
@@ -36,9 +37,11 @@ import betterquesting.client.gui2.editors.GuiTaskEditor;
 import betterquesting.network.handlers.NetQuestAction;
 import betterquesting.questing.QuestDatabase;
 import betterquesting.questing.tasks.TaskRetrieval;
+import com.google.common.collect.ImmutableList;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.client.resources.I18n;
+import net.minecraft.util.text.TextFormatting;
 import org.lwjgl.util.vector.Vector4f;
 
 import java.util.HashMap;
@@ -152,6 +155,11 @@ public class GuiQuest extends GuiScreenCanvas implements IPEventListener, INeeds
         } else {
             cvBackground.addPanel(new PanelButton(new GuiTransform(GuiAlign.BOTTOM_CENTER, -100, -16, 200, 16, 0), 0, QuestTranslation.translate("gui.back")));
         }
+
+        PanelButton copyButton = new PanelButton(new GuiTransform(GuiAlign.TOP_LEFT, 16, 10, 16, 16, 0), 8, "");
+        copyButton.setIcon(PresetIcon.ICON_COPY.getTexture());
+        copyButton.setTooltip(ImmutableList.of(QuestTranslation.translate("betterquesting.btn.copy.tooltip.main"), QuestTranslation.translate("betterquesting.btn.copy.tooltip.shift")));
+        cvBackground.addPanel(copyButton);
 
         cvInner = new CanvasEmpty(new GuiTransform(GuiAlign.FULL_BOX, new GuiPadding(16, 32, 16, 24), 0));
         cvBackground.addPanel(cvInner);
@@ -296,6 +304,13 @@ public class GuiQuest extends GuiScreenCanvas implements IPEventListener, INeeds
             NetQuestAction.requestClaim(new int[]{questID});
         } else if (btn.getButtonID() == 7) { // Task detect/submit
             NetQuestAction.requestDetect(new int[]{questID});
+        } else if (btn.getButtonID() == 8) { // copy quest description
+            var string = QuestTranslation.translate(quest.getProperty(NativeProps.DESC));
+            if (isShiftKeyDown()) {
+                string = TextFormatting.getTextWithoutFormattingCodes(string);
+            }
+            //noinspection DataFlowIssue
+            setClipboardString(string);
         }
     }
 

--- a/src/main/java/betterquesting/client/gui2/GuiQuestLines.java
+++ b/src/main/java/betterquesting/client/gui2/GuiQuestLines.java
@@ -694,17 +694,18 @@ public class GuiQuestLines extends GuiScreenCanvas implements IPEventListener, I
             openQuestLine(entry.getQuestLineEntry());
             int selectedQuestId = entry.getQuest().getID();
             Optional<PanelButtonQuest> targetQuestButton = cvQuest.getQuestButtons().stream().filter(panelButtonQuest -> panelButtonQuest.getStoredValue().getID() == selectedQuestId).findFirst();
-            targetQuestButton.ifPresent(panelButtonQuest -> {
-                GuiTextureColored newTexture = new GuiTextureColored(panelButtonQuest.txFrame,
-                        new GuiColorPulse(
-                                new GuiColorStatic(255, 220, 115, 255),
-                                new GuiColorStatic(255, 191, 0, 255),
-                                1, 0
-                        ));
-                panelButtonQuest.setTextures(newTexture, newTexture, newTexture);
-            });
+            targetQuestButton.ifPresent(this::highlightButton);
         });
         mc.displayGuiScreen(guiQuestSearch);
+    }
+
+    private void highlightButton(PanelButtonQuest panelButtonQuest) {
+        GuiTextureColored newTexture = new GuiTextureColored(
+                panelButtonQuest.txFrame,
+                new GuiColorPulse(new GuiColorStatic(64, 32, 0, 255), new GuiColorStatic(255, 191, 0, 255), 0.5f, 0));
+        panelButtonQuest.setTextures(newTexture, newTexture, newTexture);
+        cvQuest.setZoom(2f);
+        cvQuest.centerOn(panelButtonQuest);
     }
 
     public static class ScrollPosition{

--- a/src/main/java/betterquesting/client/gui2/editors/GuiQuestDescEditor.java
+++ b/src/main/java/betterquesting/client/gui2/editors/GuiQuestDescEditor.java
@@ -3,6 +3,7 @@ package betterquesting.client.gui2.editors;
 import javax.annotation.Nullable;
 
 import betterquesting.api.properties.IPropertyContainer;
+import betterquesting.api.storage.BQ_Settings;
 import net.minecraft.client.gui.GuiScreen;
 import org.lwjgl.input.Keyboard;
 
@@ -35,8 +36,6 @@ import net.minecraft.util.text.TextFormatting;
 
 public class GuiQuestDescEditor<T extends IPropertyContainer> extends GuiScreenCanvas implements IPEventListener, IVolatileScreen {
 
-    private static final boolean FORCE_OPEN_WINDOW = true;
-
     private final T container;
     private final String beforeName;
     private final String beforeDesc;
@@ -53,7 +52,7 @@ public class GuiQuestDescEditor<T extends IPropertyContainer> extends GuiScreenC
         beforeName = container.getProperty(NativeProps.NAME);
         beforeDesc = container.getProperty(NativeProps.DESC);
         TextEditorFrame window = TextEditorFrame.get(container);
-        if (FORCE_OPEN_WINDOW && window == null) {
+        if (BQ_Settings.separateDescriptionEditor && window == null) {
             window = TextEditorFrame.getOrCreate(container, runnable, beforeName, beforeName, beforeDesc);
         }
         if (window != null) {

--- a/src/main/java/betterquesting/client/gui2/editors/GuiQuestDescEditor.java
+++ b/src/main/java/betterquesting/client/gui2/editors/GuiQuestDescEditor.java
@@ -37,6 +37,7 @@ import net.minecraft.util.text.TextFormatting;
 public class GuiQuestDescEditor<T extends IPropertyContainer> extends GuiScreenCanvas implements IPEventListener, IVolatileScreen {
 
     private final T container;
+    private final String title;
     private final String beforeName;
     private final String beforeDesc;
     public final Runnable runnable;
@@ -45,9 +46,10 @@ public class GuiQuestDescEditor<T extends IPropertyContainer> extends GuiScreenC
     private PanelButton close;
     private @Nullable TextEditorFrame window;
 
-    public GuiQuestDescEditor(GuiScreen parent, T container, Runnable runnable) {
+    public GuiQuestDescEditor(GuiScreen parent, T container, String title, Runnable runnable) {
         super(parent);
         this.container = container;
+        this.title = title;
         this.runnable = runnable;
         beforeName = container.getProperty(NativeProps.NAME);
         beforeDesc = container.getProperty(NativeProps.DESC);
@@ -185,8 +187,7 @@ public class GuiQuestDescEditor<T extends IPropertyContainer> extends GuiScreenC
         cvBackground.addPanel(new PanelButton(new GuiTransform(GuiAlign.BOTTOM_LEFT, 0 + 20, -16, 80, 16, 0), 1, QuestTranslation.translate("gui.cancel")));
         cvBackground.addPanel(new PanelButton(new GuiTransform(GuiAlign.BOTTOM_RIGHT, -80 - 20, -16, 80, 16, 0), 2, QuestTranslation.translate("gui.done")));
 
-        PanelTextBox txTitle = new PanelTextBox(new GuiTransform(GuiAlign.TOP_EDGE, new GuiPadding(0, 16, 0, -32), 0),
-                                                QuestTranslation.translate("betterquesting.title.edit_quest")).setAlignment(1);
+        PanelTextBox txTitle = new PanelTextBox(new GuiTransform(GuiAlign.TOP_EDGE, new GuiPadding(0, 16, 0, -32), 0), title).setAlignment(1);
         txTitle.setColor(PresetColor.TEXT_HEADER.getColor());
         cvBackground.addPanel(txTitle);
 

--- a/src/main/java/betterquesting/client/gui2/editors/GuiQuestDescEditor.java
+++ b/src/main/java/betterquesting/client/gui2/editors/GuiQuestDescEditor.java
@@ -2,13 +2,14 @@ package betterquesting.client.gui2.editors;
 
 import javax.annotation.Nullable;
 
+import betterquesting.api.properties.IPropertyContainer;
+import net.minecraft.client.gui.GuiScreen;
 import org.lwjgl.input.Keyboard;
 
 import com.google.common.collect.Lists;
 
 import betterquesting.api.client.gui.misc.IVolatileScreen;
 import betterquesting.api.properties.NativeProps;
-import betterquesting.api.questing.IQuest;
 import betterquesting.api2.client.gui.GuiScreenCanvas;
 import betterquesting.api2.client.gui.controls.IPanelButton;
 import betterquesting.api2.client.gui.controls.PanelButton;
@@ -32,28 +33,28 @@ import betterquesting.api2.client.gui.themes.presets.PresetTexture;
 import betterquesting.api2.utils.QuestTranslation;
 import net.minecraft.util.text.TextFormatting;
 
-public class GuiQuestDescEditor extends GuiScreenCanvas implements IPEventListener, IVolatileScreen {
+public class GuiQuestDescEditor<T extends IPropertyContainer> extends GuiScreenCanvas implements IPEventListener, IVolatileScreen {
 
     private static final boolean FORCE_OPEN_WINDOW = true;
 
-    private final int questID;
-    private final IQuest quest;
+    private final T container;
     private final String beforeName;
     private final String beforeDesc;
+    public final Runnable runnable;
     private String name; //TODO: Add this to GUI
     private PanelTextField<String> description;
     private PanelButton close;
     private @Nullable TextEditorFrame window;
 
-    public GuiQuestDescEditor(GuiQuestEditor parent, int questID, IQuest quest) {
+    public GuiQuestDescEditor(GuiScreen parent, T container, Runnable runnable) {
         super(parent);
-        this.questID = questID;
-        this.quest = quest;
-        beforeName = quest.getProperty(NativeProps.NAME);
-        beforeDesc = quest.getProperty(NativeProps.DESC);
-        TextEditorFrame window = TextEditorFrame.get(questID);
+        this.container = container;
+        this.runnable = runnable;
+        beforeName = container.getProperty(NativeProps.NAME);
+        beforeDesc = container.getProperty(NativeProps.DESC);
+        TextEditorFrame window = TextEditorFrame.get(container);
         if (FORCE_OPEN_WINDOW && window == null) {
-            window = TextEditorFrame.getOrCreate(questID, beforeName, beforeName, beforeDesc);
+            window = TextEditorFrame.getOrCreate(container, runnable, beforeName, beforeName, beforeDesc);
         }
         if (window != null) {
             this.window = window;
@@ -74,7 +75,7 @@ public class GuiQuestDescEditor extends GuiScreenCanvas implements IPEventListen
      */
     public void showWindow() {
         if (window == null)
-            window = TextEditorFrame.getOrCreate(questID, beforeName, name, description.getRawText());
+            window = TextEditorFrame.getOrCreate(container, runnable, beforeName, name, description.getRawText());
         window.setGui(this);
         window.toFront();
         window.requestFocus();
@@ -107,9 +108,10 @@ public class GuiQuestDescEditor extends GuiScreenCanvas implements IPEventListen
      * Save the name and the desc, and close the screen and the window.
      */
     public void saveAndClose() {
-        quest.setProperty(NativeProps.NAME, name.trim());
-        quest.setProperty(NativeProps.DESC, description.getRawText());
-        GuiQuestEditor.sendChanges(questID);
+        container.setProperty(NativeProps.NAME, name.trim());
+        container.setProperty(NativeProps.DESC, description.getRawText());
+        runnable.run();
+
         removeWindow();
         close();
     }

--- a/src/main/java/betterquesting/client/gui2/editors/GuiQuestEditor.java
+++ b/src/main/java/betterquesting/client/gui2/editors/GuiQuestEditor.java
@@ -223,7 +223,7 @@ public class GuiQuestEditor extends GuiScreenCanvas implements IPEventListener, 
             }
             case 7: // Description Editor
             {
-                mc.displayGuiScreen(new GuiQuestDescEditor<>(this, quest, () -> sendChanges(questID)));
+                mc.displayGuiScreen(new GuiQuestDescEditor<>(this, quest, QuestTranslation.translate("betterquesting.title.edit_quest"), () -> sendChanges(questID)));
                 break;
             }
             case 8: {

--- a/src/main/java/betterquesting/client/gui2/editors/GuiQuestEditor.java
+++ b/src/main/java/betterquesting/client/gui2/editors/GuiQuestEditor.java
@@ -223,7 +223,7 @@ public class GuiQuestEditor extends GuiScreenCanvas implements IPEventListener, 
             }
             case 7: // Description Editor
             {
-                mc.displayGuiScreen(new GuiQuestDescEditor(this, questID, quest));
+                mc.displayGuiScreen(new GuiQuestDescEditor<>(this, quest, () -> sendChanges(questID)));
                 break;
             }
             case 8: {

--- a/src/main/java/betterquesting/client/gui2/editors/GuiQuestLinesEditor.java
+++ b/src/main/java/betterquesting/client/gui2/editors/GuiQuestLinesEditor.java
@@ -293,7 +293,7 @@ public class GuiQuestLinesEditor extends GuiScreenCanvas implements IPEventListe
             if (order > 0) SendReorder(order);
         } else if (btn.getButtonID() == 8) // Big Description Editor
         {
-            mc.displayGuiScreen(new GuiQuestDescEditor<>(this, selected, () -> SendChanges(new DBEntry<>(selID, selected))));
+            mc.displayGuiScreen(new GuiQuestDescEditor<>(this, selected, QuestTranslation.translate("betterquesting.title.edit_line"), () -> SendChanges(new DBEntry<>(selID, selected))));
         }
     }
 

--- a/src/main/java/betterquesting/client/gui2/editors/GuiQuestLinesEditor.java
+++ b/src/main/java/betterquesting/client/gui2/editors/GuiQuestLinesEditor.java
@@ -48,6 +48,7 @@ public class GuiQuestLinesEditor extends GuiScreenCanvas implements IPEventListe
     private PanelButton btnDesign;
     private PanelButton btnVis;
     private PanelButton btnIcon;
+    private PanelButton btnTextEditor;
 
     private IQuestLine selected;
     private int selID = -1;
@@ -63,12 +64,14 @@ public class GuiQuestLinesEditor extends GuiScreenCanvas implements IPEventListe
 
             if (selected == null) {
                 selID = -1;
+                btnTextEditor.setActive(false);
                 btnDesign.setActive(false);
                 btnIcon.setActive(false);
                 btnVis.setActive(false);
                 tfName.setText("");
                 tfDesc.setText("");
             } else {
+                btnTextEditor.setActive(true);
                 btnDesign.setActive(true);
                 btnIcon.setActive(true);
                 btnVis.setActive(true);
@@ -167,7 +170,8 @@ public class GuiQuestLinesEditor extends GuiScreenCanvas implements IPEventListe
         btnDesign.setActive(selected != null);
         cvRight.addPanel(btnDesign);
 
-        PanelButton btnTextEditor = new PanelButton(new GuiTransform(GuiAlign.TOP_RIGHT, new GuiPadding(-16, 48, 0, -64), 0), 8, "Aa");
+        btnTextEditor = new PanelButton(new GuiTransform(GuiAlign.TOP_RIGHT, new GuiPadding(-16, 48, 0, -64), 0), 8, "Aa");
+        btnTextEditor.setActive(selected != null);
         cvRight.addPanel(btnTextEditor);
 
         // Dividers
@@ -184,12 +188,14 @@ public class GuiQuestLinesEditor extends GuiScreenCanvas implements IPEventListe
 
             if (selected == null) {
                 selID = -1;
+                btnTextEditor.setActive(false);
                 btnDesign.setActive(false);
                 btnIcon.setActive(false);
                 btnVis.setActive(false);
                 tfName.setText("");
                 tfDesc.setText("");
             } else {
+                btnTextEditor.setActive(true);
                 btnDesign.setActive(true);
                 btnIcon.setActive(true);
                 btnVis.setActive(true);
@@ -266,6 +272,7 @@ public class GuiQuestLinesEditor extends GuiScreenCanvas implements IPEventListe
             selID = entry.getID();
             tfName.setText(selected.getUnlocalisedName());
             tfDesc.setText(selected.getUnlocalisedDescription());
+            btnTextEditor.setActive(true);
             btnDesign.setActive(true);
             btnIcon.setActive(true);
             btnVis.setActive(true);

--- a/src/main/java/betterquesting/client/gui2/editors/GuiQuestLinesEditor.java
+++ b/src/main/java/betterquesting/client/gui2/editors/GuiQuestLinesEditor.java
@@ -293,13 +293,7 @@ public class GuiQuestLinesEditor extends GuiScreenCanvas implements IPEventListe
             if (order > 0) SendReorder(order);
         } else if (btn.getButtonID() == 8) // Big Description Editor
         {
-            mc.displayGuiScreen(new GuiTextEditor(this, tfDesc.getRawText(), value -> {
-                if (selected != null) {
-                    tfDesc.setText(value);
-                    selected.setProperty(NativeProps.DESC, value);
-                    SendChanges(new DBEntry<>(selID, selected));
-                }
-            }));
+            mc.displayGuiScreen(new GuiQuestDescEditor<>(this, selected, () -> SendChanges(new DBEntry<>(selID, selected))));
         }
     }
 

--- a/src/main/java/betterquesting/client/gui2/editors/TextEditorFrame.java
+++ b/src/main/java/betterquesting/client/gui2/editors/TextEditorFrame.java
@@ -48,14 +48,13 @@ import javax.swing.text.Element;
 import javax.swing.text.JTextComponent;
 import javax.swing.undo.UndoManager;
 
+import betterquesting.api.properties.IPropertyContainer;
 import betterquesting.api.properties.NativeProps;
-import betterquesting.api.questing.IQuest;
 import betterquesting.api2.utils.QuestTranslation;
 import betterquesting.core.BetterQuesting;
 import betterquesting.core.ModReference;
-import betterquesting.questing.QuestDatabase;
-import io.netty.util.collection.IntObjectHashMap;
-import io.netty.util.collection.IntObjectMap;
+import it.unimi.dsi.fastutil.objects.Object2ObjectMap;
+import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 import net.minecraft.client.Minecraft;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.text.TextFormatting;
@@ -69,34 +68,36 @@ public class TextEditorFrame extends JFrame {
     // This is NOT a cache.
     // This contains windows that is open.
     // This makes it possible to show and remain multiple editor windows.
-    // questID -> TextEditorFrame
-    private static final IntObjectMap<TextEditorFrame> open = new IntObjectHashMap<>();
+    // IPropertyContainer -> TextEditorFrame
+    private static final Object2ObjectMap<IPropertyContainer, TextEditorFrame> open = new Object2ObjectOpenHashMap<>();
 
-    public static @Nullable TextEditorFrame get(int questID) {
-        return open.get(questID);
+    public static @Nullable TextEditorFrame get(IPropertyContainer container) {
+        return open.get(container);
     }
 
-    public static TextEditorFrame getOrCreate(int questID, String title, String name, String description) {
-        if (open.containsKey(questID))
-            return open.get(questID);
-        TextEditorFrame frame = new TextEditorFrame(questID, title, name, description);
-        open.put(questID, frame);
+    public static TextEditorFrame getOrCreate(IPropertyContainer container, Runnable runnable, String title, String name, String description) {
+        if (open.containsKey(container))
+            return open.get(container);
+        TextEditorFrame frame = new TextEditorFrame(container, runnable, title, name, description);
+        open.put(container, frame);
         return frame;
     }
 
-    private final int questID;
+    private final IPropertyContainer container;
+    private final Runnable runnable;
     private final JTextField nameText;
     private final JButton close;
     private final JTextArea descText;
 
-    private @Nullable GuiQuestDescEditor gui = null;
+    private @Nullable GuiQuestDescEditor<?> gui = null;
 
     private boolean valueChangedByGuiScreen = false;
     private boolean byTopCornerCloseButton = true;
 
-    private TextEditorFrame(int questID, String title, String name, String description) {
+    private TextEditorFrame(IPropertyContainer container, Runnable runnable, String title, String name, String description) {
         super("Better Questing Text Editor | " + title);
-        this.questID = questID;
+        this.container = container;
+        this.runnable = runnable;
 
         initLogoCache();
 
@@ -116,7 +117,7 @@ public class TextEditorFrame extends JFrame {
                         gui.cancel();
                     }
                 } else {
-                    open.remove(questID);
+                    open.remove(container);
                     setVisible(false);
                     dispose();
                 }
@@ -238,7 +239,7 @@ public class TextEditorFrame extends JFrame {
         setVisible(true);
     }
 
-    public void setGui(@Nullable GuiQuestDescEditor gui) {
+    public void setGui(@Nullable GuiQuestDescEditor<?> gui) {
         this.gui = gui;
         close.setEnabled(gui != null);
     }
@@ -300,10 +301,9 @@ public class TextEditorFrame extends JFrame {
     }
 
     private void saveAndClose() {
-        IQuest quest = QuestDatabase.INSTANCE.getValue(questID);
-        quest.setProperty(NativeProps.NAME, getName().trim());
-        quest.setProperty(NativeProps.DESC, getDesc());
-        GuiQuestEditor.sendChanges(questID);
+        container.setProperty(NativeProps.NAME, getName().trim());
+        container.setProperty(NativeProps.DESC, getDesc());
+        runnable.run();
         close();
     }
 

--- a/src/main/java/betterquesting/client/gui2/editors/TextEditorFrame.java
+++ b/src/main/java/betterquesting/client/gui2/editors/TextEditorFrame.java
@@ -76,11 +76,7 @@ public class TextEditorFrame extends JFrame {
     }
 
     public static TextEditorFrame getOrCreate(IPropertyContainer container, Runnable runnable, String title, String name, String description) {
-        if (open.containsKey(container))
-            return open.get(container);
-        TextEditorFrame frame = new TextEditorFrame(container, runnable, title, name, description);
-        open.put(container, frame);
-        return frame;
+        return open.computeIfAbsent(container, c -> new TextEditorFrame(c, runnable, title, name, description));
     }
 
     private final IPropertyContainer container;

--- a/src/main/java/betterquesting/commands/admin/QuestCommandComplete.java
+++ b/src/main/java/betterquesting/commands/admin/QuestCommandComplete.java
@@ -71,7 +71,7 @@ public class QuestCommandComplete extends QuestCommandBase {
 
         String pName = NameCache.INSTANCE.getName(uuid);
 
-        if ("all".equalsIgnoreCase(action)) {
+        if (action.equalsIgnoreCase("all")) {
             var list = new IntArrayList();
             for (var i : QuestDatabase.INSTANCE.getEntries()) {
                 list.add(i.getID());

--- a/src/main/java/betterquesting/commands/admin/QuestCommandComplete.java
+++ b/src/main/java/betterquesting/commands/admin/QuestCommandComplete.java
@@ -7,6 +7,7 @@ import betterquesting.commands.QuestCommandBase;
 import betterquesting.network.handlers.NetQuestEdit;
 import betterquesting.questing.QuestDatabase;
 import betterquesting.storage.NameCache;
+import it.unimi.dsi.fastutil.ints.IntArrayList;
 import net.minecraft.command.CommandBase;
 import net.minecraft.command.CommandException;
 import net.minecraft.command.ICommandSender;
@@ -22,7 +23,7 @@ import java.util.UUID;
 public class QuestCommandComplete extends QuestCommandBase {
     @Override
     public String getUsageSuffix() {
-        return "<quest_id> [username|uuid]";
+        return "[all|<quest_id>] [username|uuid]";
     }
 
     @Override
@@ -34,6 +35,7 @@ public class QuestCommandComplete extends QuestCommandBase {
     public List<String> autoComplete(MinecraftServer server, ICommandSender sender, String[] args) {
         if (args.length == 2) {
             List<String> list = new ArrayList<>();
+            list.add("all");
             for (DBEntry<IQuest> i : QuestDatabase.INSTANCE.getEntries()) {
                 list.add("" + i.getID());
             }
@@ -52,6 +54,7 @@ public class QuestCommandComplete extends QuestCommandBase {
 
     @Override
     public void runCommand(MinecraftServer server, CommandBase command, ICommandSender sender, String[] args) throws CommandException {
+        String action = args[1].trim();
         UUID uuid;
 
         if (args.length >= 3) {
@@ -68,11 +71,20 @@ public class QuestCommandComplete extends QuestCommandBase {
 
         String pName = NameCache.INSTANCE.getName(uuid);
 
-        int id = Integer.parseInt(args[1].trim());
-        IQuest quest = QuestDatabase.INSTANCE.getValue(id);
-        if (quest == null) throw getException(command);
-        NetQuestEdit.setQuestStates(new int[]{id}, true, uuid);
-        sender.sendMessage(new TextComponentTranslation("betterquesting.cmd.complete", new TextComponentTranslation(quest.getProperty(NativeProps.NAME)), pName));
+        if ("all".equalsIgnoreCase(action)) {
+            var list = new IntArrayList();
+            for (var i : QuestDatabase.INSTANCE.getEntries()) {
+                list.add(i.getID());
+            }
+            NetQuestEdit.setQuestStates(list.elements(), true, uuid);
+            sender.sendMessage(new TextComponentTranslation("betterquesting.cmd.complete_all", pName));
+        } else {
+            int id = Integer.parseInt(action);
+            IQuest quest = QuestDatabase.INSTANCE.getValue(id);
+            if (quest == null) throw getException(command);
+            NetQuestEdit.setQuestStates(new int[]{id}, true, uuid);
+            sender.sendMessage(new TextComponentTranslation("betterquesting.cmd.complete", new TextComponentTranslation(quest.getProperty(NativeProps.NAME)), pName));
+        }
     }
 
     @Override

--- a/src/main/java/betterquesting/commands/admin/QuestCommandComplete.java
+++ b/src/main/java/betterquesting/commands/admin/QuestCommandComplete.java
@@ -77,7 +77,7 @@ public class QuestCommandComplete extends QuestCommandBase {
                 list.add(i.getID());
             }
             NetQuestEdit.setQuestStates(list.elements(), true, uuid);
-            sender.sendMessage(new TextComponentTranslation("betterquesting.cmd.complete_all", pName));
+            sender.sendMessage(new TextComponentTranslation("betterquesting.cmd.complete_all", list.size(), pName));
         } else {
             int id = Integer.parseInt(action);
             IQuest quest = QuestDatabase.INSTANCE.getValue(id);

--- a/src/main/java/betterquesting/commands/admin/QuestCommandDefaults.java
+++ b/src/main/java/betterquesting/commands/admin/QuestCommandDefaults.java
@@ -47,7 +47,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.function.BiFunction;
-import java.util.function.Function;
 import java.util.stream.Stream;
 
 public class QuestCommandDefaults extends QuestCommandBase {
@@ -61,8 +60,6 @@ public class QuestCommandDefaults extends QuestCommandBase {
     public static final String MULTI_QUEST_LINE_DIRECTORY = "MultipleQuestLine";
 
     public static final int FILE_NAME_MAX_LENGTH = 16;
-
-    private static final Function<File, NBTTagCompound> READ_NBT = file -> NBTConverter.JSONtoNBT_Object(JsonHelper.ReadFromFile(file), new NBTTagCompound(), true);
 
     @Override
     public String getUsageSuffix() {
@@ -282,7 +279,7 @@ public class QuestCommandDefaults extends QuestCommandBase {
             sendChatMessage(sender, "betterquesting.cmd.error");
             return;
         }
-        QuestSettings.INSTANCE.readFromNBT(READ_NBT.apply(settingsFile));
+        QuestSettings.INSTANCE.readFromNBT(readNBT(settingsFile));
         File questLineDir = new File(dataDir, QUEST_LINE_DIR);
         NBTTagList questLineDatabase = new NBTTagList();
         List<File> sortedQuestLineFiles = new ArrayList<>();
@@ -306,7 +303,7 @@ public class QuestCommandDefaults extends QuestCommandBase {
         }
 
         sortedQuestLineFiles.stream()
-                .map(READ_NBT)
+                .map(QuestCommandDefaults::readNBT)
                 .forEach(questLineDatabase::appendTag);
 
         QuestLineDatabase.INSTANCE.readFromNBT(questLineDatabase, false);
@@ -318,7 +315,7 @@ public class QuestCommandDefaults extends QuestCommandBase {
                     .map(Path::toFile)
                     .filter(x -> FilenameUtils.isExtension(x.getName(), "json"))
                     .forEach(questFile -> {
-                                NBTTagCompound questTag = READ_NBT.apply(questFile);
+                                NBTTagCompound questTag = readNBT(questFile);
                                 int questId = questTag.hasKey("questID", Constants.NBT.TAG_ANY_NUMERIC) ? questTag.getInteger("questID") : -1;
 
                                 if (questId < 0) {
@@ -462,6 +459,10 @@ public class QuestCommandDefaults extends QuestCommandBase {
 
     private static String removeChatFormatting(String string) {
         return string.replaceAll("§[0-9a-fk-or]", "");
+    }
+
+    private static NBTTagCompound readNBT(File file) {
+        return NBTConverter.JSONtoNBT_Object(JsonHelper.ReadFromFile(file), new NBTTagCompound(), true);
     }
 
     /** Helper method that handles having null sender. */

--- a/src/main/java/betterquesting/commands/admin/QuestCommandDefaults.java
+++ b/src/main/java/betterquesting/commands/admin/QuestCommandDefaults.java
@@ -287,12 +287,10 @@ public class QuestCommandDefaults extends QuestCommandBase {
         NBTTagList questLineDatabase = new NBTTagList();
         List<File> sortedQuestLineFiles = new ArrayList<>();
         try (Stream<Path> paths = Files.walk(questLineDir.toPath())) {
-            paths.filter(Files::isRegularFile).forEach(
-                    path -> {
-                        File questLineFile = path.toFile();
-                        sortedQuestLineFiles.add(questLineFile);
-                    }
-            );
+            paths.filter(Files::isRegularFile)
+                    .map(Path::toFile)
+                    .filter(x -> FilenameUtils.isExtension(x.getName(), "json"))
+                    .forEach(sortedQuestLineFiles::add);
         } catch (IOException e) {
             QuestingAPI.getLogger().log(Level.ERROR, "Failed to traverse directory\n" + questLineDir, e);
             sendChatMessage(sender, "betterquesting.cmd.error");

--- a/src/main/java/betterquesting/commands/admin/QuestCommandDefaults.java
+++ b/src/main/java/betterquesting/commands/admin/QuestCommandDefaults.java
@@ -35,6 +35,7 @@ import net.minecraft.util.text.TextComponentTranslation;
 import net.minecraftforge.common.util.Constants;
 import net.minecraftforge.server.permission.DefaultPermissionLevel;
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.FilenameUtils;
 import org.apache.logging.log4j.Level;
 import org.jetbrains.annotations.Nullable;
 
@@ -60,6 +61,8 @@ public class QuestCommandDefaults extends QuestCommandBase {
     public static final String MULTI_QUEST_LINE_DIRECTORY = "MultipleQuestLine";
 
     public static final int FILE_NAME_MAX_LENGTH = 16;
+
+    private static final Function<File, NBTTagCompound> READ_NBT = file -> NBTConverter.JSONtoNBT_Object(JsonHelper.ReadFromFile(file), new NBTTagCompound(), true);
 
     @Override
     public String getUsageSuffix() {
@@ -269,9 +272,6 @@ public class QuestCommandDefaults extends QuestCommandBase {
             return;
         }
 
-        Function<File, NBTTagCompound> readNbt =
-                file -> NBTConverter.JSONtoNBT_Object(JsonHelper.ReadFromFile(file), new NBTTagCompound(), true);
-
         boolean editMode = QuestSettings.INSTANCE.getProperty(NativeProps.EDIT_MODE);
         boolean hardMode = QuestSettings.INSTANCE.getProperty(NativeProps.HARDCORE);
         NBTTagList jsonP = QuestDatabase.INSTANCE.writeProgressToNBT(new NBTTagList(), null);
@@ -282,7 +282,7 @@ public class QuestCommandDefaults extends QuestCommandBase {
             sendChatMessage(sender, "betterquesting.cmd.error");
             return;
         }
-        QuestSettings.INSTANCE.readFromNBT(readNbt.apply(settingsFile));
+        QuestSettings.INSTANCE.readFromNBT(READ_NBT.apply(settingsFile));
         File questLineDir = new File(dataDir, QUEST_LINE_DIR);
         NBTTagList questLineDatabase = new NBTTagList();
         List<File> sortedQuestLineFiles = new ArrayList<>();
@@ -308,7 +308,7 @@ public class QuestCommandDefaults extends QuestCommandBase {
         }
 
         sortedQuestLineFiles.stream()
-                .map(readNbt)
+                .map(READ_NBT)
                 .forEach(questLineDatabase::appendTag);
 
         QuestLineDatabase.INSTANCE.readFromNBT(questLineDatabase, false);
@@ -316,25 +316,26 @@ public class QuestCommandDefaults extends QuestCommandBase {
 
         File questDir = new File(dataDir, QUEST_DIR);
         try (Stream<Path> paths = Files.walk(questDir.toPath())) {
-            paths.filter(Files::isRegularFile).forEach(
-                    path -> {
-                        File questFile = path.toFile();
-                        NBTTagCompound questTag = readNbt.apply(questFile);
-                        int questId = questTag.hasKey("questID", Constants.NBT.TAG_ANY_NUMERIC) ? questTag.getInteger("questID") : -1;
+            paths.filter(Files::isRegularFile)
+                    .map(Path::toFile)
+                    .filter(x -> FilenameUtils.isExtension(x.getName(), "json"))
+                    .forEach(questFile -> {
+                                NBTTagCompound questTag = READ_NBT.apply(questFile);
+                                int questId = questTag.hasKey("questID", Constants.NBT.TAG_ANY_NUMERIC) ? questTag.getInteger("questID") : -1;
 
-                        if (questId < 0) {
-                            questId = Integer.parseInt(questFile.getName().replaceAll("[^0-9]+", ""));
-                        }
+                                if (questId < 0) {
+                                    questId = Integer.parseInt(questFile.getName().replaceAll("[^0-9]+", ""));
+                                }
 
-                        if (questId < 0) {
-                            return;
-                        }
+                                if (questId < 0) {
+                                    return;
+                                }
 
-                        IQuest quest = new QuestInstance();
-                        quest.readFromNBT(questTag);
-                        QuestDatabase.INSTANCE.add(questId, quest);
-                    }
-            );
+                                IQuest quest = new QuestInstance();
+                                quest.readFromNBT(questTag);
+                                QuestDatabase.INSTANCE.add(questId, quest);
+                            }
+                    );
         } catch (IOException e) {
             QuestingAPI.getLogger().log(Level.ERROR, "Failed to traverse directory\n" + questDir, e);
             sendChatMessage(sender, "betterquesting.cmd.error");

--- a/src/main/java/betterquesting/core/proxies/CommonProxy.java
+++ b/src/main/java/betterquesting/core/proxies/CommonProxy.java
@@ -12,7 +12,6 @@ import betterquesting.handlers.EventHandler;
 import betterquesting.handlers.GuiHandler;
 import betterquesting.network.handlers.*;
 import betterquesting.questing.rewards.factory.*;
-import betterquesting.questing.rewards.loot.LootRegistry;
 import betterquesting.questing.tasks.factory.*;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraftforge.common.MinecraftForge;
@@ -27,7 +26,6 @@ public class CommonProxy {
         ExpansionLoader.INSTANCE.initCommonAPIs();
 
         MinecraftForge.EVENT_BUS.register(EventHandler.INSTANCE);
-        MinecraftForge.EVENT_BUS.register(new LootRegistry());
         MinecraftForge.TERRAIN_GEN_BUS.register(EventHandler.INSTANCE);
 
         NetworkRegistry.INSTANCE.registerGuiHandler(BetterQuesting.instance, new GuiHandler());

--- a/src/main/java/betterquesting/handlers/ConfigHandler.java
+++ b/src/main/java/betterquesting/handlers/ConfigHandler.java
@@ -23,6 +23,7 @@ public class ConfigHandler {
         BQ_Settings.useBookmark = config.getBoolean("Use Quest Bookmark", Configuration.CATEGORY_GENERAL, true, "Jumps the user to the last opened quest");
         BQ_Settings.guiWidth = config.getInt("Max GUI Width", Configuration.CATEGORY_GENERAL, -1, -1, Integer.MAX_VALUE, "Clamps the max UI width (-1 to disable)");
         BQ_Settings.guiHeight = config.getInt("Max GUI Height", Configuration.CATEGORY_GENERAL, -1, -1, Integer.MAX_VALUE, "Clamps the max UI height (-1 to disable)");
+        BQ_Settings.separateDescriptionEditor = config.getBoolean("Automatically Open Separate Text Editor for Descriptions", Configuration.CATEGORY_GENERAL, false, "If true, when editing the description of a quest or questline, automatically open a separate window for editing. This window will display text without applying formatting codes, unlike the inbuilt editor. Regardless of this setting, a button will appear to open the separate window.");
 
         BQ_Settings.scrollMultiplier = config.getFloat("Scroll Speed Multiplier", Configuration.CATEGORY_GENERAL, 1F, 0F, 10F, "Increases or decreases the scrolling speed");
 

--- a/src/main/java/betterquesting/handlers/ConfigHandler.java
+++ b/src/main/java/betterquesting/handlers/ConfigHandler.java
@@ -37,6 +37,7 @@ public class ConfigHandler {
         BQ_Settings.lockTray = config.getBoolean("Lock Tray", Configuration.CATEGORY_GENERAL, false, "If true, locks the quest chapter list and opens it initially");
         BQ_Settings.skipHome = config.getBoolean("Skip Home", Configuration.CATEGORY_GENERAL, false, "If true, skip the home GUI and open quests at startup. This property will be changed by the mod itself.");
         BQ_Settings.viewMode = config.getBoolean("View mode", Configuration.CATEGORY_GENERAL, false, "If view mode enabled, User can view all quests");
+        BQ_Settings.limitBack = config.getBoolean("Limit Back", Configuration.CATEGORY_GENERAL, false, "If true, the back keybind will not return to the home screen");
 
         BQ_Settings.defaultVisibility = config.getString("Default Quest Visibility", Configuration.CATEGORY_GENERAL, "NORMAL", "The default visibility value used when creating quests");
 

--- a/src/main/resources/assets/betterquesting/bq_themes.json
+++ b/src/main/resources/assets/betterquesting/bq_themes.json
@@ -1,7 +1,7 @@
 [
   {
     "themeID": "betterquesting:new_test",
-    "themeName": "New Test",
+    "themeName": "Semi-Transparent",
     "themeParent": "none",
     "textures": {
       "betterquesting:panel_main": {

--- a/src/main/resources/assets/betterquesting/lang/en_us.lang
+++ b/src/main/resources/assets/betterquesting/lang/en_us.lang
@@ -1,4 +1,5 @@
 betterquesting.title.quest_lines=Quest Lines
+betterquesting.title.edit_line=Edit Quest Line
 betterquesting.title.edit_line1=Edit Quest Lines
 betterquesting.title.edit_line2=Edit Quest Line - %s
 betterquesting.title.edit_quest=Edit Quest

--- a/src/main/resources/assets/betterquesting/lang/en_us.lang
+++ b/src/main/resources/assets/betterquesting/lang/en_us.lang
@@ -202,7 +202,7 @@ betterquesting.toolbox.tool.set_main.name=Set as Main
 betterquesting.toolbox.tool.set_main.desc=Set or unset the quest as main, which increases the link draw size
 
 betterquesting.cmd.complete=Completed quest %s for %s
-betterquesting.cmd.complete_all=Completed all quests for %s
+betterquesting.cmd.complete_all=Completed %s quests for %s
 betterquesting.cmd.default.save=Quest database saved as default
 betterquesting.cmd.default.save2=Quest database saved to %s
 betterquesting.cmd.default.load=Reloaded default quest database

--- a/src/main/resources/assets/betterquesting/lang/en_us.lang
+++ b/src/main/resources/assets/betterquesting/lang/en_us.lang
@@ -200,6 +200,7 @@ betterquesting.toolbox.tool.set_main.name=Set as Main
 betterquesting.toolbox.tool.set_main.desc=Set or unset the quest as main, which increases the link draw size
 
 betterquesting.cmd.complete=Completed quest %s for %s
+betterquesting.cmd.complete_all=Completed all quests for %s
 betterquesting.cmd.default.save=Quest database saved as default
 betterquesting.cmd.default.save2=Quest database saved to %s
 betterquesting.cmd.default.load=Reloaded default quest database

--- a/src/main/resources/assets/betterquesting/lang/en_us.lang
+++ b/src/main/resources/assets/betterquesting/lang/en_us.lang
@@ -68,6 +68,8 @@ betterquesting.btn.share_quest=Share to Chat
 betterquesting.btn.copy_id=Copy Quest ID
 betterquesting.btn.edit_name_desc.just_close=Just Close
 betterquesting.btn.edit_name_desc.open_window=Open Window
+betterquesting.btn.copy.tooltip.main=Click to copy description
+betterquesting.btn.copy.tooltip.shift=Hold shift to copy description without formatting
 
 betterquesting.home.exit=Exit
 betterquesting.home.quests=Quests


### PR DESCRIPTION
changes in this PR:
- rename "New Test" to "Semi-Transparent" (port of https://github.com/GTNewHorizons/BetterQuesting/pull/177).
- when loading from the new quest format, skip non `.json` files (related to https://github.com/GTNewHorizons/BetterQuesting/pull/184).
- add a button to copy the quest description (port of https://github.com/GTNewHorizons/BetterQuesting/pull/181) - slight difference in that it copies it with formatting codes when clicked, and strips formatting codes when holding shift (indicated via tooltip).
- add argument to command, allowing `/bq_admin complete all [player]` (port of https://github.com/GTNewHorizons/BetterQuesting/pull/186).
- improve highlight method by focusing and zooming on it + flashing color more frequently and severely (port of https://github.com/GTNewHorizons/BetterQuesting/pull/134) - slight difference in that it flashes faster and doesn't become pitch black.
- remove unused registration of event bus (port of https://github.com/GTNewHorizons/BetterQuesting/pull/163). a bit weirder here, since it does `register(new LootRegistry())`, but everything uses `LootRegistry.INSTANCE`.
- fixes for the back keybind:
	- make it only indicate incompatibility with GUIs, not UNIVERSAL.
	- fix the back keybind not working for mouse buttons.
	- add config to prevent going back when the parent screen is the home screen (default: `false`) (feature of the back keybind for BQu:T)
- make some changes to the external editor:
	- add a config for if it automatically appears (default: `true`) - theres always a button on the top right of the GUI that opens it regardless.
	- make the logic more abstract, and use it to allow editing the questline descriptions too.
- fix the "edit questline description" button always being clickable, even if no questline was selected.

resolves #78, resolves #121. 
originally intended to just port several GTNH fixes, but then forgot that was the point and made some other changes.