### PR TITLE
Make any task optional

### DIFF
--- a/src/main/java/betterquesting/client/gui2/GuiQuest.java
+++ b/src/main/java/betterquesting/client/gui2/GuiQuest.java
@@ -47,6 +47,7 @@ import org.lwjgl.util.vector.Vector4f;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 public class GuiQuest extends GuiScreenCanvas implements IPEventListener, INeedsRefresh {
 
@@ -390,13 +391,8 @@ public class GuiQuest extends GuiScreenCanvas implements IPEventListener, INeeds
         for (int i = 0; i < entries.size(); i++) {
             ITask tsk = entries.get(i).getValue();
 
-            String taskName = (i + 1) + ". " + QuestTranslation.translate(tsk.getUnlocalisedName());
-            if (tsk instanceof TaskRetrieval) {
-                EnumLogic entryLogic = ((TaskRetrieval) tsk).getEntryLogic();
-                if (entryLogic != EnumLogic.AND)
-                    taskName += " (" + entryLogic + ")";
-            }
-            PanelTextBox titleReward = new PanelTextBox(new GuiTransform(new Vector4f(), 0, yOffset, rectTask.getWidth(), 12, 0), taskName);
+            String titleText = (i + 1) + ". " + getTaskTitle(tsk, QuestingAPI.getQuestingUUID(mc.player));
+            PanelTextBox titleReward = new PanelTextBox(new GuiTransform(new Vector4f(), 0, yOffset, rectTask.getWidth(), 12, 0), titleText);
             titleReward.setColor(PresetColor.TEXT_HEADER.getColor()).setAlignment(1);
             titleReward.setEnabled(true);
             csTask.addPanel(titleReward);
@@ -423,6 +419,20 @@ public class GuiQuest extends GuiScreenCanvas implements IPEventListener, INeeds
         csTask.setScrollY(scrollPosition.getTaskScrollY());
         csTask.updatePanelScroll();
 
+    }
+
+    private static String getTaskTitle(ITask task, UUID uuid) {
+        String taskName = QuestTranslation.translate(task.getUnlocalisedName());
+        if (task instanceof TaskRetrieval retrieval) {
+            EnumLogic entryLogic = retrieval.getEntryLogic();
+            if (entryLogic != EnumLogic.AND) {
+                taskName += " (" + entryLogic + ")";
+            }
+        }
+        if (task.ignored(uuid)) {
+            return QuestTranslation.translate("bq_standard.task.is_optional") + " " + taskName;
+        }
+        return taskName;
     }
 
     private void refreshDescPanel(boolean hasReward) {

--- a/src/main/java/betterquesting/questing/tasks/TaskAdvancement.java
+++ b/src/main/java/betterquesting/questing/tasks/TaskAdvancement.java
@@ -1,5 +1,6 @@
 package betterquesting.questing.tasks;
 
+import betterquesting.NBTUtil;
 import betterquesting.api.questing.IQuest;
 import betterquesting.api.questing.tasks.ITask;
 import betterquesting.api2.client.gui.misc.IGuiRect;
@@ -27,6 +28,11 @@ import javax.annotation.Nullable;
 import java.util.*;
 
 public class TaskAdvancement implements ITask {
+
+    private static final boolean DEFAULT_OPTIONAL = false;
+
+    public boolean optional = DEFAULT_OPTIONAL;
+
     private final Set<UUID> completeUsers = new TreeSet<>();
     public ResourceLocation advID;
 
@@ -124,14 +130,21 @@ public class TaskAdvancement implements ITask {
 
     @Override
     public NBTTagCompound writeToNBT(NBTTagCompound nbt, boolean reduce) {
+        NBTUtil.setBoolean(nbt, "optional", optional, DEFAULT_OPTIONAL, reduce);
         nbt.setString("advancement_id", advID == null ? "" : advID.toString());
         return nbt;
     }
 
     @Override
     public void readFromNBT(NBTTagCompound nbt) {
+        optional = NBTUtil.getBoolean(nbt, "optional", DEFAULT_OPTIONAL);
         String id = nbt.getString("advancement_id");
         advID = StringUtils.isNullOrEmpty(id) ? null : new ResourceLocation(id);
+    }
+
+    @Override
+    public boolean ignored(UUID uuid) {
+        return optional;
     }
 
     @Override

--- a/src/main/java/betterquesting/questing/tasks/TaskBlockBreak.java
+++ b/src/main/java/betterquesting/questing/tasks/TaskBlockBreak.java
@@ -1,5 +1,6 @@
 package betterquesting.questing.tasks;
 
+import betterquesting.NBTUtil;
 import betterquesting.NbtBlockType;
 import betterquesting.api.questing.IQuest;
 import betterquesting.api.questing.tasks.ITask;
@@ -34,6 +35,9 @@ import javax.annotation.Nullable;
 import java.util.*;
 
 public class TaskBlockBreak implements ITask {
+    private static final boolean DEFAULT_OPTIONAL = false;
+
+    public boolean optional = DEFAULT_OPTIONAL;
     private final Set<UUID> completeUsers = new TreeSet<>();
     private final TreeMap<UUID, int[]> userProgress = new TreeMap<>();
     public final List<NbtBlockType> blockTypes = new ArrayList<>();
@@ -116,6 +120,7 @@ public class TaskBlockBreak implements ITask {
 
     @Override
     public NBTTagCompound writeToNBT(NBTTagCompound nbt, boolean reduce) {
+        NBTUtil.setBoolean(nbt, "optional", optional, DEFAULT_OPTIONAL, reduce);
         NBTTagList bAry = new NBTTagList();
         for (NbtBlockType block : blockTypes) {
             bAry.appendTag(block.writeToNBT(new NBTTagCompound(), reduce));
@@ -127,6 +132,7 @@ public class TaskBlockBreak implements ITask {
 
     @Override
     public void readFromNBT(NBTTagCompound nbt) {
+        optional = NBTUtil.getBoolean(nbt, "optional", DEFAULT_OPTIONAL);
         blockTypes.clear();
         NBTTagList bList = nbt.getTagList("blocks", 10);
         for (int i = 0; i < bList.tagCount(); i++) {
@@ -267,6 +273,11 @@ public class TaskBlockBreak implements ITask {
 
     private void setBulkProgress(@Nonnull List<Tuple<UUID, int[]>> list) {
         list.forEach((entry) -> setUserProgress(entry.getFirst(), entry.getSecond()));
+    }
+
+    @Override
+    public boolean ignored(UUID uuid) {
+        return optional;
     }
 
     @Override

--- a/src/main/java/betterquesting/questing/tasks/TaskCheckbox.java
+++ b/src/main/java/betterquesting/questing/tasks/TaskCheckbox.java
@@ -1,5 +1,6 @@
 package betterquesting.questing.tasks;
 
+import betterquesting.NBTUtil;
 import betterquesting.api.questing.IQuest;
 import betterquesting.api.questing.tasks.ITask;
 import betterquesting.api2.client.gui.misc.IGuiRect;
@@ -25,6 +26,9 @@ import java.util.TreeSet;
 import java.util.UUID;
 
 public class TaskCheckbox implements ITask {
+    private static final boolean DEFAULT_OPTIONAL = false;
+
+    public boolean optional = DEFAULT_OPTIONAL;
     private final Set<UUID> completeUsers = new TreeSet<>();
 
     @Override
@@ -64,11 +68,13 @@ public class TaskCheckbox implements ITask {
 
     @Override
     public NBTTagCompound writeToNBT(NBTTagCompound nbt, boolean reduce) {
+        NBTUtil.setBoolean(nbt, "optional", optional, DEFAULT_OPTIONAL, reduce);
         return nbt;
     }
 
     @Override
     public void readFromNBT(NBTTagCompound nbt) {
+        optional = NBTUtil.getBoolean(nbt, "optional", DEFAULT_OPTIONAL);
     }
 
     @Override
@@ -111,6 +117,11 @@ public class TaskCheckbox implements ITask {
     @SideOnly(Side.CLIENT)
     public GuiScreen getTaskEditor(GuiScreen parent, DBEntry<IQuest> quest) {
         return null;
+    }
+
+    @Override
+    public boolean ignored(UUID uuid) {
+        return optional;
     }
 
     @Override

--- a/src/main/java/betterquesting/questing/tasks/TaskCrafting.java
+++ b/src/main/java/betterquesting/questing/tasks/TaskCrafting.java
@@ -37,6 +37,7 @@ public class TaskCrafting implements ITask {
     private static final boolean DEFAULT_ALLOW_ANVIL = false;
     private static final boolean DEFAULT_ALLOW_SMELT = true;
     private static final boolean DEFAULT_ALLOW_CRAFT = true;
+    private static final boolean DEFAULT_OPTIONAL = false;
     private final Set<UUID> completeUsers = new TreeSet<>();
     public final NonNullList<BigItemStack> requiredItems = NonNullList.create();
     public final TreeMap<UUID, int[]> userProgress = new TreeMap<>();
@@ -45,6 +46,7 @@ public class TaskCrafting implements ITask {
     public boolean allowAnvil = DEFAULT_ALLOW_ANVIL;
     public boolean allowSmelt = DEFAULT_ALLOW_SMELT;
     public boolean allowCraft = DEFAULT_ALLOW_CRAFT;
+    public boolean optional = DEFAULT_OPTIONAL;
 
     @Override
     public ResourceLocation getFactoryID() {
@@ -135,6 +137,7 @@ public class TaskCrafting implements ITask {
         NBTUtil.setBoolean(nbt, "allowCraft", allowCraft, DEFAULT_ALLOW_CRAFT, reduce);
         NBTUtil.setBoolean(nbt, "allowSmelt", allowSmelt, DEFAULT_ALLOW_SMELT, reduce);
         NBTUtil.setBoolean(nbt, "allowAnvil", allowAnvil, DEFAULT_ALLOW_ANVIL, reduce);
+        NBTUtil.setBoolean(nbt, "optional", optional, DEFAULT_OPTIONAL, reduce);
 
         NBTTagList itemArray = new NBTTagList();
         for (BigItemStack stack : this.requiredItems) {
@@ -152,6 +155,7 @@ public class TaskCrafting implements ITask {
         allowCraft = NBTUtil.getBoolean(nbt, "allowCraft", DEFAULT_ALLOW_CRAFT);
         allowSmelt = NBTUtil.getBoolean(nbt, "allowSmelt", DEFAULT_ALLOW_SMELT);
         allowAnvil = NBTUtil.getBoolean(nbt, "allowAnvil", DEFAULT_ALLOW_ANVIL);
+        optional = NBTUtil.getBoolean(nbt, "optional", DEFAULT_OPTIONAL);
 
         requiredItems.clear();
         NBTTagList iList = nbt.getTagList("requiredItems", 10);
@@ -274,6 +278,11 @@ public class TaskCrafting implements ITask {
 
     private void setBulkProgress(@Nonnull List<Tuple<UUID, int[]>> list) {
         list.forEach((entry) -> setUserProgress(entry.getFirst(), entry.getSecond()));
+    }
+
+    @Override
+    public boolean ignored(UUID uuid) {
+        return optional;
     }
 
     @Override

--- a/src/main/java/betterquesting/questing/tasks/TaskFluid.java
+++ b/src/main/java/betterquesting/questing/tasks/TaskFluid.java
@@ -46,6 +46,7 @@ public class TaskFluid implements ITaskInventory, IFluidTask, IItemTask {
     private static final boolean DEFAULT_CONSUME = false;
     private static final boolean DEFAULT_GROUP_DETECT = false;
     private static final boolean DEFAULT_AUTO_CONSUME = false;
+    private static final boolean DEFAULT_OPTIONAL = false;
     private final Set<UUID> completeUsers = new ObjectOpenHashSet<>();
     public final NonNullList<FluidStack> requiredFluids = NonNullList.create();
     public final Map<UUID, int[]> userProgress = new Object2ObjectOpenHashMap<>();
@@ -54,6 +55,7 @@ public class TaskFluid implements ITaskInventory, IFluidTask, IItemTask {
     public boolean consume = DEFAULT_CONSUME;
     public boolean groupDetect = DEFAULT_GROUP_DETECT;
     public boolean autoConsume = DEFAULT_AUTO_CONSUME;
+    public boolean optional = DEFAULT_OPTIONAL;
     private boolean progressChanged = false;
 
     @Override
@@ -311,6 +313,7 @@ public class TaskFluid implements ITaskInventory, IFluidTask, IItemTask {
         NBTUtil.setBoolean(nbt, "consume", consume, DEFAULT_CONSUME, reduce);
         NBTUtil.setBoolean(nbt, "groupDetect", groupDetect, DEFAULT_GROUP_DETECT, reduce);
         NBTUtil.setBoolean(nbt, "autoConsume", autoConsume, DEFAULT_AUTO_CONSUME, reduce);
+        NBTUtil.setBoolean(nbt, "optional", optional, DEFAULT_OPTIONAL, reduce);
 
         NBTTagList itemArray = new NBTTagList();
         for (FluidStack stack : this.requiredFluids) {
@@ -328,6 +331,7 @@ public class TaskFluid implements ITaskInventory, IFluidTask, IItemTask {
         consume = NBTUtil.getBoolean(nbt, "consume", DEFAULT_CONSUME);
         groupDetect = NBTUtil.getBoolean(nbt, "groupDetect", DEFAULT_GROUP_DETECT);
         autoConsume = NBTUtil.getBoolean(nbt, "autoConsume", DEFAULT_AUTO_CONSUME);
+        optional = NBTUtil.getBoolean(nbt, "optional", DEFAULT_OPTIONAL);
 
         requiredFluids.clear();
         NBTTagList fList = nbt.getTagList("requiredFluids", 10);
@@ -556,6 +560,11 @@ public class TaskFluid implements ITaskInventory, IFluidTask, IItemTask {
         }
 
         return hasDrained ? handler.getContainer() : item;
+    }
+
+    @Override
+    public boolean ignored(UUID uuid) {
+        return optional;
     }
 
     @Override

--- a/src/main/java/betterquesting/questing/tasks/TaskHunt.java
+++ b/src/main/java/betterquesting/questing/tasks/TaskHunt.java
@@ -37,6 +37,7 @@ public class TaskHunt implements ITask {
     private static final int DEFAULT_REQUIRED = 1;
     private static final boolean DEFAULT_IGNORE_NBT = true;
     private static final boolean DEFAULT_SUBTYPES = true;
+    private static final boolean DEFAULT_OPTIONAL = false;
     private final Set<UUID> completeUsers = new TreeSet<>();
     private final TreeMap<UUID, Integer> userProgress = new TreeMap<>();
     public String idName = DEFAULT_ENTITY;
@@ -44,6 +45,7 @@ public class TaskHunt implements ITask {
     public int required = DEFAULT_REQUIRED;
     public boolean ignoreNBT = DEFAULT_IGNORE_NBT;
     public boolean subtypes = DEFAULT_SUBTYPES;
+    public boolean optional = DEFAULT_OPTIONAL;
 
     /**
      * NBT representation of the intended target. Used only for NBT comparison checks
@@ -127,6 +129,7 @@ public class TaskHunt implements ITask {
         NBTUtil.setBoolean(nbt, "ignoreNBT", ignoreNBT, DEFAULT_IGNORE_NBT, reduce);
         NBTUtil.setTag(nbt, "targetNBT", targetTags, reduce);
         NBTUtil.setString(nbt, "damageType", damageType, DEFAULT_DAMAGE_TYPE, reduce);
+        NBTUtil.setBoolean(nbt, "optional", optional, DEFAULT_OPTIONAL, reduce);
         return nbt;
     }
 
@@ -138,6 +141,7 @@ public class TaskHunt implements ITask {
         ignoreNBT = NBTUtil.getBoolean(nbt, "ignoreNBT", DEFAULT_IGNORE_NBT);
         targetTags = nbt.getCompoundTag("targetNBT");
         damageType = NBTUtil.getString(nbt, "damageType", DEFAULT_DAMAGE_TYPE);
+        optional = NBTUtil.getBoolean(nbt, "optional", DEFAULT_OPTIONAL);
     }
 
     @Override
@@ -242,6 +246,11 @@ public class TaskHunt implements ITask {
         List<Tuple<UUID, Integer>> list = new ArrayList<>();
         uuids.forEach((key) -> list.add(new Tuple<>(key, getUsersProgress(key))));
         return list;
+    }
+
+    @Override
+    public boolean ignored(UUID uuid) {
+        return optional;
     }
 
     @Override

--- a/src/main/java/betterquesting/questing/tasks/TaskInteractEntity.java
+++ b/src/main/java/betterquesting/questing/tasks/TaskInteractEntity.java
@@ -42,6 +42,7 @@ public class TaskInteractEntity implements ITask {
     private static final boolean DEFAULT_ON_INTERACT = true;
     private static final boolean DEFAULT_ON_HIT = false;
     private static final int DEFAULT_REQUIRED = 1;
+    private static final boolean DEFAULT_OPTIONAL = false;
     private final Set<UUID> completeUsers = new TreeSet<>();
     private final TreeMap<UUID, Integer> userProgress = new TreeMap<>();
 
@@ -59,6 +60,7 @@ public class TaskInteractEntity implements ITask {
     public boolean onInteract = DEFAULT_ON_INTERACT;
     public boolean onHit = DEFAULT_ON_HIT;
     public int required = DEFAULT_REQUIRED;
+    public boolean optional = DEFAULT_OPTIONAL;
 
     @Override
     public String getUnlocalisedName() {
@@ -238,6 +240,7 @@ public class TaskInteractEntity implements ITask {
         NBTUtil.setInteger(nbt, "requiredUses", required, DEFAULT_REQUIRED, reduce);
         NBTUtil.setBoolean(nbt, "onInteract", onInteract, DEFAULT_ON_INTERACT, reduce);
         NBTUtil.setBoolean(nbt, "onHit", onHit, DEFAULT_ON_HIT, reduce);
+        NBTUtil.setBoolean(nbt, "optional", optional, DEFAULT_OPTIONAL, reduce);
         return nbt;
     }
 
@@ -257,6 +260,7 @@ public class TaskInteractEntity implements ITask {
         required = NBTUtil.getInteger(nbt, "requiredUses", DEFAULT_REQUIRED);
         onInteract = NBTUtil.getBoolean(nbt, "onInteract", DEFAULT_ON_INTERACT);
         onHit = NBTUtil.getBoolean(nbt, "onHit", DEFAULT_ON_HIT);
+        optional = NBTUtil.getBoolean(nbt, "optional", DEFAULT_OPTIONAL);
     }
 
     private void setUserProgress(UUID uuid, int progress) {
@@ -273,6 +277,11 @@ public class TaskInteractEntity implements ITask {
         List<Tuple<UUID, Integer>> list = new ArrayList<>();
         uuids.forEach((key) -> list.add(new Tuple<>(key, getUsersProgress(key))));
         return list;
+    }
+
+    @Override
+    public boolean ignored(UUID uuid) {
+        return optional;
     }
 
     @Override

--- a/src/main/java/betterquesting/questing/tasks/TaskInteractItem.java
+++ b/src/main/java/betterquesting/questing/tasks/TaskInteractItem.java
@@ -44,6 +44,7 @@ public class TaskInteractItem implements ITask {
     private static final boolean DEFAULT_ON_INTERACT = true;
     private static final boolean DEFAULT_ON_HIT = false;
     private static final int DEFAULT_REQUIRED = 1;
+    private static final boolean DEFAULT_OPTIONAL = false;
     private final Set<UUID> completeUsers = new TreeSet<>();
     private final TreeMap<UUID, Integer> userProgress = new TreeMap<>();
 
@@ -56,6 +57,7 @@ public class TaskInteractItem implements ITask {
     public boolean onInteract = DEFAULT_ON_INTERACT;
     public boolean onHit = DEFAULT_ON_HIT;
     public int required = DEFAULT_REQUIRED;
+    public boolean optional = DEFAULT_OPTIONAL;
 
     @Override
     public String getUnlocalisedName() {
@@ -227,6 +229,7 @@ public class TaskInteractItem implements ITask {
         NBTUtil.setInteger(nbt, "requiredUses", required, DEFAULT_REQUIRED, reduce);
         NBTUtil.setBoolean(nbt, "onInteract", onInteract, DEFAULT_ON_INTERACT, reduce);
         NBTUtil.setBoolean(nbt, "onHit", onHit, DEFAULT_ON_HIT, reduce);
+        NBTUtil.setBoolean(nbt, "optional", optional, DEFAULT_OPTIONAL, reduce);
         return nbt;
     }
 
@@ -241,6 +244,7 @@ public class TaskInteractItem implements ITask {
         required = NBTUtil.getInteger(nbt, "requiredUses", DEFAULT_REQUIRED);
         onInteract = NBTUtil.getBoolean(nbt, "onInteract", DEFAULT_ON_INTERACT);
         onHit = NBTUtil.getBoolean(nbt, "onHit", DEFAULT_ON_HIT);
+        optional = NBTUtil.getBoolean(nbt, "optional", DEFAULT_OPTIONAL);
     }
 
     private void setUserProgress(UUID uuid, Integer progress) {
@@ -257,6 +261,11 @@ public class TaskInteractItem implements ITask {
         List<Tuple<UUID, Integer>> list = new ArrayList<>();
         uuids.forEach((key) -> list.add(new Tuple<>(key, getUsersProgress(key))));
         return list;
+    }
+
+    @Override
+    public boolean ignored(UUID uuid) {
+        return optional;
     }
 
     @Override

--- a/src/main/java/betterquesting/questing/tasks/TaskLocation.java
+++ b/src/main/java/betterquesting/questing/tasks/TaskLocation.java
@@ -39,6 +39,7 @@ public class TaskLocation implements ITaskTickable {
     private static final boolean DEFAULT_HIDE_INFO = false;
     private static final boolean DEFAULT_INVERT = false;
     private static final boolean DEFAULT_TAXI_CAB = false;
+    private static final boolean DEFAULT_OPTIONAL = false;
     private final Set<UUID> completeUsers = new TreeSet<>();
     public String name = "New Location";
     public String structure = DEFAULT_STRUCTURE;
@@ -52,6 +53,7 @@ public class TaskLocation implements ITaskTickable {
     public boolean hideInfo = DEFAULT_HIDE_INFO;
     public boolean invert = DEFAULT_INVERT;
     public boolean taxiCab = DEFAULT_TAXI_CAB;
+    public boolean optional = DEFAULT_OPTIONAL;
 
     @Override
     public ResourceLocation getFactoryID() {
@@ -155,6 +157,7 @@ public class TaskLocation implements ITaskTickable {
         NBTUtil.setBoolean(nbt, "hideInfo", hideInfo, DEFAULT_HIDE_INFO, reduce);
         NBTUtil.setBoolean(nbt, "invert", invert, DEFAULT_INVERT, reduce);
         NBTUtil.setBoolean(nbt, "taxiCabDist", taxiCab, DEFAULT_TAXI_CAB, reduce);
+        NBTUtil.setBoolean(nbt, "optional", optional, DEFAULT_OPTIONAL, reduce);
         return nbt;
     }
 
@@ -172,6 +175,7 @@ public class TaskLocation implements ITaskTickable {
         hideInfo = NBTUtil.getBoolean(nbt, "hideInfo", DEFAULT_HIDE_INFO);
         invert = NBTUtil.getBoolean(nbt, "invert", DEFAULT_INVERT) || nbt.getBoolean("invertDistance");
         taxiCab = NBTUtil.getBoolean(nbt, "taxiCabDist", DEFAULT_TAXI_CAB);
+        optional = NBTUtil.getBoolean(nbt, "optional", DEFAULT_OPTIONAL);
     }
 
     @Override
@@ -208,6 +212,11 @@ public class TaskLocation implements ITaskTickable {
     @Override
     public GuiScreen getTaskEditor(GuiScreen parent, DBEntry<IQuest> quest) {
         return null;
+    }
+
+    @Override
+    public boolean ignored(UUID uuid) {
+        return optional;
     }
 
     @Override

--- a/src/main/java/betterquesting/questing/tasks/TaskMeeting.java
+++ b/src/main/java/betterquesting/questing/tasks/TaskMeeting.java
@@ -33,6 +33,7 @@ public class TaskMeeting implements ITaskTickable {
     private static final int DEFAULT_AMOUNT = 1;
     private static final boolean DEFAULT_IGNORE_NBT = true;
     private static final boolean DEFAULT_SUBTYPES = true;
+    private static final boolean DEFAULT_OPTIONAL = false;
     private final Set<UUID> completeUsers = new TreeSet<>();
 
     public String idName = DEFAULT_ENTITY;
@@ -40,6 +41,7 @@ public class TaskMeeting implements ITaskTickable {
     public int amount = DEFAULT_AMOUNT;
     public boolean ignoreNBT = DEFAULT_IGNORE_NBT;
     public boolean subtypes = DEFAULT_SUBTYPES;
+    public boolean optional = DEFAULT_OPTIONAL;
 
     /**
      * NBT representation of the intended target. Used only for NBT comparison checks
@@ -135,6 +137,7 @@ public class TaskMeeting implements ITaskTickable {
         NBTUtil.setBoolean(json, "subtypes", subtypes, DEFAULT_SUBTYPES, reduce);
         NBTUtil.setBoolean(json, "ignoreNBT", ignoreNBT, DEFAULT_IGNORE_NBT, reduce);
         NBTUtil.setTag(json, "targetNBT", targetTags, reduce);
+        NBTUtil.setBoolean(json, "optional", optional, DEFAULT_OPTIONAL, reduce);
 
         return json;
     }
@@ -147,6 +150,7 @@ public class TaskMeeting implements ITaskTickable {
         subtypes = NBTUtil.getBoolean(nbt, "subtypes", DEFAULT_SUBTYPES);
         ignoreNBT = NBTUtil.getBoolean(nbt, "ignoreNBT", DEFAULT_IGNORE_NBT);
         targetTags = nbt.getCompoundTag("targetNBT");
+        optional = NBTUtil.getBoolean(nbt, "optional", DEFAULT_OPTIONAL);
     }
 
     @Override
@@ -187,6 +191,11 @@ public class TaskMeeting implements ITaskTickable {
     @Override
     public IGuiPanel getTaskGui(IGuiRect rect, DBEntry<IQuest> quest) {
         return new PanelTaskMeeting(rect, this);
+    }
+
+    @Override
+    public boolean ignored(UUID uuid) {
+        return optional;
     }
 
     @Override

--- a/src/main/java/betterquesting/questing/tasks/TaskOptionalRetrieval.java
+++ b/src/main/java/betterquesting/questing/tasks/TaskOptionalRetrieval.java
@@ -6,6 +6,7 @@ import net.minecraft.util.ResourceLocation;
 
 import java.util.UUID;
 
+@Deprecated
 public class TaskOptionalRetrieval extends TaskRetrieval {
 
     @Override

--- a/src/main/java/betterquesting/questing/tasks/TaskOptionalRetrieval.java
+++ b/src/main/java/betterquesting/questing/tasks/TaskOptionalRetrieval.java
@@ -1,26 +1,13 @@
 package betterquesting.questing.tasks;
 
-import betterquesting.core.BetterQuesting;
-import betterquesting.questing.tasks.factory.FactoryTaskOptionalRetrieval;
-import net.minecraft.util.ResourceLocation;
-
-import java.util.UUID;
+import net.minecraft.nbt.NBTTagCompound;
 
 @Deprecated
 public class TaskOptionalRetrieval extends TaskRetrieval {
 
     @Override
-    public String getUnlocalisedName() {
-        return BetterQuesting.MODID_STD + ".task.optional_retrieval";
-    }
-
-    @Override
-    public ResourceLocation getFactoryID() {
-        return FactoryTaskOptionalRetrieval.INSTANCE.getRegistryName();
-    }
-
-    @Override
-    public boolean ignored(UUID uuid) {
-        return true;
+    public void readFromNBT(NBTTagCompound nbt) {
+        super.readFromNBT(nbt);
+        optional = true;
     }
 }

--- a/src/main/java/betterquesting/questing/tasks/TaskRetrieval.java
+++ b/src/main/java/betterquesting/questing/tasks/TaskRetrieval.java
@@ -49,6 +49,7 @@ public class TaskRetrieval implements ITaskInventory, IItemTask {
     private static final boolean DEFAULT_CONSUME = false;
     private static final boolean DEFAULT_GROUP_DETECT = false;
     private static final boolean DEFAULT_AUTO_CONSUME = false;
+    private static final boolean DEFAULT_OPTIONAL = false;
     private static final EnumLogic DEFAULT_ENTRY_LOGIC = EnumLogic.AND;
 
     private final Set<UUID> completeUsers = new ObjectOpenHashSet<>();
@@ -59,6 +60,7 @@ public class TaskRetrieval implements ITaskInventory, IItemTask {
     public boolean consume = DEFAULT_CONSUME;
     public boolean groupDetect = DEFAULT_GROUP_DETECT;
     public boolean autoConsume = DEFAULT_AUTO_CONSUME;
+    public boolean optional = DEFAULT_OPTIONAL;
     private EnumLogic entryLogic = DEFAULT_ENTRY_LOGIC;
     private boolean resync = false;
     private boolean progressChanged = false;
@@ -328,6 +330,7 @@ public class TaskRetrieval implements ITaskInventory, IItemTask {
         NBTUtil.setBoolean(nbt, "groupDetect", groupDetect, DEFAULT_GROUP_DETECT, reduce);
         NBTUtil.setBoolean(nbt, "autoConsume", autoConsume, DEFAULT_AUTO_CONSUME, reduce);
         NBTUtil.setString(nbt, "entryLogic", entryLogic.name(), DEFAULT_ENTRY_LOGIC.name(), reduce);
+        NBTUtil.setBoolean(nbt, "optional", optional, DEFAULT_OPTIONAL, reduce);
 
         NBTTagList itemArray = new NBTTagList();
         for (BigItemStack stack : this.requiredItems) {
@@ -346,6 +349,7 @@ public class TaskRetrieval implements ITaskInventory, IItemTask {
         groupDetect = NBTUtil.getBoolean(nbt, "groupDetect", DEFAULT_GROUP_DETECT);
         autoConsume = NBTUtil.getBoolean(nbt, "autoConsume", DEFAULT_AUTO_CONSUME);
         setEntryLogic(NBTUtil.getEnum(nbt, "entryLogic", EnumLogic.class, true, DEFAULT_ENTRY_LOGIC));
+        optional = NBTUtil.getBoolean(nbt, "optional", DEFAULT_OPTIONAL);
 
         requiredItems.clear();
         NBTTagList iList = nbt.getTagList("requiredItems", 10);
@@ -526,6 +530,11 @@ public class TaskRetrieval implements ITaskInventory, IItemTask {
     @SideOnly(Side.CLIENT)
     public GuiScreen getTaskEditor(GuiScreen parent, DBEntry<IQuest> quest) {
         return new GuiEditTaskRetrieval(parent, quest, this);
+    }
+
+    @Override
+    public boolean ignored(UUID uuid) {
+        return optional;
     }
 
     @Override

--- a/src/main/java/betterquesting/questing/tasks/TaskScoreboard.java
+++ b/src/main/java/betterquesting/questing/tasks/TaskScoreboard.java
@@ -36,6 +36,7 @@ public class TaskScoreboard implements ITaskTickable {
     private static final float DEFAULT_CONVERSION = 1F;
     private static final String DEFAULT_SUFFIX = "";
     private static final ScoreOperation DEFAULT_OPERATION = ScoreOperation.MORE_OR_EQUAL;
+    private static final boolean DEFAULT_OPTIONAL = false;
     private final Set<UUID> completeUsers = new TreeSet<>();
     public String scoreName = "Score";
     public String scoreDisp = "Score";
@@ -44,6 +45,7 @@ public class TaskScoreboard implements ITaskTickable {
     public float conversion = DEFAULT_CONVERSION;
     public String suffix = DEFAULT_SUFFIX;
     public ScoreOperation operation = DEFAULT_OPERATION;
+    public boolean optional = DEFAULT_OPTIONAL;
 
     @Override
     public ResourceLocation getFactoryID() {
@@ -124,6 +126,7 @@ public class TaskScoreboard implements ITaskTickable {
         NBTUtil.setFloat(nbt, "unitConversion", conversion, DEFAULT_CONVERSION, reduce);
         NBTUtil.setString(nbt, "unitSuffix", suffix, DEFAULT_SUFFIX, reduce);
         NBTUtil.setString(nbt, "operation", operation.name(), DEFAULT_OPERATION.name(), reduce);
+        NBTUtil.setBoolean(nbt, "optional", optional, DEFAULT_OPTIONAL, reduce);
         return nbt;
     }
 
@@ -136,6 +139,7 @@ public class TaskScoreboard implements ITaskTickable {
         conversion = NBTUtil.getFloat(nbt, "unitConversion", DEFAULT_CONVERSION);
         suffix = NBTUtil.getString(nbt, "unitSuffix", DEFAULT_SUFFIX);
         operation = NBTUtil.getEnum(nbt, "operation", ScoreOperation.class, true, DEFAULT_OPERATION);
+        optional = NBTUtil.getBoolean(nbt, "optional", DEFAULT_OPTIONAL);
     }
 
     @Override
@@ -212,6 +216,11 @@ public class TaskScoreboard implements ITaskTickable {
     @SideOnly(Side.CLIENT)
     public GuiScreen getTaskEditor(GuiScreen parent, DBEntry<IQuest> quest) {
         return new GuiEditTaskScoreboard(parent, quest, this);
+    }
+
+    @Override
+    public boolean ignored(UUID uuid) {
+        return optional;
     }
 
     @Override

--- a/src/main/java/betterquesting/questing/tasks/TaskTame.java
+++ b/src/main/java/betterquesting/questing/tasks/TaskTame.java
@@ -35,12 +35,14 @@ public class TaskTame implements ITask {
     private static final int DEFAULT_REQUIRED = 1;
     private static final boolean DEFAULT_IGNORE_NBT = true;
     private static final boolean DEFAULT_SUBTYPES = true;
+    private static final boolean DEFAULT_OPTIONAL = false;
     private final Set<UUID> completeUsers = new TreeSet<>();
     public final HashMap<UUID, Integer> userProgress = new HashMap<>();
     public String idName = DEFAULT_ENTITY;
     public int required = DEFAULT_REQUIRED;
     public boolean ignoreNBT = DEFAULT_IGNORE_NBT;
     public boolean subtypes = DEFAULT_SUBTYPES;
+    public boolean optional = DEFAULT_OPTIONAL;
 
     /**
      * NBT representation of the intended target. Used only for NBT comparison checks
@@ -147,6 +149,7 @@ public class TaskTame implements ITask {
         NBTUtil.setBoolean(nbt, "subtypes", subtypes, DEFAULT_SUBTYPES, reduce);
         NBTUtil.setBoolean(nbt, "ignoreNBT", ignoreNBT, DEFAULT_IGNORE_NBT, reduce);
         NBTUtil.setTag(nbt, "targetNBT", targetTags, reduce);
+        NBTUtil.setBoolean(nbt, "optional", optional, DEFAULT_OPTIONAL, reduce);
 
         return nbt;
     }
@@ -158,6 +161,7 @@ public class TaskTame implements ITask {
         subtypes = NBTUtil.getBoolean(nbt, "subtypes", DEFAULT_SUBTYPES);
         ignoreNBT = NBTUtil.getBoolean(nbt, "ignoreNBT", DEFAULT_IGNORE_NBT);
         targetTags = nbt.getCompoundTag("targetNBT");
+        optional = NBTUtil.getBoolean(nbt, "optional", DEFAULT_OPTIONAL);
     }
 
     @Override
@@ -236,6 +240,11 @@ public class TaskTame implements ITask {
         List<Tuple<UUID, Integer>> list = new ArrayList<>();
         uuids.forEach((key) -> list.add(new Tuple<>(key, getUsersProgress(key))));
         return list;
+    }
+
+    @Override
+    public boolean ignored(UUID uuid) {
+        return optional;
     }
 
     @Override

--- a/src/main/java/betterquesting/questing/tasks/TaskTrigger.java
+++ b/src/main/java/betterquesting/questing/tasks/TaskTrigger.java
@@ -1,5 +1,6 @@
 package betterquesting.questing.tasks;
 
+import betterquesting.NBTUtil;
 import betterquesting.advancement.BqsAdvListener;
 import betterquesting.api.api.QuestingAPI;
 import betterquesting.api.questing.IQuest;
@@ -38,6 +39,7 @@ import java.util.*;
 
 public class TaskTrigger implements ITask {
     private static final Gson GSON = new GsonBuilder().setPrettyPrinting().create();
+    private static final boolean DEFAULT_OPTIONAL = false;
 
     private final Set<UUID> completeUsers = new TreeSet<>();
 
@@ -45,6 +47,7 @@ public class TaskTrigger implements ITask {
     private String critJson = "{}";
     private BqsAdvListener listener = null;
     private boolean needsSetup = true;
+    public boolean optional = DEFAULT_OPTIONAL;
 
     public String desc = "";
 
@@ -195,6 +198,7 @@ public class TaskTrigger implements ITask {
         nbt.setString("description", desc);
         nbt.setString("trigger", triggerID);
         nbt.setString("conditions", critJson);
+        NBTUtil.setBoolean(nbt, "optional", optional, DEFAULT_OPTIONAL, reduce);
         return nbt;
     }
 
@@ -203,6 +207,12 @@ public class TaskTrigger implements ITask {
         this.desc = nbt.getString("description");
         this.setTriggerID(nbt.getString("trigger"));
         this.setCriteriaJson(nbt.getString("conditions"));
+        optional = NBTUtil.getBoolean(nbt, "optional", DEFAULT_OPTIONAL);
+    }
+
+    @Override
+    public boolean ignored(UUID uuid) {
+        return optional;
     }
 
     @Override

--- a/src/main/java/betterquesting/questing/tasks/TaskXP.java
+++ b/src/main/java/betterquesting/questing/tasks/TaskXP.java
@@ -26,11 +26,13 @@ public class TaskXP implements ITaskTickable {
     private static final boolean DEFAULT_LEVELS = true;
     private static final int DEFAULT_AMOUNT = 30;
     private static final boolean DEFAULT_CONSUME = true;
+    private static final boolean DEFAULT_OPTIONAL = false;
     private final Set<UUID> completeUsers = new TreeSet<>();
     private final HashMap<UUID, Long> userProgress = new HashMap<>();
     public boolean levels = DEFAULT_LEVELS;
     public int amount = DEFAULT_AMOUNT;
     public boolean consume = DEFAULT_CONSUME;
+    public boolean optional = DEFAULT_OPTIONAL;
 
     @Override
     public ResourceLocation getFactoryID() {
@@ -116,6 +118,7 @@ public class TaskXP implements ITaskTickable {
         NBTUtil.setInteger(nbt, "amount", amount, DEFAULT_AMOUNT, reduce);
         NBTUtil.setBoolean(nbt, "isLevels", levels, DEFAULT_LEVELS, reduce);
         NBTUtil.setBoolean(nbt, "consume", consume, DEFAULT_CONSUME, reduce);
+        NBTUtil.setBoolean(nbt, "optional", optional, DEFAULT_OPTIONAL, reduce);
         return nbt;
     }
 
@@ -124,6 +127,7 @@ public class TaskXP implements ITaskTickable {
         amount = NBTUtil.getInteger(nbt, "amount", DEFAULT_AMOUNT);
         levels = NBTUtil.getBoolean(nbt, "isLevels", DEFAULT_LEVELS);
         consume = NBTUtil.getBoolean(nbt, "consume", DEFAULT_CONSUME);
+        optional = NBTUtil.getBoolean(nbt, "optional", DEFAULT_OPTIONAL);
     }
 
     @Override
@@ -216,6 +220,11 @@ public class TaskXP implements ITaskTickable {
     public long getUsersProgress(UUID uuid) {
         Long n = userProgress.get(uuid);
         return n == null ? 0 : n;
+    }
+
+    @Override
+    public boolean ignored(UUID uuid) {
+        return optional;
     }
 
     @Override

--- a/src/main/java/betterquesting/questing/tasks/factory/FactoryTaskOptionalRetrieval.java
+++ b/src/main/java/betterquesting/questing/tasks/factory/FactoryTaskOptionalRetrieval.java
@@ -3,7 +3,7 @@ package betterquesting.questing.tasks.factory;
 import betterquesting.api.questing.tasks.ITask;
 import betterquesting.api2.registry.IFactoryData;
 import betterquesting.core.BetterQuesting;
-import betterquesting.questing.tasks.TaskOptionalRetrieval;
+import betterquesting.questing.tasks.TaskRetrieval;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.ResourceLocation;
 
@@ -17,14 +17,17 @@ public class FactoryTaskOptionalRetrieval implements IFactoryData<ITask, NBTTagC
     }
 
     @Override
-    public TaskOptionalRetrieval createNew() {
-        return new TaskOptionalRetrieval();
+    public TaskRetrieval createNew() {
+        TaskRetrieval task = new TaskRetrieval();
+        task.optional = true;
+        return task;
     }
 
     @Override
-    public TaskOptionalRetrieval loadFromData(NBTTagCompound json) {
-        TaskOptionalRetrieval task = new TaskOptionalRetrieval();
+    public TaskRetrieval loadFromData(NBTTagCompound json) {
+        TaskRetrieval task = new TaskRetrieval();
         task.readFromNBT(json);
+        task.optional = true;
         return task;
     }
 }

--- a/src/main/java/betterquesting/questing/tasks/factory/FactoryTaskOptionalRetrieval.java
+++ b/src/main/java/betterquesting/questing/tasks/factory/FactoryTaskOptionalRetrieval.java
@@ -3,7 +3,7 @@ package betterquesting.questing.tasks.factory;
 import betterquesting.api.questing.tasks.ITask;
 import betterquesting.api2.registry.IFactoryData;
 import betterquesting.core.BetterQuesting;
-import betterquesting.questing.tasks.TaskRetrieval;
+import betterquesting.questing.tasks.TaskOptionalRetrieval;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.ResourceLocation;
 
@@ -17,17 +17,14 @@ public class FactoryTaskOptionalRetrieval implements IFactoryData<ITask, NBTTagC
     }
 
     @Override
-    public TaskRetrieval createNew() {
-        TaskRetrieval task = new TaskRetrieval();
-        task.optional = true;
-        return task;
+    public TaskOptionalRetrieval createNew() {
+        return new TaskOptionalRetrieval();
     }
 
     @Override
-    public TaskRetrieval loadFromData(NBTTagCompound json) {
-        TaskRetrieval task = new TaskRetrieval();
+    public TaskOptionalRetrieval loadFromData(NBTTagCompound json) {
+        TaskOptionalRetrieval task = new TaskOptionalRetrieval();
         task.readFromNBT(json);
-        task.optional = true;
         return task;
     }
 }

--- a/src/main/resources/assets/betterquesting/lang/en_us.lang
+++ b/src/main/resources/assets/betterquesting/lang/en_us.lang
@@ -259,6 +259,7 @@ jdoc.betterquesting.quest.properties.desc=Properties defining the quest's appear
 jdoc.betterquesting.quest.properties.betterquesting.name=BetterQuesting
 jdoc.betterquesting.quest.properties.betterquesting.desc=BetterQuesting properties
 
+bq_standard.task.is_optional=Optional
 bq_standard.task.retrieval=Retrieval Task
 bq_standard.task.optional_retrieval=Optional Retrieval Task
 bq_standard.task.crafting=Crafting Task


### PR DESCRIPTION
changes in this PR:
- add a boolean to every task in BQ to allow the task being made `optional`, which means it does not need to be completed for the quest to be completed.
- make this display as `#. Optional Name Task`
- make `optional_retrieval` tasks switch to be `retrieval` tasks that have `optional` enabled and deprecate them. they still appear as a task in the GUI.

supersedes #126