### PR TITLE
Improve rendering/search performance and fix client leaks

### DIFF
--- a/src/main/java/betterquesting/api/utils/RenderUtils.java
+++ b/src/main/java/betterquesting/api/utils/RenderUtils.java
@@ -2,6 +2,7 @@ package betterquesting.api.utils;
 
 import betterquesting.api2.client.gui.misc.GuiRectangle;
 import betterquesting.api2.client.gui.misc.IGuiRect;
+import betterquesting.api2.client.gui.misc.IRenderedStackProvider;
 import betterquesting.api2.client.gui.resources.colors.GuiColorStatic;
 import betterquesting.api2.client.gui.resources.colors.IGuiColor;
 import betterquesting.api2.client.gui.themes.presets.PresetTexture;
@@ -666,6 +667,11 @@ public class RenderUtils {
         drawHoveringText(ItemStack.EMPTY, textLines, mouseX, mouseY, screenWidth, screenHeight, maxTextWidth, font);
     }
 
+    public static void drawHoveringText(IRenderedStackProvider stackProvider, List<String> textLines, int mouseX, int mouseY, int screenWidth, int screenHeight, int maxTextWidth, FontRenderer font) {
+        drawHoveringText(stackProvider.getRenderedStack(), textLines, mouseX, mouseY, screenWidth, screenHeight, maxTextWidth, font);
+        stackProvider.resetRenderedStack();
+    }
+
     /**
      * Modified version of Forge's tooltip rendering that doesn't adjust Z depth
      */
@@ -769,29 +775,10 @@ public class RenderUtils {
         } else if (tooltipY + tooltipHeight + 4 > screenHeight) {
             tooltipY = screenHeight - tooltipHeight - 4;
         }
-		
-		/*int backgroundColor = 0xF0100010;
-		int borderColorStart = 0x505000FF;
-		int borderColorEnd = (borderColorStart & 0xFEFEFE) >> 1 | borderColorStart & 0xFF000000;
-		
-		RenderTooltipEvent.Color colorEvent = new RenderTooltipEvent.Color(stack, textLines, tooltipX, tooltipY, font, backgroundColor, borderColorStart, borderColorEnd);
-		MinecraftForge.EVENT_BUS.post(colorEvent);
-		backgroundColor = colorEvent.getBackground();
-		borderColorStart = colorEvent.getBorderStart();
-		borderColorEnd = colorEvent.getBorderEnd();
-		
-		GuiUtils.drawGradientRect(0, tooltipX - 3, tooltipY - 4, tooltipX + tooltipTextWidth + 3, tooltipY - 3, backgroundColor, backgroundColor);
-		GuiUtils.drawGradientRect(0, tooltipX - 3, tooltipY + tooltipHeight + 3, tooltipX + tooltipTextWidth + 3, tooltipY + tooltipHeight + 4, backgroundColor, backgroundColor);
-		GuiUtils.drawGradientRect(0, tooltipX - 3, tooltipY - 3, tooltipX + tooltipTextWidth + 3, tooltipY + tooltipHeight + 3, backgroundColor, backgroundColor);
-		GuiUtils.drawGradientRect(0, tooltipX - 4, tooltipY - 3, tooltipX - 3, tooltipY + tooltipHeight + 3, backgroundColor, backgroundColor);
-		GuiUtils.drawGradientRect(0, tooltipX + tooltipTextWidth + 3, tooltipY - 3, tooltipX + tooltipTextWidth + 4, tooltipY + tooltipHeight + 3, backgroundColor, backgroundColor);
-		GuiUtils.drawGradientRect(0, tooltipX - 3, tooltipY - 3 + 1, tooltipX - 3 + 1, tooltipY + tooltipHeight + 3 - 1, borderColorStart, borderColorEnd);
-		GuiUtils.drawGradientRect(0, tooltipX + tooltipTextWidth + 2, tooltipY - 3 + 1, tooltipX + tooltipTextWidth + 3, tooltipY + tooltipHeight + 3 - 1, borderColorStart, borderColorEnd);
-		GuiUtils.drawGradientRect(0, tooltipX - 3, tooltipY - 3, tooltipX + tooltipTextWidth + 3, tooltipY - 3 + 1, borderColorStart, borderColorStart);
-		GuiUtils.drawGradientRect(0, tooltipX - 3, tooltipY + tooltipHeight + 2, tooltipX + tooltipTextWidth + 3, tooltipY + tooltipHeight + 3, borderColorEnd, borderColorEnd);
 
-		MinecraftForge.EVENT_BUS.post(new RenderTooltipEvent.PostBackground(stack, textLines, tooltipX, tooltipY, font, tooltipTextWidth, tooltipHeight));*/
+        // Doesn't fire RenderTooltipEvent.Color as we draw background/border according to theme
         PresetTexture.TOOLTIP_BG.getTexture().drawTexture(tooltipX - 4, tooltipY - 4, tooltipTextWidth + 8, tooltipHeight + 8, 0F, 1F);
+        MinecraftForge.EVENT_BUS.post(new RenderTooltipEvent.PostBackground(stack, textLines, tooltipX, tooltipY, font, tooltipTextWidth, tooltipHeight));
         int tooltipTop = tooltipY;
 
         GlStateManager.translate(0F, 0F, 0.1F);

--- a/src/main/java/betterquesting/api/utils/RenderUtils.java
+++ b/src/main/java/betterquesting/api/utils/RenderUtils.java
@@ -22,6 +22,7 @@ import net.minecraftforge.fml.relauncher.SideOnly;
 import org.lwjgl.opengl.GL11;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.awt.*;
 import java.util.ArrayList;
 import java.util.List;
@@ -32,19 +33,19 @@ import java.util.Locale;
 public class RenderUtils {
     public static final String REGEX_NUMBER = "[^\\.0123456789-]"; // I keep screwing this up so now it's reusable
 
-    public static void RenderItemStack(Minecraft mc, ItemStack stack, int x, int y, String text) {
+    public static void RenderItemStack(Minecraft mc, ItemStack stack, int x, int y, @Nullable String text) {
         RenderItemStack(mc, stack, x, y, text, Color.WHITE.getRGB());
     }
 
-    public static void RenderItemStack(Minecraft mc, ItemStack stack, int x, int y, String text, Color color) {
+    public static void RenderItemStack(Minecraft mc, ItemStack stack, int x, int y, @Nullable String text, Color color) {
         RenderItemStack(mc, stack, x, y, text, color.getRGB());
     }
 
-    public static void RenderItemStack(Minecraft mc, ItemStack stack, int x, int y, String text, int color) {
+    public static void RenderItemStack(Minecraft mc, ItemStack stack, int x, int y, @Nullable String text, int color) {
         RenderItemStack(mc, stack, x, y, 16F, text, color);
     }
 
-    public static void RenderItemStack(Minecraft mc, ItemStack stack, int x, int y, float z, String text, int color) {
+    public static void RenderItemStack(Minecraft mc, ItemStack stack, int x, int y, float z, @Nullable String text, int color) {
         if (stack == null || stack.isEmpty()) {
             return;
         }
@@ -70,7 +71,9 @@ public class RenderUtils {
         try {
             itemRender.renderItemAndEffectIntoGUI(stack, x, y);
 
-            if (stack.getCount() != 1 || text != null) {
+            // Custom ItemStack text
+            if (stack.getCount() != 1 || (text != null && !text.isEmpty())) {
+                String textToDraw = text == null ? String.valueOf(stack.getCount()) : text;
                 GlStateManager.pushMatrix();
 
                 int w = getStringWidth(text, font);
@@ -94,7 +97,7 @@ public class RenderUtils {
                 GlStateManager.disableDepth();
                 GlStateManager.disableBlend();
 
-                font.drawString(text, 0, 0, 16777215, true);
+                font.drawStringWithShadow(textToDraw, 0, 0, 16777215);
 
                 GlStateManager.enableLighting();
                 GlStateManager.enableDepth();
@@ -103,7 +106,7 @@ public class RenderUtils {
                 GlStateManager.popMatrix();
             }
 
-            itemRender.renderItemOverlayIntoGUI(font, stack, x, y, "");
+            itemRender.renderItemOverlayIntoGUI(font, stack, x, y, null); // Pass null to skip rendering default ItemStack text
         } catch (Exception e) {
             BetterQuesting.logger.warn("Unabled to render item " + stack, e);
         }

--- a/src/main/java/betterquesting/api2/client/gui/GuiContainerCanvas.java
+++ b/src/main/java/betterquesting/api2/client/gui/GuiContainerCanvas.java
@@ -28,7 +28,7 @@ import java.util.ListIterator;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 // This will probably be rewritten at a later date once I reimplement Minecraft's inventory controls natively into their own isolated canvas elements
-public class GuiContainerCanvas extends GuiContainer implements IScene {
+public class GuiContainerCanvas extends GuiContainer implements IScene, IRenderedStackProvider {
     private final List<IGuiPanel> guiPanels = new CopyOnWriteArrayList<>();
     private final GuiRectangle rootTransform = new GuiRectangle(0, 0, 0, 0, 0);
     private final GuiTransform transform = new GuiTransform(GuiAlign.FULL_BOX, new GuiPadding(16, 16, 16, 16), 0);
@@ -36,6 +36,7 @@ public class GuiContainerCanvas extends GuiContainer implements IScene {
     private boolean useMargins = true;
     private boolean useDefaultBG = false;
     private boolean isVolatile = false;
+    private ItemStack renderedStack = ItemStack.EMPTY;
 
     public final GuiScreen parent;
 
@@ -396,7 +397,18 @@ public class GuiContainerCanvas extends GuiContainer implements IScene {
 
     @Override
     protected void drawHoveringText(List<String> textLines, int x, int y, FontRenderer font) {
-        RenderUtils.drawHoveringText(textLines, x, y, width, height, -1, font);
+        RenderUtils.drawHoveringText(this, textLines, x, y, width, height, -1, font);
+    }
+
+    @Nonnull
+    @Override
+    public ItemStack getRenderedStack() {
+        return renderedStack;
+    }
+
+    @Override
+    public void setRenderedStack(@Nonnull ItemStack stack) {
+        renderedStack = stack;
     }
 
     public void confirmClose(int id) {

--- a/src/main/java/betterquesting/api2/client/gui/GuiScreenCanvas.java
+++ b/src/main/java/betterquesting/api2/client/gui/GuiScreenCanvas.java
@@ -27,7 +27,7 @@ import java.util.List;
 import java.util.ListIterator;
 import java.util.concurrent.CopyOnWriteArrayList;
 
-public class GuiScreenCanvas extends GuiScreen implements IScene {
+public class GuiScreenCanvas extends GuiScreen implements IScene, IRenderedStackProvider {
     private final List<IGuiPanel> guiPanels = new CopyOnWriteArrayList<>();
     private final GuiRectangle rootTransform = new GuiRectangle(0, 0, 0, 0, 0);
     private final GuiTransform transform = new GuiTransform(GuiAlign.FULL_BOX, new GuiPadding(16, 16, 16, 16), 0);
@@ -35,6 +35,7 @@ public class GuiScreenCanvas extends GuiScreen implements IScene {
     private boolean useMargins = true;
     private boolean useDefaultBG = false;
     private boolean isVolatile = false;
+    private ItemStack renderedStack = ItemStack.EMPTY;
 
     public final GuiScreen parent;
 
@@ -404,7 +405,18 @@ public class GuiScreenCanvas extends GuiScreen implements IScene {
 
     @Override
     protected void drawHoveringText(List<String> textLines, int x, int y, @Nonnull FontRenderer font) {
-        RenderUtils.drawHoveringText(textLines, x, y, width, height, -1, font);
+        RenderUtils.drawHoveringText(this, textLines, x, y, width, height, -1, font);
+    }
+
+    @Nonnull
+    @Override
+    public ItemStack getRenderedStack() {
+        return renderedStack;
+    }
+
+    @Override
+    public void setRenderedStack(@Nonnull ItemStack stack) {
+        renderedStack = stack;
     }
 
     private void confirmClose(int id) {

--- a/src/main/java/betterquesting/api2/client/gui/SceneController.java
+++ b/src/main/java/betterquesting/api2/client/gui/SceneController.java
@@ -26,9 +26,10 @@ public class SceneController {
     public static void onGuiOpened(GuiOpenEvent event) {
         if (event.getGui() instanceof IScene) {
             // TODO: Review the following
-            // Does this need to be cleared if the GUI isn't compatible?
             // Would this interfere with an overlay canvas?
             curScene = (IScene) event.getGui();
+        } else {
+            curScene = null;
         }
     }
 }

--- a/src/main/java/betterquesting/api2/client/gui/controls/PanelButtonQuest.java
+++ b/src/main/java/betterquesting/api2/client/gui/controls/PanelButtonQuest.java
@@ -33,16 +33,15 @@ import java.util.UUID;
 
 public class PanelButtonQuest extends PanelButtonStorage<DBEntry<IQuest>> {
     public final GuiRectangle rect;
-    public final EntityPlayer player;
     public final IGuiTexture txFrame;
 
     public PanelButtonQuest(GuiRectangle rect, int id, String txt, DBEntry<IQuest> value) {
         super(rect, id, txt, value);
         this.rect = rect;
 
-        player = Minecraft.getMinecraft().player;
+        EntityPlayer player = Minecraft.getMinecraft().player;
         EnumQuestState qState = value == null ? EnumQuestState.LOCKED : value.getValue().getState(player);
-        IGuiColor txIconCol = null;
+        IGuiColor txIconCol;
         boolean lock = false;
 
         if (value != null) {
@@ -67,7 +66,7 @@ public class PanelButtonQuest extends PanelButtonStorage<DBEntry<IQuest>> {
         if (!this.getTransform().contains(mx, my)) return null;
 
         DBEntry<IQuest> value = this.getStoredValue();
-        return value == null ? Collections.emptyList() : getQuestTooltip(value.getValue(), player, value.getID());
+        return value == null ? Collections.emptyList() : getQuestTooltip(value.getValue(), Minecraft.getMinecraft().player, value.getID());
     }
 
     private List<String> getQuestTooltip(IQuest quest, EntityPlayer player, int qID) {

--- a/src/main/java/betterquesting/api2/client/gui/controls/PanelButtonStorage.java
+++ b/src/main/java/betterquesting/api2/client/gui/controls/PanelButtonStorage.java
@@ -7,18 +7,24 @@ public class PanelButtonStorage<T> extends PanelButton {
     private T stored = null;
     private ICallback<T> callback = null;
 
+    /**
+     * Creates a panel button that stores a value.
+     * <p>
+     *     Note: If a subclass overrides {@link #setStoredValue(T)}, make sure to call that method during construction
+     *     time after calling this super constructor!
+     * </p>
+     */
     public PanelButtonStorage(IGuiRect rect, int id, String txt, T value) {
         super(rect, id, txt);
-        this.setStoredValue(value);
+        setStoredRaw(value);
     }
 
-    // Overload that doesn't call setStoredValue()
-    protected PanelButtonStorage(IGuiRect rect, int id, String txt) {
-        super(rect, id, txt);
+    private void setStoredRaw(T value) {
+        stored = value;
     }
 
     public PanelButtonStorage<T> setStoredValue(T value) {
-        this.stored = value;
+        setStoredRaw(value);
         return this;
     }
 

--- a/src/main/java/betterquesting/api2/client/gui/controls/PanelButtonStorage.java
+++ b/src/main/java/betterquesting/api2/client/gui/controls/PanelButtonStorage.java
@@ -12,6 +12,11 @@ public class PanelButtonStorage<T> extends PanelButton {
         this.setStoredValue(value);
     }
 
+    // Overload that doesn't call setStoredValue()
+    protected PanelButtonStorage(IGuiRect rect, int id, String txt) {
+        super(rect, id, txt);
+    }
+
     public PanelButtonStorage<T> setStoredValue(T value) {
         this.stored = value;
         return this;

--- a/src/main/java/betterquesting/api2/client/gui/misc/IRenderedStackProvider.java
+++ b/src/main/java/betterquesting/api2/client/gui/misc/IRenderedStackProvider.java
@@ -1,0 +1,16 @@
+package betterquesting.api2.client.gui.misc;
+
+import javax.annotation.Nonnull;
+
+import net.minecraft.item.ItemStack;
+
+public interface IRenderedStackProvider {
+    @Nonnull
+    ItemStack getRenderedStack();
+
+    void setRenderedStack(@Nonnull ItemStack stack);
+
+    default void resetRenderedStack() {
+        setRenderedStack(ItemStack.EMPTY);
+    }
+}

--- a/src/main/java/betterquesting/api2/client/gui/panels/content/PanelFluidSlot.java
+++ b/src/main/java/betterquesting/api2/client/gui/panels/content/PanelFluidSlot.java
@@ -22,11 +22,11 @@ public class PanelFluidSlot extends PanelButtonStorage<FluidStack> {
     }
 
     public PanelFluidSlot(IGuiRect rect, int id, FluidStack value, boolean showCount) {
-        super(rect, id, "", value);
+        super(rect, id, "");
         this.showCount = showCount;
 
         this.setTextures(PresetTexture.ITEM_FRAME.getTexture(), PresetTexture.ITEM_FRAME.getTexture(), new LayeredTexture(PresetTexture.ITEM_FRAME.getTexture(), new ColorTexture(PresetColor.ITEM_HIGHLIGHT.getColor(), new GuiPadding(1, 1, 1, 1))));
-        this.setStoredValue(value); // Need to run this again because of the instatiation order of showCount
+        this.setStoredValue(value); // Make sure to run this because the super overload doesn't (as this depends on instantiation order of showCount)
 
     }
 

--- a/src/main/java/betterquesting/api2/client/gui/panels/content/PanelFluidSlot.java
+++ b/src/main/java/betterquesting/api2/client/gui/panels/content/PanelFluidSlot.java
@@ -22,11 +22,11 @@ public class PanelFluidSlot extends PanelButtonStorage<FluidStack> {
     }
 
     public PanelFluidSlot(IGuiRect rect, int id, FluidStack value, boolean showCount) {
-        super(rect, id, "");
+        super(rect, id, "", null); // Value will be set by setStoredValue()
         this.showCount = showCount;
 
         this.setTextures(PresetTexture.ITEM_FRAME.getTexture(), PresetTexture.ITEM_FRAME.getTexture(), new LayeredTexture(PresetTexture.ITEM_FRAME.getTexture(), new ColorTexture(PresetColor.ITEM_HIGHLIGHT.getColor(), new GuiPadding(1, 1, 1, 1))));
-        this.setStoredValue(value); // Make sure to run this because the super overload doesn't (as this depends on instantiation order of showCount)
+        this.setStoredValue(value);
 
     }
 

--- a/src/main/java/betterquesting/api2/client/gui/panels/content/PanelItemSlot.java
+++ b/src/main/java/betterquesting/api2/client/gui/panels/content/PanelItemSlot.java
@@ -43,12 +43,12 @@ public class PanelItemSlot extends PanelButtonStorage<BigItemStack> {
     }
 
     public PanelItemSlot(IGuiRect rect, int id, BigItemStack value, boolean showCount, boolean oreDict) {
-        super(rect, id, "");
+        super(rect, id, "", null); // Value will be set by setStoredValue()
         this.showCount = showCount;
         this.oreDict = oreDict;
 
         this.setTextures(PresetTexture.ITEM_FRAME.getTexture(), PresetTexture.ITEM_FRAME.getTexture(), new LayeredTexture(PresetTexture.ITEM_FRAME.getTexture(), new ColorTexture(PresetColor.ITEM_HIGHLIGHT.getColor(), new GuiPadding(1, 1, 1, 1))));
-        this.setStoredValue(value); // Make sure to run this because the super overload doesn't (as this depends on instantiation order of showCount)
+        this.setStoredValue(value);
     }
 
     @Override

--- a/src/main/java/betterquesting/api2/client/gui/panels/content/PanelItemSlot.java
+++ b/src/main/java/betterquesting/api2/client/gui/panels/content/PanelItemSlot.java
@@ -76,10 +76,10 @@ public class PanelItemSlot extends PanelButtonStorage<BigItemStack> {
             }
 
             Minecraft mc = Minecraft.getMinecraft();
-            if (mc.currentScreen instanceof IRenderedStackProvider) {
+            if (mc.currentScreen instanceof IRenderedStackProvider renderedStackProvider) {
                 ItemStack representativeStack = ttStack.getBaseStack().copy();
                 representativeStack.setCount(ttStack.stackSize);
-                ((IRenderedStackProvider) mc.currentScreen).setRenderedStack(representativeStack);
+                renderedStackProvider.setRenderedStack(representativeStack);
             }
             return ttStack.getBaseStack().getTooltip(mc.player, mc.gameSettings.advancedItemTooltips ? TooltipFlags.ADVANCED : TooltipFlags.NORMAL);
         }

--- a/src/main/java/betterquesting/api2/client/gui/panels/content/PanelItemSlot.java
+++ b/src/main/java/betterquesting/api2/client/gui/panels/content/PanelItemSlot.java
@@ -42,12 +42,12 @@ public class PanelItemSlot extends PanelButtonStorage<BigItemStack> {
     }
 
     public PanelItemSlot(IGuiRect rect, int id, BigItemStack value, boolean showCount, boolean oreDict) {
-        super(rect, id, "", value);
+        super(rect, id, "");
         this.showCount = showCount;
         this.oreDict = oreDict;
 
         this.setTextures(PresetTexture.ITEM_FRAME.getTexture(), PresetTexture.ITEM_FRAME.getTexture(), new LayeredTexture(PresetTexture.ITEM_FRAME.getTexture(), new ColorTexture(PresetColor.ITEM_HIGHLIGHT.getColor(), new GuiPadding(1, 1, 1, 1))));
-        this.setStoredValue(value); // Need to run this again because of the instatiation order of showCount
+        this.setStoredValue(value); // Make sure to run this because the super overload doesn't (as this depends on instantiation order of showCount)
     }
 
     @Override

--- a/src/main/java/betterquesting/api2/client/gui/panels/content/PanelItemSlot.java
+++ b/src/main/java/betterquesting/api2/client/gui/panels/content/PanelItemSlot.java
@@ -4,6 +4,7 @@ import betterquesting.api.utils.BigItemStack;
 import betterquesting.api2.client.gui.controls.PanelButtonStorage;
 import betterquesting.api2.client.gui.misc.GuiPadding;
 import betterquesting.api2.client.gui.misc.IGuiRect;
+import betterquesting.api2.client.gui.misc.IRenderedStackProvider;
 import betterquesting.api2.client.gui.resources.textures.ColorTexture;
 import betterquesting.api2.client.gui.resources.textures.ItemTexture;
 import betterquesting.api2.client.gui.resources.textures.LayeredTexture;
@@ -75,6 +76,11 @@ public class PanelItemSlot extends PanelButtonStorage<BigItemStack> {
             }
 
             Minecraft mc = Minecraft.getMinecraft();
+            if (mc.currentScreen instanceof IRenderedStackProvider) {
+                ItemStack representativeStack = ttStack.getBaseStack().copy();
+                representativeStack.setCount(ttStack.stackSize);
+                ((IRenderedStackProvider) mc.currentScreen).setRenderedStack(representativeStack);
+            }
             return ttStack.getBaseStack().getTooltip(mc.player, mc.gameSettings.advancedItemTooltips ? TooltipFlags.ADVANCED : TooltipFlags.NORMAL);
         }
 

--- a/src/main/java/betterquesting/api2/client/gui/panels/content/PanelItemSlot.java
+++ b/src/main/java/betterquesting/api2/client/gui/panels/content/PanelItemSlot.java
@@ -55,12 +55,9 @@ public class PanelItemSlot extends PanelButtonStorage<BigItemStack> {
         super.setStoredValue(value);
 
         if (value != null) {
-            Minecraft mc = Minecraft.getMinecraft();
             this.setIcon(oreDict || value.getBaseStack().getItemDamage() == OreDictionary.WILDCARD_VALUE ? new OreDictTexture(1F, value, showCount, true) : new ItemTexture(value, showCount, true), 1);
-            this.setTooltip(value.getBaseStack().getTooltip(mc.player, mc.gameSettings.advancedItemTooltips ? TooltipFlags.ADVANCED : TooltipFlags.NORMAL));
         } else {
             this.setIcon(null);
-            this.setTooltip(null);
         }
 
         updateOreStacks();

--- a/src/main/java/betterquesting/api2/client/gui/panels/lists/CanvasEntityDatabase.java
+++ b/src/main/java/betterquesting/api2/client/gui/panels/lists/CanvasEntityDatabase.java
@@ -43,7 +43,7 @@ public class CanvasEntityDatabase extends CanvasSearch<EntityEntry, EntityEntry>
             return false;
         }
 
-        this.addPanel(new PanelButtonStorage<>(new GuiRectangle(0, index * 16, cachedWidth, 16, 0), btnId, ee.getName(), ee));
+        this.addPanelToBuffer(new PanelButtonStorage<>(new GuiRectangle(0, index * 16, cachedWidth, 16, 0), btnId, ee.getName(), ee));
 
         return true;
     }

--- a/src/main/java/betterquesting/api2/client/gui/panels/lists/CanvasFluidDatabase.java
+++ b/src/main/java/betterquesting/api2/client/gui/panels/lists/CanvasFluidDatabase.java
@@ -51,7 +51,7 @@ public class CanvasFluidDatabase extends CanvasSearch<FluidStack, Fluid> {
         int x = (index % (cachedWidth / 18)) * 18;
         int y = (index / (cachedWidth / 18)) * 18;
 
-        this.addPanel(new PanelFluidSlot(new GuiRectangle(x, y, 18, 18, 0), btnId, stack));
+        this.addPanelToBuffer(new PanelFluidSlot(new GuiRectangle(x, y, 18, 18, 0), btnId, stack));
 
         return true;
     }

--- a/src/main/java/betterquesting/api2/client/gui/panels/lists/CanvasItemDatabase.java
+++ b/src/main/java/betterquesting/api2/client/gui/panels/lists/CanvasItemDatabase.java
@@ -84,7 +84,7 @@ public class CanvasItemDatabase extends CanvasSearch<ItemStack, Item> {
         int x = (index % (cachedWidth / 18)) * 18;
         int y = (index / (cachedWidth / 18)) * 18;
 
-        this.addPanel(new PanelItemSlot(new GuiRectangle(x, y, 18, 18, 0), btnId, new BigItemStack(stack)).setCallback(c -> {}));
+        this.addPanelToBuffer(new PanelItemSlot(new GuiRectangle(x, y, 18, 18, 0), btnId, new BigItemStack(stack)).setCallback(c -> {}));
 
         return true;
     }

--- a/src/main/java/betterquesting/api2/client/gui/panels/lists/CanvasScrolling.java
+++ b/src/main/java/betterquesting/api2/client/gui/panels/lists/CanvasScrolling.java
@@ -492,17 +492,20 @@ public class CanvasScrolling implements IGuiCanvas {
         float zs = zoomScale.readValue();
 
         for (IGuiPanel panel : guiPanels) {
+            IGuiRect transform = panel.getTransform();
+            int transformX = transform.getX();
+            int transformY = transform.getY();
             if (first) {
-                left = panel.getTransform().getX();
-                top = panel.getTransform().getY();
-                right = panel.getTransform().getX() + panel.getTransform().getWidth();
-                bottom = panel.getTransform().getY() + panel.getTransform().getHeight();
+                left = transformX;
+                top = transformY;
+                right = transformX + transform.getWidth();
+                bottom = transformY + transform.getHeight();
                 first = false;
             } else {
-                left = Math.min(left, panel.getTransform().getX());
-                top = Math.min(top, panel.getTransform().getY());
-                right = Math.max(right, panel.getTransform().getX() + panel.getTransform().getWidth());
-                bottom = Math.max(bottom, panel.getTransform().getY() + panel.getTransform().getHeight());
+                left = Math.min(left, transformX);
+                top = Math.min(top, transformY);
+                right = Math.max(right, transformX + transform.getWidth());
+                bottom = Math.max(bottom, transformY + transform.getHeight());
             }
         }
 
@@ -511,8 +514,8 @@ public class CanvasScrolling implements IGuiCanvas {
         top -= margin;
         bottom += margin;
 
-        right -= (int) Math.ceil(this.getTransform().getWidth() / zs);
-        bottom -= (int) Math.ceil(this.getTransform().getHeight() / zs);
+        right -= (int) Math.ceil(transform.getWidth() / zs);
+        bottom -= (int) Math.ceil(transform.getHeight() / zs);
 
         if (extendedScroll) {
             scrollBounds.x = Math.min(left, right);

--- a/src/main/java/betterquesting/api2/client/gui/panels/lists/CanvasScrollingBuffered.java
+++ b/src/main/java/betterquesting/api2/client/gui/panels/lists/CanvasScrollingBuffered.java
@@ -51,6 +51,7 @@ public class CanvasScrollingBuffered extends CanvasScrolling {
 
         guiPanels.add(panel);
         if (hasMultipleDepths || panel.getTransform().getDepth() != guiPanels.get(0).getTransform().getDepth()) {
+            hasMultipleDepths = true;
             guiPanels.sort(ComparatorGuiDepth.INSTANCE);
         }
 

--- a/src/main/java/betterquesting/api2/client/gui/panels/lists/CanvasScrollingBuffered.java
+++ b/src/main/java/betterquesting/api2/client/gui/panels/lists/CanvasScrollingBuffered.java
@@ -10,7 +10,8 @@ import betterquesting.api2.client.gui.panels.IGuiPanel;
 public class CanvasScrollingBuffered extends CanvasScrolling {
 
     private final List<IGuiPanel> buffer = new ArrayList<>();
-    private boolean requiresSorting;
+    /* If panels should be sorted by depth. Once set, should not be unset. */
+    private boolean hasMultipleDepths;
 
     public CanvasScrollingBuffered(IGuiRect rect) {
         super(rect);
@@ -26,16 +27,17 @@ public class CanvasScrollingBuffered extends CanvasScrolling {
             return;
 
         guiPanels.addAll(buffer);
+        int depth = guiPanels.get(0).getTransform().getDepth();
         for (IGuiPanel panel : buffer) {
-            if (requiresSorting || panel.getTransform().getDepth() != guiPanels.get(0).getTransform().getDepth()) {
-                requiresSorting = true;
+            if (hasMultipleDepths || panel.getTransform().getDepth() != depth) {
+                hasMultipleDepths = true;
             }
             cullingManager.addPanel(panel, true);
             panel.initPanel();
         }
         buffer.clear();
 
-        if (requiresSorting) {
+        if (hasMultipleDepths) {
             guiPanels.sort(ComparatorGuiDepth.INSTANCE);
         }
 
@@ -48,8 +50,7 @@ public class CanvasScrollingBuffered extends CanvasScrolling {
         if (panel == null || guiPanels.contains(panel)) return;
 
         guiPanels.add(panel);
-        if (requiresSorting || panel.getTransform().getDepth() != guiPanels.get(0).getTransform().getDepth()) {
-            requiresSorting = true;
+        if (hasMultipleDepths || panel.getTransform().getDepth() != guiPanels.get(0).getTransform().getDepth()) {
             guiPanels.sort(ComparatorGuiDepth.INSTANCE);
         }
 
@@ -64,6 +65,6 @@ public class CanvasScrollingBuffered extends CanvasScrolling {
     public void resetCanvas()
     {
         super.resetCanvas();
-        requiresSorting = false;
+        hasMultipleDepths = false;
     }
 }

--- a/src/main/java/betterquesting/api2/client/gui/panels/lists/CanvasScrollingBuffered.java
+++ b/src/main/java/betterquesting/api2/client/gui/panels/lists/CanvasScrollingBuffered.java
@@ -1,6 +1,7 @@
 package betterquesting.api2.client.gui.panels.lists;
 
 import java.util.ArrayList;
+import java.util.List;
 
 import betterquesting.api2.client.gui.misc.ComparatorGuiDepth;
 import betterquesting.api2.client.gui.misc.IGuiRect;
@@ -8,13 +9,14 @@ import betterquesting.api2.client.gui.panels.IGuiPanel;
 
 public class CanvasScrollingBuffered extends CanvasScrolling {
 
-    private final ArrayList<IGuiPanel> buffer = new ArrayList<>();
+    private final List<IGuiPanel> buffer = new ArrayList<>();
+    private boolean requiresSorting;
 
     public CanvasScrollingBuffered(IGuiRect rect) {
         super(rect);
     }
 
-    public void addPanelToBuffer(IGuiPanel panel) {
+    protected void addPanelToBuffer(IGuiPanel panel) {
         if (panel != null)
             buffer.add(panel);
     }
@@ -22,19 +24,46 @@ public class CanvasScrollingBuffered extends CanvasScrolling {
     public void flushBuffer() {
         if (buffer.isEmpty())
             return;
-        for (IGuiPanel panel : buffer) {
-            if (guiPanels.contains(panel))
-                continue;
 
-            guiPanels.add(panel);
+        guiPanels.addAll(buffer);
+        for (IGuiPanel panel : buffer) {
+            if (requiresSorting || panel.getTransform().getDepth() != guiPanels.get(0).getTransform().getDepth()) {
+                requiresSorting = true;
+            }
             cullingManager.addPanel(panel, true);
             panel.initPanel();
         }
         buffer.clear();
 
-        guiPanels.sort(ComparatorGuiDepth.INSTANCE);
+        if (requiresSorting) {
+            guiPanels.sort(ComparatorGuiDepth.INSTANCE);
+        }
 
         this.refreshScrollBounds();
     }
 
+    @Override
+    public void addCulledPanel(IGuiPanel panel, boolean useCulling)
+    {
+        if (panel == null || guiPanels.contains(panel)) return;
+
+        guiPanels.add(panel);
+        if (requiresSorting || panel.getTransform().getDepth() != guiPanels.get(0).getTransform().getDepth()) {
+            requiresSorting = true;
+            guiPanels.sort(ComparatorGuiDepth.INSTANCE);
+        }
+
+        cullingManager.addPanel(panel, useCulling);
+
+        panel.initPanel();
+
+        this.refreshScrollBounds();
+    }
+
+    @Override
+    public void resetCanvas()
+    {
+        super.resetCanvas();
+        requiresSorting = false;
+    }
 }

--- a/src/main/java/betterquesting/api2/client/gui/panels/lists/CanvasSearch.java
+++ b/src/main/java/betterquesting/api2/client/gui/panels/lists/CanvasSearch.java
@@ -1,6 +1,7 @@
 package betterquesting.api2.client.gui.panels.lists;
 
 import betterquesting.api2.client.gui.misc.IGuiRect;
+import betterquesting.core.BetterQuesting;
 import com.google.common.base.Stopwatch;
 
 import java.util.*;
@@ -76,9 +77,9 @@ public abstract class CanvasSearch<T, E> extends CanvasScrollingBuffered {
 
         searchTime.stop();
 
-        if (!searching.hasNext())
+        if (!searching.hasNext()) {
             searching = null;
-
+        }
     }
 
     private void updateResults() {
@@ -88,16 +89,21 @@ public abstract class CanvasSearch<T, E> extends CanvasScrollingBuffered {
 
         searchTime.reset().start();
 
-        int count = 0;
-        while (!pendingResults.isEmpty() && searchTime.elapsed(TimeUnit.MILLISECONDS) < 10 && count < 200) {
+        while (!pendingResults.isEmpty() && searchTime.elapsed(TimeUnit.MILLISECONDS) < 10) {
             if (addResult(pendingResults.poll(), searchIdx, resultWidth)) {
                 searchIdx++;
-                count++;
             }
         }
 
         searchTime.stop();
+
+        // Fixed scroll position
+        int currentScrollY = this.getScrollY();
         flushBuffer();
+        if (this.getScrollY() > currentScrollY) {
+            this.setScrollY(currentScrollY);
+            updatePanelScroll();
+        }
     }
 
     public List<T> getResults() {

--- a/src/main/java/betterquesting/api2/client/gui/panels/lists/CanvasSearch.java
+++ b/src/main/java/betterquesting/api2/client/gui/panels/lists/CanvasSearch.java
@@ -1,7 +1,6 @@
 package betterquesting.api2.client.gui.panels.lists;
 
 import betterquesting.api2.client.gui.misc.IGuiRect;
-import betterquesting.core.BetterQuesting;
 import com.google.common.base.Stopwatch;
 
 import java.util.*;

--- a/src/main/java/betterquesting/client/BookmarkManager.java
+++ b/src/main/java/betterquesting/client/BookmarkManager.java
@@ -1,0 +1,36 @@
+package betterquesting.client;
+
+import betterquesting.api2.client.gui.GuiScreenCanvas;
+import betterquesting.client.gui2.GuiQuest;
+import net.minecraft.client.gui.GuiScreen;
+
+public class BookmarkManager {
+    public static BookmarkManager INSTANCE = new BookmarkManager();
+
+    private GuiScreen parent;
+    private Integer questId;
+
+    private BookmarkManager() {}
+
+    public void setBookmark(GuiScreenCanvas parent) {
+        this.parent = parent;
+        this.questId = null;
+    }
+
+    public void setBookmark(GuiScreenCanvas parent, int questId) {
+        this.parent = parent;
+        this.questId = questId;
+    }
+
+    public GuiScreen getBookmark() {
+        if (questId == null) {
+            return parent;
+        }
+        return new GuiQuest(parent, questId);
+    }
+
+    public void reset() {
+        parent = null;
+        questId = null;
+    }
+}

--- a/src/main/java/betterquesting/client/gui2/GuiHome.java
+++ b/src/main/java/betterquesting/client/gui2/GuiHome.java
@@ -52,8 +52,6 @@ import java.util.function.Consumer;
 
 @SideOnly(Side.CLIENT)
 public class GuiHome extends GuiScreenCanvas {
-    public static GuiScreen bookmark;
-
     public GuiHome(GuiScreen parent) {
         super(parent);
     }

--- a/src/main/java/betterquesting/client/gui2/GuiQuestLines.java
+++ b/src/main/java/betterquesting/client/gui2/GuiQuestLines.java
@@ -67,7 +67,9 @@ import java.util.*;
 
 public class GuiQuestLines extends GuiScreenCanvas implements IPEventListener, INeedsRefresh {
 
-    private ScrollPosition scrollPosition;
+    private static OpenTray openTray = OpenTray.NONE;
+
+    private final ScrollPosition scrollPosition;
 
     private IQuestLine selectedLine = null;
     private static int selectedLineId = -1;
@@ -76,7 +78,6 @@ public class GuiQuestLines extends GuiScreenCanvas implements IPEventListener, I
 
     private CanvasQuestLine cvQuest;
 
-    // Keep these separate for now
     private CanvasHoverTray cvChapterTray;
     private CanvasHoverTray cvDescTray;
     private CanvasHoverTray cvFrame;
@@ -95,10 +96,8 @@ public class GuiQuestLines extends GuiScreenCanvas implements IPEventListener, I
 
     private PanelButton btnDesign;
 
-    private static boolean trayLock;
-    private static boolean viewMode;
-    private int questsCompleted = 0;
-    private int totalQuests = 0;
+    private boolean trayLock;
+    private boolean viewMode;
 
     private final List<PanelButtonStorage<DBEntry<IQuestLine>>> btnListRef = new ArrayList<>();
 
@@ -106,10 +105,7 @@ public class GuiQuestLines extends GuiScreenCanvas implements IPEventListener, I
         super(parent);
         trayLock = BQ_Settings.lockTray;
         viewMode = BQ_Settings.viewMode;
-
-        if (scrollPosition == null) {
-            scrollPosition = new ScrollPosition(0);
-        }
+        scrollPosition = new ScrollPosition(0);
     }
 
     @Override
@@ -138,7 +134,7 @@ public class GuiQuestLines extends GuiScreenCanvas implements IPEventListener, I
         }
 
         boolean canEdit = QuestingAPI.getAPI(ApiReference.SETTINGS).canUserEdit(mc.player);
-        boolean preOpen = trayLock;
+        boolean preOpen = trayLock && openTray != OpenTray.NONE;
 
         PEventBroadcaster.INSTANCE.register(this, PEventButton.class);
 
@@ -188,11 +184,8 @@ public class GuiQuestLines extends GuiScreenCanvas implements IPEventListener, I
 
         // === TRAY STATE ===
 
-        boolean chapterTrayOpened = false;
-        boolean descTrayOpened = trayLock && cvDescTray != null && cvDescTray.isTrayOpen();
-        if (preOpen && !descTrayOpened) {
-            chapterTrayOpened = true;
-        }
+        boolean chapterTrayOpened = preOpen && openTray == OpenTray.CHAPTER;
+        boolean descTrayOpened = preOpen && openTray == OpenTray.DESCRIPTION;
 
         // === CHAPTER TRAY ===
 
@@ -244,8 +237,10 @@ public class GuiQuestLines extends GuiScreenCanvas implements IPEventListener, I
         PanelButton btnTrayToggle = new PanelButton(new GuiTransform(GuiAlign.TOP_LEFT, 8, 24, 32, 16, 0), -1, "");
         btnTrayToggle.setIcon(PresetIcon.ICON_BOOKMARK.getTexture(), selectedLineId < 0 && !chapterTrayOpened ? new GuiColorPulse(0xFFFFFFFF, 0xFF444444, 2F, 0F) : new GuiColorStatic(0xFFFFFFFF), 0);
         btnTrayToggle.setClickAction((b) -> {
-            cvFrame.setTrayState(cvChapterTray.isTrayOpen(), 200);
-            cvChapterTray.setTrayState(!cvChapterTray.isTrayOpen(), 200);
+            boolean wasOpen = cvChapterTray.isTrayOpen();
+            openTray = wasOpen ? OpenTray.NONE : OpenTray.CHAPTER;
+            cvFrame.setTrayState(wasOpen, 200);
+            cvChapterTray.setTrayState(!wasOpen, 200);
             btnTrayToggle.setIcon(PresetIcon.ICON_BOOKMARK.getTexture());
         });
         btnTrayToggle.setTooltip(Collections.singletonList(QuestTranslation.translate("betterquesting.title.quest_lines")));
@@ -253,8 +248,10 @@ public class GuiQuestLines extends GuiScreenCanvas implements IPEventListener, I
 
         PanelButton btnDescToggle = new PanelButton(new GuiTransform(GuiAlign.TOP_LEFT, 8, 40, 32, 16, 0), -1, "").setIcon(PresetIcon.ICON_DESC.getTexture());
         btnDescToggle.setClickAction((b) -> {
-            cvFrame.setTrayState(cvDescTray.isTrayOpen(), 200);
-            cvDescTray.setTrayState(!cvDescTray.isTrayOpen(), 200);
+            boolean wasOpen = cvDescTray.isTrayOpen();
+            openTray = wasOpen ? OpenTray.NONE : OpenTray.DESCRIPTION;
+            cvFrame.setTrayState(wasOpen, 200);
+            cvDescTray.setTrayState(!wasOpen, 200);
         });
         btnDescToggle.setTooltip(Collections.singletonList(QuestTranslation.translate("betterquesting.gui.description")));
         cvBackground.addPanel(btnDescToggle);
@@ -581,18 +578,18 @@ public class GuiQuestLines extends GuiScreenCanvas implements IPEventListener, I
     }
 
     private void refreshQuestCompletion() {
-        EntityPlayer player = mc.player;
-        UUID playerUUId = QuestingAPI.getQuestingUUID(player);
+        UUID playerUUID = QuestingAPI.getQuestingUUID(mc.player);
 
         if (selectedLine == null) {
             return;
         }
 
-        questsCompleted = 0;
-        totalQuests = 0;
+        int questsCompleted = 0;
+        int totalQuests = 0;
+        var database = Objects.requireNonNull(QuestingAPI.getAPI(ApiReference.QUEST_DB));
 
         for (DBEntry<IQuestLineEntry> entry : selectedLine.getEntries()) {
-            IQuest quest = QuestingAPI.getAPI(ApiReference.QUEST_DB).getValue(entry.getID());
+            IQuest quest = database.getValue(entry.getID());
 
             if (quest.getProperty(NativeProps.LOGIC_QUEST) == EnumLogic.XOR) {
                 // Subtract the number of requirements - 1 to simulate only doing 1 task for XOR requirements
@@ -601,7 +598,7 @@ public class GuiQuestLines extends GuiScreenCanvas implements IPEventListener, I
 
             totalQuests++;
 
-            if (quest.isComplete(playerUUId)) {
+            if (quest.isComplete(playerUUID)) {
                 questsCompleted++;
             }
         }
@@ -704,6 +701,10 @@ public class GuiQuestLines extends GuiScreenCanvas implements IPEventListener, I
         panelButtonQuest.setTextures(newTexture, newTexture, newTexture);
         cvQuest.setZoom(2f);
         cvQuest.centerOn(panelButtonQuest);
+    }
+
+    enum OpenTray {
+        NONE, CHAPTER, DESCRIPTION
     }
 
     public static class ScrollPosition{

--- a/src/main/java/betterquesting/client/gui2/GuiQuestLines.java
+++ b/src/main/java/betterquesting/client/gui2/GuiQuestLines.java
@@ -44,6 +44,7 @@ import betterquesting.api2.client.gui.themes.presets.PresetIcon;
 import betterquesting.api2.client.gui.themes.presets.PresetTexture;
 import betterquesting.api2.storage.DBEntry;
 import betterquesting.api2.utils.QuestTranslation;
+import betterquesting.client.BookmarkManager;
 import betterquesting.client.gui2.editors.GuiQuestEditor;
 import betterquesting.client.gui2.editors.GuiQuestLinesEditor;
 import betterquesting.client.gui2.editors.designer.GuiDesigner;
@@ -76,9 +77,9 @@ public class GuiQuestLines extends GuiScreenCanvas implements IPEventListener, I
     private CanvasQuestLine cvQuest;
 
     // Keep these separate for now
-    private static CanvasHoverTray cvChapterTray;
-    private static CanvasHoverTray cvDescTray;
-    private static CanvasHoverTray cvFrame;
+    private CanvasHoverTray cvChapterTray;
+    private CanvasHoverTray cvDescTray;
+    private CanvasHoverTray cvFrame;
 
     private CanvasScrolling cvDesc;
     private PanelVScrollBar scDesc;
@@ -121,7 +122,7 @@ public class GuiQuestLines extends GuiScreenCanvas implements IPEventListener, I
     public void initPanel() {
         super.initPanel();
 
-        GuiHome.bookmark = this;
+        BookmarkManager.INSTANCE.setBookmark(this);
         // If we move to quest gui - we set skip home to true
         if (!BQ_Settings.skipHome) {
             ConfigHandler.config.get(Configuration.CATEGORY_GENERAL, "Skip Home", false).set(true);
@@ -137,11 +138,7 @@ public class GuiQuestLines extends GuiScreenCanvas implements IPEventListener, I
         }
 
         boolean canEdit = QuestingAPI.getAPI(ApiReference.SETTINGS).canUserEdit(mc.player);
-        boolean preOpen = false;
-        // First time load, if tray locked - let the tray open
-        if (trayLock && cvChapterTray == null && cvDescTray == null) preOpen = true;
-        else if (trayLock && cvChapterTray != null && cvChapterTray.isTrayOpen()) preOpen = true;
-        else if (trayLock && cvDescTray != null && cvDescTray.isTrayOpen()) preOpen = true;
+        boolean preOpen = trayLock;
 
         PEventBroadcaster.INSTANCE.register(this, PEventButton.class);
 
@@ -191,9 +188,9 @@ public class GuiQuestLines extends GuiScreenCanvas implements IPEventListener, I
 
         // === TRAY STATE ===
 
-        boolean chapterTrayOpened = trayLock && cvChapterTray != null && cvChapterTray.isTrayOpen();
+        boolean chapterTrayOpened = false;
         boolean descTrayOpened = trayLock && cvDescTray != null && cvDescTray.isTrayOpen();
-        if (preOpen && !chapterTrayOpened && !descTrayOpened) {
+        if (preOpen && !descTrayOpened) {
             chapterTrayOpened = true;
         }
 
@@ -461,9 +458,9 @@ public class GuiQuestLines extends GuiScreenCanvas implements IPEventListener, I
         {
             @SuppressWarnings("unchecked")
             DBEntry<IQuest> quest = ((PanelButtonStorage<DBEntry<IQuest>>) btn).getStoredValue();
-            GuiHome.bookmark = new GuiQuest(this, quest.getID());
+            BookmarkManager.INSTANCE.setBookmark(this, quest.getID());
 
-            mc.displayGuiScreen(GuiHome.bookmark);
+            mc.displayGuiScreen(BookmarkManager.INSTANCE.getBookmark());
         }
     }
 

--- a/src/main/java/betterquesting/client/gui2/GuiQuestSearch.java
+++ b/src/main/java/betterquesting/client/gui2/GuiQuestSearch.java
@@ -15,6 +15,7 @@ import betterquesting.api2.client.gui.panels.lists.CanvasQuestSearch;
 import betterquesting.api2.client.gui.themes.presets.PresetColor;
 import betterquesting.api2.client.gui.themes.presets.PresetTexture;
 import betterquesting.api2.utils.QuestTranslation;
+import betterquesting.client.BookmarkManager;
 import betterquesting.misc.QuestSearchEntry;
 import net.minecraft.client.gui.GuiScreen;
 
@@ -84,8 +85,8 @@ public class GuiQuestSearch extends GuiScreenCanvas {
         CanvasQuestSearch canvasQuestSearch = new CanvasQuestSearch(new GuiTransform(GuiAlign.FULL_BOX, new GuiPadding(0, 32, 8, 24), 0), mc.player);
         canvasQuestSearch.setQuestOpenCallback(questSearchEntry -> {
             acceptCallback(questSearchEntry);
-            GuiHome.bookmark = new GuiQuest(this, questSearchEntry.getQuest().getID());
-            mc.displayGuiScreen(GuiHome.bookmark);
+            BookmarkManager.INSTANCE.setBookmark(this, questSearchEntry.getQuest().getID());
+            mc.displayGuiScreen(BookmarkManager.INSTANCE.getBookmark());
         });
         canvasQuestSearch.setQuestHighlightCallback(questSearchEntry -> {
             mc.displayGuiScreen(parent);

--- a/src/main/java/betterquesting/client/gui2/editors/GuiPrerequisiteEditor.java
+++ b/src/main/java/betterquesting/client/gui2/editors/GuiPrerequisiteEditor.java
@@ -107,14 +107,14 @@ public class GuiPrerequisiteEditor extends GuiScreenCanvas implements IPEventLis
                 PanelButtonStorage<DBEntry<IQuest>> btnAdd = new PanelButtonStorage<>(new GuiRectangle(0, index * 16, 16, 16, 0), 2, "", entry);
                 btnAdd.setIcon(PresetIcon.ICON_POSITIVE.getTexture());
                 btnAdd.setActive(!containsReq(quest, entry.getID()));
-                this.addPanel(btnAdd);
+                this.addPanelToBuffer(btnAdd);
 
                 PanelButtonStorage<DBEntry<IQuest>> btnEdit = new PanelButtonStorage<>(new GuiRectangle(16, index * 16, width - 32, 16, 0), 1, QuestTranslation.translate(entry.getValue().getProperty(NativeProps.NAME)), entry);
-                this.addPanel(btnEdit);
+                this.addPanelToBuffer(btnEdit);
 
                 PanelButtonStorage<DBEntry<IQuest>> btnDel = new PanelButtonStorage<>(new GuiRectangle(width - 16, index * 16, 16, 16, 0), 4, "", entry);
                 btnDel.setIcon(PresetIcon.ICON_TRASH.getTexture());
-                this.addPanel(btnDel);
+                this.addPanelToBuffer(btnDel);
 
                 return true;
             }

--- a/src/main/java/betterquesting/client/gui2/editors/GuiRewardEditor.java
+++ b/src/main/java/betterquesting/client/gui2/editors/GuiRewardEditor.java
@@ -103,7 +103,7 @@ public class GuiRewardEditor extends GuiScreenCanvas implements IPEventListener,
 
             @Override
             protected boolean addResult(IFactoryData<IReward, NBTTagCompound> entry, int index, int cachedWidth) {
-                this.addPanel(new PanelButtonStorage<>(new GuiRectangle(0, index * 16, cachedWidth, 16, 0), 1, entry.getRegistryName().toString(), entry));
+                this.addPanelToBuffer(new PanelButtonStorage<>(new GuiRectangle(0, index * 16, cachedWidth, 16, 0), 1, entry.getRegistryName().toString(), entry));
                 return true;
             }
         };

--- a/src/main/java/betterquesting/client/gui2/editors/GuiTaskEditor.java
+++ b/src/main/java/betterquesting/client/gui2/editors/GuiTaskEditor.java
@@ -103,7 +103,7 @@ public class GuiTaskEditor extends GuiScreenCanvas implements IPEventListener, I
 
             @Override
             protected boolean addResult(IFactoryData<ITask, NBTTagCompound> entry, int index, int cachedWidth) {
-                this.addPanel(new PanelButtonStorage<>(new GuiRectangle(0, index * 16, cachedWidth, 16, 0), 1, entry.getRegistryName().toString(), entry));
+                this.addPanelToBuffer(new PanelButtonStorage<>(new GuiRectangle(0, index * 16, cachedWidth, 16, 0), 1, entry.getRegistryName().toString(), entry));
                 return true;
             }
         };

--- a/src/main/java/betterquesting/handlers/EventHandler.java
+++ b/src/main/java/betterquesting/handlers/EventHandler.java
@@ -23,7 +23,7 @@ import betterquesting.api2.storage.DBEntry;
 import betterquesting.api2.utils.ParticipantInfo;
 import betterquesting.api2.utils.QuestTranslation;
 import betterquesting.client.BQ_Keybindings;
-import betterquesting.client.gui2.GuiHome;
+import betterquesting.client.BookmarkManager;
 import betterquesting.client.gui2.GuiQuest;
 import betterquesting.client.gui2.GuiQuestLines;
 import betterquesting.client.themes.ThemeRegistry;
@@ -105,8 +105,9 @@ public class EventHandler {
         Minecraft mc = Minecraft.getMinecraft();
 
         if (mc.currentScreen == null && BQ_Keybindings.openQuests.isPressed()) {
-            if (BQ_Settings.useBookmark && GuiHome.bookmark != null) {
-                mc.displayGuiScreen(GuiHome.bookmark);
+            GuiScreen bookmark = BookmarkManager.INSTANCE.getBookmark();
+            if (BQ_Settings.useBookmark && bookmark != null) {
+                mc.displayGuiScreen(bookmark);
             } else {
                 GuiScreen guiToDisplay = ThemeRegistry.INSTANCE.getGui(PresetGUIs.HOME, GArgsNone.NONE);
                 if (BQ_Settings.useBookmark && BQ_Settings.skipHome)

--- a/src/main/java/betterquesting/handlers/GuiHandler.java
+++ b/src/main/java/betterquesting/handlers/GuiHandler.java
@@ -2,11 +2,13 @@ package betterquesting.handlers;
 
 import betterquesting.api.storage.BQ_Settings;
 import betterquesting.blocks.TileSubmitStation;
+import betterquesting.client.BookmarkManager;
 import betterquesting.client.gui2.GuiHome;
 import betterquesting.client.gui2.GuiQuestHelp;
 import betterquesting.client.gui2.editors.GuiEditLootGroup;
 import betterquesting.client.gui2.inventory.ContainerSubmitStation;
 import betterquesting.client.gui2.inventory.GuiSubmitStation;
+import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.math.BlockPos;
@@ -37,8 +39,9 @@ public class GuiHandler implements IGuiHandler {
             return new GuiEditLootGroup(null);
         }
         else if(ID == 3) {
-            if(BQ_Settings.useBookmark && GuiHome.bookmark != null) {
-                return GuiHome.bookmark;
+            GuiScreen bookmark = BookmarkManager.INSTANCE.getBookmark();
+            if(BQ_Settings.useBookmark && bookmark != null) {
+                return bookmark;
             }
             else {
                 return new GuiHome(null);

--- a/src/main/java/betterquesting/handlers/SaveLoadHandler.java
+++ b/src/main/java/betterquesting/handlers/SaveLoadHandler.java
@@ -8,6 +8,7 @@ import betterquesting.api.storage.BQ_Settings;
 import betterquesting.api.utils.JsonHelper;
 import betterquesting.api.utils.NBTConverter;
 import betterquesting.api2.utils.BQThreadedIO;
+import betterquesting.client.BookmarkManager;
 import betterquesting.client.QuestNotification;
 import betterquesting.client.gui2.GuiHome;
 import betterquesting.commands.admin.QuestCommandDefaults;
@@ -78,7 +79,7 @@ public class SaveLoadHandler {
         hasUpdate = false;
 
         if (BetterQuesting.proxy.isClient()) {
-            GuiHome.bookmark = null;
+            BookmarkManager.INSTANCE.reset();
             QuestNotification.resetNotices();
         }
 
@@ -165,7 +166,7 @@ public class SaveLoadHandler {
             PartyManager.INSTANCE.reset();
 
             if (BetterQuesting.proxy.isClient()) {
-                GuiHome.bookmark = null;
+                BookmarkManager.INSTANCE.reset();
                 QuestNotification.resetNotices();
             }
 


### PR DESCRIPTION
This PR has various client-side related improvements to performance.
- Faster rendering of each `ItemStack` in BQ GUIs by skipping empty text. Previously the text was being drawn twice, even if there was nothing to draw. Example profile of a questline with many quest icons before PR: https://spark.lucko.me/xfvJvzt2z5?hl=2607,80
- Optimize canvas search besides just quest database searching (related to #114, porting GTNewHorizons/BetterQuesting#211). This allows the item search page (the one you would use to configure item retrieval tasks) to finish loading in seconds, rather than 10s of minutes in a large modpack.
  - Reduce `setStoredValue()` calls from 2 to 1 in `PanelItemSlot`.
  - Fix scroll position while populating search (ports GTNewHorizons/BetterQuesting#204).
  - Don't call `setTooltip()` when initializing `PanelItemSlot`, as it'll be calculated in `getTooltip()` on hover anyways.
- Provide `ItemStack` context to Forge events when rendering tooltips. Previously the events were always being passed `ItemStack.EMPTY`.
- Fix `WorldClient` leaks (ports GTNewHorizons/BetterQuesting#206).
- Refactor bookmarking feature to `BookmarkManager`, fixing a leak of `WorldClient` if using the quest book in one dimension but not in the current dimension.