### PR TITLE
Rework Show Quest Command

### DIFF
--- a/src/main/java/betterquesting/client/gui2/GuiQuestLines.java
+++ b/src/main/java/betterquesting/client/gui2/GuiQuestLines.java
@@ -47,6 +47,7 @@ import betterquesting.api2.utils.QuestTranslation;
 import betterquesting.client.gui2.editors.GuiQuestEditor;
 import betterquesting.client.gui2.editors.GuiQuestLinesEditor;
 import betterquesting.client.gui2.editors.designer.GuiDesigner;
+import betterquesting.commands.client.QuestCommandShow;
 import betterquesting.handlers.ConfigHandler;
 import betterquesting.network.handlers.NetQuestAction;
 import betterquesting.questing.QuestDatabase;
@@ -346,7 +347,7 @@ public class GuiQuestLines extends GuiScreenCanvas implements IPEventListener, I
                     }
                     if (questExistsUnderMouse) {
                         Runnable questSharer = () -> {
-                            mc.player.sendChatMessage("betterquesting.msg.share_quest:" + cvQuest.getButtonAt(mx, my).getStoredValue().getID());
+                            QuestCommandShow.sendTrigger(mc.player, cvQuest.getButtonAt(mx, my).getStoredValue().getID());
                             mc.displayGuiScreen(null);
                         };
                         popup.addButton(QuestTranslation.translate("betterquesting.btn.share_quest"), null, questSharer);

--- a/src/main/java/betterquesting/commands/client/QuestCommandShow.java
+++ b/src/main/java/betterquesting/commands/client/QuestCommandShow.java
@@ -4,20 +4,14 @@ import betterquesting.api.api.QuestingAPI;
 import betterquesting.api.questing.IQuest;
 import betterquesting.api2.cache.QuestCache;
 import betterquesting.api2.storage.DBEntry;
-import betterquesting.client.gui2.GuiQuest;
-import betterquesting.client.gui2.GuiQuestLines;
 import betterquesting.commands.QuestCommandBase;
 import betterquesting.questing.QuestDatabase;
-import net.minecraft.client.Minecraft;
 import net.minecraft.client.entity.EntityPlayerSP;
 import net.minecraft.command.CommandBase;
 import net.minecraft.command.CommandException;
 import net.minecraft.command.ICommandSender;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.util.text.TextComponentTranslation;
-import net.minecraftforge.client.event.GuiOpenEvent;
-import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.server.permission.DefaultPermissionLevel;
 
 import java.util.Collections;
@@ -26,16 +20,11 @@ import java.util.stream.Collectors;
 
 public class QuestCommandShow extends QuestCommandBase {
 
-    public static boolean sentViaClick = false;
-    private static int questId = -1;
+    public static final String PREFIX = "betterquesting.msg.share_quest:";
+    public static final String VIEW = "betterquesting.msg.view_quest:";
 
-    @SubscribeEvent
-    public void onOpenGui(GuiOpenEvent event) {
-        if (questId != -1) {
-            event.setGui(new GuiQuest(new GuiQuestLines(null), questId));
-            MinecraftForge.EVENT_BUS.unregister(this);
-            questId = -1;
-        }
+    public static void sendTrigger(EntityPlayerSP player, int id) {
+        player.sendChatMessage(PREFIX + id);
     }
 
     @Override
@@ -45,24 +34,18 @@ public class QuestCommandShow extends QuestCommandBase {
 
     @Override
     public void runCommand(MinecraftServer server, CommandBase command, ICommandSender sender, String[] args) throws CommandException {
-        if (sender instanceof EntityPlayerSP && args.length == 2) {
+        if (sender instanceof EntityPlayerSP player && args.length == 2) {
             try {
-                questId = Integer.parseInt(args[1]);
-                if (sentViaClick) {
-                    sentViaClick = false;
-                    Minecraft.getMinecraft().addScheduledTask(() -> Minecraft.getMinecraft().displayGuiScreen(new GuiQuest(new GuiQuestLines(null), questId)));
-                } else {
-                    IQuest quest = QuestDatabase.INSTANCE.getValue(questId);
-                    if (quest != null) {
-                        EntityPlayerSP player = (EntityPlayerSP) sender;
-                        if (QuestCache.isQuestShown(quest, QuestingAPI.getQuestingUUID(player), player)) {
-                            MinecraftForge.EVENT_BUS.register(this);
-                            return;
-                        } else {
-                            sender.sendMessage(new TextComponentTranslation("betterquesting.msg.share_quest_hover_text_failure"));
-                        }
-                    }
+                int questId = Integer.parseInt(args[1]);
+                IQuest quest = QuestDatabase.INSTANCE.getValue(questId);
+                if (quest == null) {
                     sender.sendMessage(new TextComponentTranslation("betterquesting.msg.share_quest_invalid", String.valueOf(questId)));
+                } else {
+                    if (QuestCache.isQuestShown(quest, QuestingAPI.getQuestingUUID(player), player)) {
+                        sendTrigger(player, questId);
+                    } else {
+                        sender.sendMessage(new TextComponentTranslation("betterquesting.msg.share_quest_hover_text_failure"));
+                    }
                 }
             } catch (NumberFormatException e) {
                 sender.sendMessage(new TextComponentTranslation("betterquesting.msg.share_quest_invalid", args[1]));

--- a/src/main/java/betterquesting/handlers/EventHandler.java
+++ b/src/main/java/betterquesting/handlers/EventHandler.java
@@ -24,6 +24,7 @@ import betterquesting.api2.utils.ParticipantInfo;
 import betterquesting.api2.utils.QuestTranslation;
 import betterquesting.client.BQ_Keybindings;
 import betterquesting.client.gui2.GuiHome;
+import betterquesting.client.gui2.GuiQuest;
 import betterquesting.client.gui2.GuiQuestLines;
 import betterquesting.client.themes.ThemeRegistry;
 import betterquesting.commands.client.QuestCommandShow;
@@ -54,6 +55,7 @@ import net.minecraft.util.text.*;
 import net.minecraft.util.text.event.ClickEvent;
 import net.minecraft.util.text.event.HoverEvent;
 import net.minecraft.world.GameType;
+import net.minecraftforge.client.event.ClientChatEvent;
 import net.minecraftforge.client.event.ClientChatReceivedEvent;
 import net.minecraftforge.client.event.TextureStitchEvent;
 import net.minecraftforge.common.MinecraftForge;
@@ -120,9 +122,9 @@ public class EventHandler {
     public void onClientChatReceived(ClientChatReceivedEvent event) {
         if (event.getMessage() != null) {
             String text = event.getMessage().getFormattedText();
-            int index = text.indexOf("betterquesting.msg.share_quest:");
+            int index = text.indexOf(QuestCommandShow.PREFIX);
             if (index != -1) {
-                int lastIndex = index + "betterquesting.msg.share_quest:".length();
+                int lastIndex = index + QuestCommandShow.PREFIX.length();
                 int endIndex = lastIndex;
                 int questId = 0;
                 for (int i = lastIndex; i < text.length(); i++) {
@@ -144,15 +146,27 @@ public class EventHandler {
                 Style newMessageStyle;
                 EntityPlayerSP player = Minecraft.getMinecraft().player;
                 if (QuestCache.isQuestShown(quest, QuestingAPI.getQuestingUUID(player), player)) {
-                    QuestCommandShow.sentViaClick = true;
                     newMessageStyle = newMessage.getStyle()
-                            .setClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND, "/bq_client show " + questId))
+                            .setClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND, QuestCommandShow.VIEW + questId))
                             .setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, new TextComponentTranslation("betterquesting.msg.share_quest_hover_text_success")));
                 } else {
                     newMessageStyle = newMessage.getStyle()
                             .setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, new TextComponentTranslation("betterquesting.msg.share_quest_hover_text_failure")));
                 }
                 event.setMessage(newMessage.setStyle(newMessageStyle));
+            }
+        }
+    }
+
+    @SideOnly(Side.CLIENT)
+    @SubscribeEvent
+    public void onClientChatEvent(ClientChatEvent event) {
+        if (event.getOriginalMessage().startsWith(QuestCommandShow.VIEW)) {
+            try {
+                int questId = Integer.parseInt(event.getOriginalMessage().substring(QuestCommandShow.VIEW.length()));
+                Minecraft.getMinecraft().addScheduledTask(() -> Minecraft.getMinecraft().displayGuiScreen(new GuiQuest(new GuiQuestLines(null), questId)));
+                event.setCanceled(true);
+            } catch (NumberFormatException ignored) {
             }
         }
     }


### PR DESCRIPTION
changes in this PR:
- rework how `QuestCommandShow` works to use `ClientChatEvent`.
- make `/bq_client show {quest}` send a message in chat sharing the quest.

reasoning:
when a player receives a `ClientChatReceivedEvent` with the relevant message, `QuestCommandShow.sentViaClick = true` is set to true. then, when the message is clicked, custom logic is fired and `sentViaClick` is set to false. due to this, the first click on a shared quest works properly, but the second doesnt - you only receive the message once. additionally, this means that if you share -> manually run `/bq_client show {quest}` the command will have no effect.

another solution might be to override and create a custom `ClickEvent`, so when `getAction` is read it is set to be true: 
```java
new ClickEvent(ClickEvent.Action.RUN_COMMAND, "/bq_client show " + questId) {
    @Override
    public Action getAction() {
        QuestCommandShow.sentViaClick = true;
        return super.getAction();
    }
}
```
