### PR TITLE
Fix ore-dict based matching in PartyInventory

### DIFF
--- a/src/main/java/betterquesting/api/utils/BigItemStack.java
+++ b/src/main/java/betterquesting/api/utils/BigItemStack.java
@@ -2,10 +2,10 @@ package betterquesting.api.utils;
 
 import betterquesting.NBTUtil;
 import net.minecraft.block.Block;
-import net.minecraft.client.util.RecipeItemHelper;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.StringUtils;
 import net.minecraftforge.oredict.OreDictionary;
 import net.minecraftforge.oredict.OreIngredient;
@@ -36,7 +36,7 @@ public class BigItemStack {
         baseStack = stack.copy();
         this.stackSize = baseStack.getCount();
         baseStack.setCount(1);
-        this.hashKey = RecipeItemHelper.pack(baseStack);
+        this.hashKey = getHashKey(baseStack);
     }
 
     public BigItemStack(@Nonnull Block block) {
@@ -62,7 +62,15 @@ public class BigItemStack {
     public BigItemStack(@Nonnull Item item, int amount, int damage) {
         baseStack = new ItemStack(item, 1, damage);
         this.stackSize = amount;
-        this.hashKey = RecipeItemHelper.pack(baseStack);
+        this.hashKey = getHashKey(baseStack);
+    }
+
+    public static int getHashKey(ItemStack stack) {
+        ResourceLocation registryName = stack.getItem().getRegistryName();
+        if (registryName == null) {
+            return 0;
+        }
+        return registryName.hashCode();
     }
 
     /**
@@ -73,7 +81,7 @@ public class BigItemStack {
     }
 
     /**
-     * @see RecipeItemHelper#pack(ItemStack)
+     * @see BigItemStack#getHashKey(ItemStack)
      * @return the hash key to use for this BigItemStack to compare with other stacks
      */
     public int getHashKey() {
@@ -167,7 +175,7 @@ public class BigItemStack {
         this.setOreDict(tags.getString("OreDict"));
         this.baseStack = new ItemStack(itemNBT); // Minecraft does the ID conversions for me
         if (tags.getShort("Damage") < 0) this.baseStack.setItemDamage(OreDictionary.WILDCARD_VALUE);
-        this.hashKey = RecipeItemHelper.pack(baseStack);
+        this.hashKey = getHashKey(baseStack);
     }
 
     @Deprecated

--- a/src/main/java/betterquesting/api/utils/BigItemStack.java
+++ b/src/main/java/betterquesting/api/utils/BigItemStack.java
@@ -2,10 +2,10 @@ package betterquesting.api.utils;
 
 import betterquesting.NBTUtil;
 import net.minecraft.block.Block;
+import net.minecraft.client.util.RecipeItemHelper;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
-import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.StringUtils;
 import net.minecraftforge.oredict.OreDictionary;
 import net.minecraftforge.oredict.OreIngredient;
@@ -36,7 +36,7 @@ public class BigItemStack {
         baseStack = stack.copy();
         this.stackSize = baseStack.getCount();
         baseStack.setCount(1);
-        this.hashKey = getHashKey(baseStack);
+        this.hashKey = RecipeItemHelper.pack(baseStack);
     }
 
     public BigItemStack(@Nonnull Block block) {
@@ -62,15 +62,7 @@ public class BigItemStack {
     public BigItemStack(@Nonnull Item item, int amount, int damage) {
         baseStack = new ItemStack(item, 1, damage);
         this.stackSize = amount;
-        this.hashKey = getHashKey(baseStack);
-    }
-
-    public static int getHashKey(ItemStack stack) {
-        ResourceLocation registryName = stack.getItem().getRegistryName();
-        if (registryName == null) {
-            return 0;
-        }
-        return registryName.hashCode();
+        this.hashKey = RecipeItemHelper.pack(baseStack);
     }
 
     /**
@@ -81,7 +73,7 @@ public class BigItemStack {
     }
 
     /**
-     * @see BigItemStack#getHashKey(ItemStack)
+     * @see RecipeItemHelper#pack(ItemStack)
      * @return the hash key to use for this BigItemStack to compare with other stacks
      */
     public int getHashKey() {
@@ -175,7 +167,7 @@ public class BigItemStack {
         this.setOreDict(tags.getString("OreDict"));
         this.baseStack = new ItemStack(itemNBT); // Minecraft does the ID conversions for me
         if (tags.getShort("Damage") < 0) this.baseStack.setItemDamage(OreDictionary.WILDCARD_VALUE);
-        this.hashKey = getHashKey(baseStack);
+        this.hashKey = RecipeItemHelper.pack(baseStack);
     }
 
     @Deprecated

--- a/src/main/java/betterquesting/questing/party/PartyInventory.java
+++ b/src/main/java/betterquesting/questing/party/PartyInventory.java
@@ -100,8 +100,18 @@ public class PartyInventory {
     public ItemMatchContext getItemCountFor(BigItemStack req, boolean taskConsumes, boolean ignoreNBT, boolean partialMatch) {
         var gatheredStacks = taskConsumes ? playerStacks : partyStacks;
 
-        // The stacks matched by Item
-        var subStacks = gatheredStacks.get(req.getHashKey());
+        List<IndexedItemStack> subStacks = null;
+        if (req.hasOreDict()) {
+            // Stacks matched by any ore-dict item
+            for (ItemStack oreStack : req.getOreIngredient().getMatchingStacks()) {
+                int itemHash = BigItemStack.getHashKey(oreStack);
+                subStacks = gatheredStacks.get(itemHash);
+                if (subStacks != null) break;
+            }
+        } else {
+            // Stacks matched by base item
+            subStacks = gatheredStacks.get(req.getHashKey());
+        }
         if (subStacks == null || subStacks.isEmpty()) {
             return ItemMatchContext.EMPTY;
         }

--- a/src/main/java/betterquesting/questing/party/PartyInventory.java
+++ b/src/main/java/betterquesting/questing/party/PartyInventory.java
@@ -5,9 +5,6 @@ import betterquesting.api.utils.ItemComparison;
 import com.github.bsideup.jabel.Desugar;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
-import it.unimi.dsi.fastutil.ints.IntList;
-
-import net.minecraft.client.util.RecipeItemHelper;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.item.ItemStack;
@@ -27,9 +24,9 @@ import java.util.List;
  * A snapshot of a party's inventories, accumulating counts of all item stacks.
  */
 public class PartyInventory {
-    /** The main player's collected inventory, keys are stacks packed by {@link RecipeItemHelper#pack(ItemStack)}. */
+    /** The main player's collected inventory, keys are item ids. */
     private final Int2ObjectMap<List<IndexedItemStack>> playerStacks;
-    /** The collapsed inventory of all party members, keys are stacks packed by {@link RecipeItemHelper#pack(ItemStack)}. */
+    /** The collapsed inventory of all party members, keys are item ids. */
     private final Int2ObjectMap<List<IndexedItemStack>> partyStacks;
     /** The main player's collected fluid containers. */
     private final List<IndexedFluidContainer> playerFluidContainers;
@@ -64,7 +61,7 @@ public class PartyInventory {
                     indexedFluidContainer = null;
                 }
 
-                int itemHash = RecipeItemHelper.pack(stack);
+                int itemHash = BigItemStack.getHashKey(stack);
                 if (player == mainPlayer) {
                     var subStacks = playerStacks.get(itemHash);
                     if (subStacks == null) {
@@ -106,12 +103,9 @@ public class PartyInventory {
         List<IndexedItemStack> subStacks = null;
         if (req.hasOreDict()) {
             // Stacks matched by any ore-dict item
-            IntList oreHashes = req.getOreIngredient().getValidItemStacksPacked();
-
-            // for-each causes autoboxing, suppress
-            //noinspection ForLoopReplaceableByForEach
-            for (int i = 0; i < oreHashes.size(); i++) {
-                subStacks = gatheredStacks.get(oreHashes.get(i));
+            for (ItemStack oreStack : req.getOreIngredient().getMatchingStacks()) {
+                int itemHash = BigItemStack.getHashKey(oreStack);
+                subStacks = gatheredStacks.get(itemHash);
                 if (subStacks != null) break;
             }
         } else {

--- a/src/main/java/betterquesting/questing/party/PartyInventory.java
+++ b/src/main/java/betterquesting/questing/party/PartyInventory.java
@@ -5,6 +5,9 @@ import betterquesting.api.utils.ItemComparison;
 import com.github.bsideup.jabel.Desugar;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
+import it.unimi.dsi.fastutil.ints.IntList;
+
+import net.minecraft.client.util.RecipeItemHelper;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.item.ItemStack;
@@ -24,9 +27,9 @@ import java.util.List;
  * A snapshot of a party's inventories, accumulating counts of all item stacks.
  */
 public class PartyInventory {
-    /** The main player's collected inventory, keys are item ids. */
+    /** The main player's collected inventory, keys are stacks packed by {@link RecipeItemHelper#pack(ItemStack)}. */
     private final Int2ObjectMap<List<IndexedItemStack>> playerStacks;
-    /** The collapsed inventory of all party members, keys are item ids. */
+    /** The collapsed inventory of all party members, keys are stacks packed by {@link RecipeItemHelper#pack(ItemStack)}. */
     private final Int2ObjectMap<List<IndexedItemStack>> partyStacks;
     /** The main player's collected fluid containers. */
     private final List<IndexedFluidContainer> playerFluidContainers;
@@ -61,7 +64,7 @@ public class PartyInventory {
                     indexedFluidContainer = null;
                 }
 
-                int itemHash = BigItemStack.getHashKey(stack);
+                int itemHash = RecipeItemHelper.pack(stack);
                 if (player == mainPlayer) {
                     var subStacks = playerStacks.get(itemHash);
                     if (subStacks == null) {
@@ -103,9 +106,12 @@ public class PartyInventory {
         List<IndexedItemStack> subStacks = null;
         if (req.hasOreDict()) {
             // Stacks matched by any ore-dict item
-            for (ItemStack oreStack : req.getOreIngredient().getMatchingStacks()) {
-                int itemHash = BigItemStack.getHashKey(oreStack);
-                subStacks = gatheredStacks.get(itemHash);
+            IntList oreHashes = req.getOreIngredient().getValidItemStacksPacked();
+
+            // for-each causes autoboxing, suppress
+            //noinspection ForLoopReplaceableByForEach
+            for (int i = 0; i < oreHashes.size(); i++) {
+                subStacks = gatheredStacks.get(oreHashes.get(i));
                 if (subStacks != null) break;
             }
         } else {

--- a/src/main/java/betterquesting/questing/party/PartyInventory.java
+++ b/src/main/java/betterquesting/questing/party/PartyInventory.java
@@ -5,6 +5,8 @@ import betterquesting.api.utils.ItemComparison;
 import com.github.bsideup.jabel.Desugar;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
+import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
+
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.item.ItemStack;
@@ -100,13 +102,19 @@ public class PartyInventory {
     public ItemMatchContext getItemCountFor(BigItemStack req, boolean taskConsumes, boolean ignoreNBT, boolean partialMatch) {
         var gatheredStacks = taskConsumes ? playerStacks : partyStacks;
 
-        List<IndexedItemStack> subStacks = null;
+        List<IndexedItemStack> subStacks;
         if (req.hasOreDict()) {
             // Stacks matched by any ore-dict item
+            subStacks = new ArrayList<>();
+            var checkedHashes = new IntOpenHashSet();
             for (ItemStack oreStack : req.getOreIngredient().getMatchingStacks()) {
                 int itemHash = BigItemStack.getHashKey(oreStack);
-                subStacks = gatheredStacks.get(itemHash);
-                if (subStacks != null) break;
+                if (checkedHashes.add(itemHash)) {
+                    var matchedSubStacks = gatheredStacks.get(itemHash);
+                    if (matchedSubStacks != null) {
+                        subStacks.addAll(matchedSubStacks);
+                    }
+                }
             }
         } else {
             // Stacks matched by base item


### PR DESCRIPTION
`PartyInventory` was not actually accounting for retrieval tasks that had ore-dict specified, just the base stack. This checks the hash of all stacks in the ore-dict when necessary to get the corresponding party's matching stacks.
~~Switched to using `RecipeItemHelper#pack()` for hashing.~~
Fixes #147.