### PR TITLE
Fix BqsAdvListener clinit error

### DIFF
--- a/src/main/java/betterquesting/advancement/BqsAdvListener.java
+++ b/src/main/java/betterquesting/advancement/BqsAdvListener.java
@@ -11,7 +11,7 @@ import net.minecraft.advancements.ICriterionTrigger;
 import net.minecraft.advancements.PlayerAdvancements;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.util.Tuple;
-import net.minecraftforge.fml.relauncher.ReflectionHelper;
+import net.minecraftforge.fml.common.ObfuscationReflectionHelper;
 
 import javax.annotation.Nonnull;
 import java.lang.reflect.Field;
@@ -87,7 +87,7 @@ public class BqsAdvListener<T extends ICriterionInstance> extends ICriterionTrig
     private static final Field f_playerAdv;
 
     static {
-        f_playerAdv = ReflectionHelper.findField(PlayerAdvancements.class, "field_192762_j", "player");
+        f_playerAdv = ObfuscationReflectionHelper.findField(PlayerAdvancements.class, "field_192762_j");
         f_playerAdv.setAccessible(true);
     }
 }


### PR DESCRIPTION
changes in this PR:
- switch `ReflectionHelper` to `ObfuscationReflectionHelper`, fixing an error when constructing `BqsAdvListener`.

the old method, while looking correct, had its parameters in the wrong order (should be in the order `fieldName, fieldObfName`, but was `field_192762_j, player`). this line hasnt been changed in BQu.

should resolve #151