### PR TITLE
Improve Search Functionality

### DIFF
--- a/src/main/java/betterquesting/api/questing/ISearchable.java
+++ b/src/main/java/betterquesting/api/questing/ISearchable.java
@@ -1,0 +1,10 @@
+package betterquesting.api.questing;
+
+import java.util.List;
+
+public interface ISearchable {
+
+    default List<String> getTextForSearch() {
+        return null;
+    }
+}

--- a/src/main/java/betterquesting/api/questing/rewards/IReward.java
+++ b/src/main/java/betterquesting/api/questing/rewards/IReward.java
@@ -1,6 +1,7 @@
 package betterquesting.api.questing.rewards;
 
 import betterquesting.api.questing.IQuest;
+import betterquesting.api.questing.ISearchable;
 import betterquesting.api2.client.gui.misc.IGuiRect;
 import betterquesting.api2.client.gui.panels.IGuiPanel;
 import betterquesting.api2.storage.DBEntry;
@@ -14,7 +15,7 @@ import net.minecraftforge.fml.relauncher.SideOnly;
 
 import javax.annotation.Nullable;
 
-public interface IReward extends INBTSaveLoad<NBTTagCompound> {
+public interface IReward extends INBTSaveLoad<NBTTagCompound>, ISearchable {
     String getUnlocalisedName();
 
     ResourceLocation getFactoryID();

--- a/src/main/java/betterquesting/api/questing/tasks/ITask.java
+++ b/src/main/java/betterquesting/api/questing/tasks/ITask.java
@@ -1,6 +1,7 @@
 package betterquesting.api.questing.tasks;
 
 import betterquesting.api.questing.IQuest;
+import betterquesting.api.questing.ISearchable;
 import betterquesting.api2.client.gui.misc.IGuiRect;
 import betterquesting.api2.client.gui.panels.IGuiPanel;
 import betterquesting.api2.storage.DBEntry;
@@ -17,7 +18,7 @@ import javax.annotation.Nullable;
 import java.util.List;
 import java.util.UUID;
 
-public interface ITask extends INBTSaveLoad<NBTTagCompound>, INBTProgress<NBTTagCompound> {
+public interface ITask extends INBTSaveLoad<NBTTagCompound>, INBTProgress<NBTTagCompound>, ISearchable {
     String getUnlocalisedName();
 
     ResourceLocation getFactoryID();
@@ -47,9 +48,5 @@ public interface ITask extends INBTSaveLoad<NBTTagCompound>, INBTProgress<NBTTag
 
     default boolean displaysCenteredAlone() {
         return false;
-    }
-
-    default List<String> getTextForSearch() {
-        return null;
     }
 }

--- a/src/main/java/betterquesting/api2/client/gui/controls/PanelTextField.java
+++ b/src/main/java/betterquesting/api2/client/gui/controls/PanelTextField.java
@@ -636,7 +636,7 @@ public class PanelTextField<T> implements IGuiPanel {
         GlStateManager.translate(-getScrollX(), -getScrollY(), 0);
 
         if (text.length() <= 0) {
-            if (!isFocused) {
+            if (lockFocus || !isFocused) {
                 mc.fontRenderer.drawString(watermark, bounds.getX() + 4, bounds.getY() + 4, colWatermark.getRGB(), false);
             }
         } else {

--- a/src/main/java/betterquesting/api2/client/gui/controls/PanelTextField.java
+++ b/src/main/java/betterquesting/api2/client/gui/controls/PanelTextField.java
@@ -33,6 +33,7 @@ public class PanelTextField<T> implements IGuiPanel {
     private boolean isFocused = false;
     private boolean isActive = true;
     private boolean canWrap = false;
+    private boolean clearOnRightClick = false;
     private int maxLength = 32;
 
     private String text;
@@ -105,6 +106,11 @@ public class PanelTextField<T> implements IGuiPanel {
     public PanelTextField<T> enableWrapping(boolean state) {
         this.canWrap = state;
         updateScrollBounds();
+        return this;
+    }
+
+    public PanelTextField<T> enableClearingOnRightClick(boolean state) {
+        this.clearOnRightClick = state;
         return this;
     }
 
@@ -663,6 +669,13 @@ public class PanelTextField<T> implements IGuiPanel {
             if (!this.isFocused) {
                 this.isFocused = true;
                 updateScrollBounds(); // Just in case
+            }
+
+            if (clearOnRightClick && button == 1) {
+                setText("");
+                if (callback != null) {
+                    callback.setValue(filter.parseValue(this.text));
+                }
             }
 
             if (canWrap) {

--- a/src/main/java/betterquesting/api2/client/gui/panels/lists/CanvasQuestSearch.java
+++ b/src/main/java/betterquesting/api2/client/gui/panels/lists/CanvasQuestSearch.java
@@ -86,11 +86,23 @@ public class CanvasQuestSearch extends CanvasSearch<QuestSearchEntry, QuestSearc
             results.add(entry);
         } else {
             // task-specific search text
-            for (DBEntry<ITask> task : entry.getQuest().getValue().getTasks().getEntries()) {
-                if (task.getValue().getTextForSearch() == null) continue;
-                for (String text : task.getValue().getTextForSearch()) {
+            for (var task : value.getTasks().getEntries()) {
+                var list = task.getValue().getTextForSearch();
+                if (list == null) continue;
+                for (String text : list) {
                     if (StringUtils.containsIgnoreCase(text, query)) {
                         results.add(entry);
+                        return;
+                    }
+                }
+            }
+            for (var reward : value.getRewards().getEntries()) {
+                var list = reward.getValue().getTextForSearch();
+                if (list == null) continue;
+                for (String text : list) {
+                    if (StringUtils.containsIgnoreCase(text, query)) {
+                        results.add(entry);
+                        return;
                     }
                 }
             }

--- a/src/main/java/betterquesting/api2/client/gui/panels/lists/CanvasQuestSearch.java
+++ b/src/main/java/betterquesting/api2/client/gui/panels/lists/CanvasQuestSearch.java
@@ -5,7 +5,7 @@ import betterquesting.api.properties.NativeProps;
 import betterquesting.api.questing.IQuest;
 import betterquesting.api.questing.IQuestLine;
 import betterquesting.api.questing.IQuestLineEntry;
-import betterquesting.api.questing.tasks.ITask;
+import betterquesting.api.questing.ISearchable;
 import betterquesting.api2.cache.QuestCache;
 import betterquesting.api2.client.gui.controls.PanelButtonCustom;
 import betterquesting.api2.client.gui.controls.PanelButtonQuest;
@@ -22,12 +22,10 @@ import betterquesting.questing.QuestLineDatabase;
 import net.minecraft.entity.player.EntityPlayer;
 import org.apache.commons.lang3.StringUtils;
 
-import java.util.ArrayDeque;
-import java.util.Iterator;
-import java.util.List;
-import java.util.UUID;
+import java.util.*;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class CanvasQuestSearch extends CanvasSearch<QuestSearchEntry, QuestSearchEntry> {
     private List<QuestSearchEntry> questList;
@@ -85,27 +83,15 @@ public class CanvasQuestSearch extends CanvasSearch<QuestSearchEntry, QuestSearc
 
             results.add(entry);
         } else {
-            // task-specific search text
-            for (var task : value.getTasks().getEntries()) {
-                var list = task.getValue().getTextForSearch();
-                if (list == null) continue;
-                for (String text : list) {
-                    if (StringUtils.containsIgnoreCase(text, query)) {
-                        results.add(entry);
-                        return;
-                    }
-                }
-            }
-            for (var reward : value.getRewards().getEntries()) {
-                var list = reward.getValue().getTextForSearch();
-                if (list == null) continue;
-                for (String text : list) {
-                    if (StringUtils.containsIgnoreCase(text, query)) {
-                        results.add(entry);
-                        return;
-                    }
-                }
-            }
+            // search tasks and rewards
+            Stream.concat(value.getTasks().getEntries().stream(), value.getRewards().getEntries().stream())
+                    .map(DBEntry::getValue)
+                    .map(ISearchable::getTextForSearch)
+                    .filter(Objects::nonNull)
+                    .flatMap(List::stream)
+                    .filter(text -> StringUtils.containsIgnoreCase(text, query))
+                    .findAny()
+                    .ifPresent(text -> results.add(entry));
         }
     }
 

--- a/src/main/java/betterquesting/client/gui2/GuiQuestLines.java
+++ b/src/main/java/betterquesting/client/gui2/GuiQuestLines.java
@@ -614,7 +614,7 @@ public class GuiQuestLines extends GuiScreenCanvas implements IPEventListener, I
         selectedLine = q.getValue();
         selectedLineId = q.getID();
         for (int i = 0; i < btnListRef.size(); i++) {
-            btnListRef.get(i).setActive((visChapters.get(i).getSecond() & 4) == 0 && q.getID() != selectedLineId);
+            btnListRef.get(i).setActive((visChapters.get(i).getSecond() & 4) == 0 && btnListRef.get(i).getStoredValue().getID() != selectedLineId);
         }
 
         cvQuest.setQuestLine(q.getValue());

--- a/src/main/java/betterquesting/client/gui2/GuiQuestSearch.java
+++ b/src/main/java/betterquesting/client/gui2/GuiQuestSearch.java
@@ -22,6 +22,7 @@ import java.util.function.Consumer;
 
 public class GuiQuestSearch extends GuiScreenCanvas {
 
+    private static String priorSearchText = null;
     private PanelTextField<String> searchBox;
 
     public GuiQuestSearch(GuiScreen parent) {
@@ -65,7 +66,13 @@ public class GuiQuestSearch extends GuiScreenCanvas {
         CanvasQuestSearch canvasQuestSearch = createSearchCanvas();
         cvInner.addPanel(canvasQuestSearch);
 
-        searchBox.setCallback(canvasQuestSearch::setSearchFilter);
+        searchBox.setCallback(text -> {
+            GuiQuestSearch.priorSearchText = text;
+            canvasQuestSearch.setSearchFilter(text);
+        });
+        if (priorSearchText != null) {
+            searchBox.writeText(priorSearchText);
+        }
 
         PanelVScrollBar scDb = new PanelVScrollBar(new GuiTransform(GuiAlign.RIGHT_EDGE, new GuiPadding(-8, 32, 0, 24), 0));
         cvInner.addPanel(scDb);

--- a/src/main/java/betterquesting/client/gui2/GuiQuestSearch.java
+++ b/src/main/java/betterquesting/client/gui2/GuiQuestSearch.java
@@ -59,6 +59,7 @@ public class GuiQuestSearch extends GuiScreenCanvas {
         searchBox = new PanelTextField<>(new GuiTransform(GuiAlign.TOP_EDGE, new GuiPadding(0, 16, 8, -32), 0), "", FieldFilterString.INSTANCE);
         searchBox.setWatermark("Search...");
         searchBox.lockFocus(true);
+        searchBox.enableClearingOnRightClick(true);
         cvInner.addPanel(searchBox);
 
         CanvasQuestSearch canvasQuestSearch = createSearchCanvas();

--- a/src/main/java/betterquesting/client/gui2/GuiQuestSearch.java
+++ b/src/main/java/betterquesting/client/gui2/GuiQuestSearch.java
@@ -84,7 +84,7 @@ public class GuiQuestSearch extends GuiScreenCanvas {
         CanvasQuestSearch canvasQuestSearch = new CanvasQuestSearch(new GuiTransform(GuiAlign.FULL_BOX, new GuiPadding(0, 32, 8, 24), 0), mc.player);
         canvasQuestSearch.setQuestOpenCallback(questSearchEntry -> {
             acceptCallback(questSearchEntry);
-            GuiHome.bookmark = new GuiQuest(parent, questSearchEntry.getQuest().getID());
+            GuiHome.bookmark = new GuiQuest(this, questSearchEntry.getQuest().getID());
             mc.displayGuiScreen(GuiHome.bookmark);
         });
         canvasQuestSearch.setQuestHighlightCallback(questSearchEntry -> {

--- a/src/main/java/betterquesting/questing/rewards/RewardChoice.java
+++ b/src/main/java/betterquesting/questing/rewards/RewardChoice.java
@@ -138,4 +138,17 @@ public class RewardChoice implements IReward {
     public GuiScreen getRewardEditor(GuiScreen screen, DBEntry<IQuest> quest) {
         return null;
     }
+
+    @Override
+    public List<String> getTextForSearch() {
+        List<String> texts = new ArrayList<>();
+        for (BigItemStack bigStack : choices) {
+            ItemStack stack = bigStack.getBaseStack();
+            texts.add(stack.getDisplayName());
+            if (bigStack.hasOreDict()) {
+                texts.add(bigStack.getOreDict());
+            }
+        }
+        return texts;
+    }
 }

--- a/src/main/java/betterquesting/questing/rewards/RewardCommand.java
+++ b/src/main/java/betterquesting/questing/rewards/RewardCommand.java
@@ -26,6 +26,8 @@ import net.minecraft.world.World;
 
 import javax.annotation.Nonnull;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.UUID;
 
 public class RewardCommand implements IReward {
@@ -120,6 +122,11 @@ public class RewardCommand implements IReward {
     @Override
     public GuiScreen getRewardEditor(GuiScreen screen, DBEntry<IQuest> quest) {
         return null;
+    }
+
+    @Override
+    public List<String> getTextForSearch() {
+        return Collections.singletonList(command);
     }
 
     public static class RewardCommandSender extends CommandBlockBaseLogic {

--- a/src/main/java/betterquesting/questing/rewards/RewardItem.java
+++ b/src/main/java/betterquesting/questing/rewards/RewardItem.java
@@ -98,4 +98,17 @@ public class RewardItem implements IReward {
     public GuiScreen getRewardEditor(GuiScreen screen, DBEntry<IQuest> quest) {
         return null;
     }
+
+    @Override
+    public List<String> getTextForSearch() {
+        List<String> texts = new ArrayList<>();
+        for (BigItemStack bigStack : items) {
+            ItemStack stack = bigStack.getBaseStack();
+            texts.add(stack.getDisplayName());
+            if (bigStack.hasOreDict()) {
+                texts.add(bigStack.getOreDict());
+            }
+        }
+        return texts;
+    }
 }

--- a/src/main/java/betterquesting/questing/rewards/RewardRecipe.java
+++ b/src/main/java/betterquesting/questing/rewards/RewardRecipe.java
@@ -15,6 +15,9 @@ import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
 import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 public class RewardRecipe implements IReward {
     public String recipeNames = "minecraft:crafting_table\nminecraft:chest";
@@ -73,5 +76,12 @@ public class RewardRecipe implements IReward {
     @Override
     public void readFromNBT(NBTTagCompound nbt) {
         recipeNames = nbt.getString("recipes");
+    }
+
+    @Override
+    public List<String> getTextForSearch() {
+        List<String> texts = new ArrayList<>();
+        Collections.addAll(texts, recipeNames.split("\n"));
+        return texts;
     }
 }

--- a/src/main/java/betterquesting/questing/rewards/RewardScoreboard.java
+++ b/src/main/java/betterquesting/questing/rewards/RewardScoreboard.java
@@ -18,6 +18,9 @@ import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import org.apache.logging.log4j.Level;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class RewardScoreboard implements IReward {
 
     private static final String DEFAULT_TYPE = "dummy";
@@ -105,5 +108,13 @@ public class RewardScoreboard implements IReward {
     @SideOnly(Side.CLIENT)
     public GuiScreen getRewardEditor(GuiScreen screen, DBEntry<IQuest> quest) {
         return null;
+    }
+
+    @Override
+    public List<String> getTextForSearch() {
+        List<String> texts = new ArrayList<>();
+        texts.add(score);
+        texts.add(String.valueOf(value));
+        return texts;
     }
 }


### PR DESCRIPTION
changes in this PR:
- add the ability to search quest rewards (requested over at https://github.com/fonnymunkey/BQTweaker/issues/10).
- clear search bar on right click (port of https://github.com/GTNewHorizons/BetterQuesting/pull/109).
- remember last search term (also ported from [109](https://github.com/GTNewHorizons/BetterQuesting/pull/109)).
- set the search menu to be the prior page when looking at quests via the search menu.
- make the text field `watermark` apply regardless of if the search bar is focused if the search bar is always focused (makes it so the `Search...` watermark actually displays).
- fix a bug where after searching all quest lines are marked as "active" and thus unclickable due to checking if `q.getID() != q.getID()` instead of `btnListRef.get(i).getStoredValue().getID() != q.getID()`.