### PR TITLE
Add Up/Down Buttons to multiple editor GUIs

### DIFF
--- a/src/main/java/betterquesting/client/gui2/editors/GuiPrerequisiteEditor.java
+++ b/src/main/java/betterquesting/client/gui2/editors/GuiPrerequisiteEditor.java
@@ -163,11 +163,11 @@ public class GuiPrerequisiteEditor extends GuiScreenCanvas implements IPEventLis
 
         List<DBEntry<IQuest>> arrReq = QuestDatabase.INSTANCE.bulkLookup(quest.getRequirements());
         for (int i = 0; i < arrReq.size(); i++) {
-            PanelButtonStorage<DBEntry<IQuest>> btnEdit = new PanelButtonStorage<>(new GuiRectangle(0, i * 16, width - 40, 16, 0), 1,
+            PanelButtonStorage<DBEntry<IQuest>> btnEdit = new PanelButtonStorage<>(new GuiRectangle(8, i * 16, width - 40, 16, 0), 1,
                     QuestTranslation.translate(arrReq.get(i).getValue().getProperty(NativeProps.NAME)), arrReq.get(i));
             canvasPreReq.addPanel(btnEdit);
 
-            PanelButtonStorage<DBEntry<IQuest>> btnType = new PanelButtonStorage<>(new GuiRectangle(width - 40, i * 16, 16, 16, 0), 6, "", arrReq.get(i));
+            PanelButtonStorage<DBEntry<IQuest>> btnType = new PanelButtonStorage<>(new GuiRectangle(width - 32, i * 16, 16, 16, 0), 6, "", arrReq.get(i));
             int arrReqID = arrReq.get(i).getID();
             btnType.setIcon(quest.getRequirementType(arrReqID).getIcon().getTexture());
             if (quest.getRequirementType(arrReqID) == IQuest.RequirementType.NORMAL)
@@ -178,12 +178,12 @@ public class GuiPrerequisiteEditor extends GuiScreenCanvas implements IPEventLis
                 btnType.setTooltip(Collections.singletonList(QuestTranslation.translate("betterquesting.btn.visible_hidden")));
             canvasPreReq.addPanel(btnType);
 
-            PanelButtonStorage<DBEntry<IQuest>> btnUp = new PanelButtonStorage<>(new GuiRectangle(width - 24, i * 16, 8, 8, 0), 7, "", arrReq.get(i));
+            PanelButtonStorage<DBEntry<IQuest>> btnUp = new PanelButtonStorage<>(new GuiRectangle(0, i * 16, 8, 8, 0), 7, "", arrReq.get(i));
             btnUp.setIcon(PresetIcon.ICON_UP.getTexture());
             btnUp.setActive(arrReq.size() > 1);
             canvasPreReq.addPanel(btnUp);
 
-            PanelButtonStorage<DBEntry<IQuest>> btnDown = new PanelButtonStorage<>(new GuiRectangle(width - 24, i * 16 + 8, 8, 8, 0), 8, "", arrReq.get(i));
+            PanelButtonStorage<DBEntry<IQuest>> btnDown = new PanelButtonStorage<>(new GuiRectangle(0, i * 16 + 8, 8, 8, 0), 8, "", arrReq.get(i));
             btnDown.setIcon(PresetIcon.ICON_DOWN.getTexture());
             btnDown.setActive(arrReq.size() > 1);
             canvasPreReq.addPanel(btnDown);

--- a/src/main/java/betterquesting/client/gui2/editors/GuiPrerequisiteEditor.java
+++ b/src/main/java/betterquesting/client/gui2/editors/GuiPrerequisiteEditor.java
@@ -83,7 +83,7 @@ public class GuiPrerequisiteEditor extends GuiScreenCanvas implements IPEventLis
         PanelTextBox panTxt = new PanelTextBox(new GuiTransform(GuiAlign.TOP_EDGE, new GuiPadding(0, 16, 0, -32), 0), QuestTranslation.translate("betterquesting.title.pre_requisites")).setAlignment(1);
         panTxt.setColor(PresetColor.TEXT_HEADER.getColor());
         cvBackground.addPanel(panTxt);
-        btnLogic = new PanelButton(new GuiTransform(GuiAlign.TOP_RIGHT, -116, 8, 100, 16, 0), 8, QuestTranslation.translate("betterquesting.btn.logic") + ": " + quest.getProperty(NativeProps.LOGIC_QUEST));
+        btnLogic = new PanelButton(new GuiTransform(GuiAlign.TOP_RIGHT, -116, 8, 100, 16, 0), 9, QuestTranslation.translate("betterquesting.btn.logic") + ": " + quest.getProperty(NativeProps.LOGIC_QUEST));
         cvBackground.addPanel(btnLogic);
 
         cvBackground.addPanel(new PanelButton(new GuiTransform(GuiAlign.BOTTOM_CENTER, -100, -16, 200, 16, 0), 0, QuestTranslation.translate("gui.back")));
@@ -163,11 +163,11 @@ public class GuiPrerequisiteEditor extends GuiScreenCanvas implements IPEventLis
 
         List<DBEntry<IQuest>> arrReq = QuestDatabase.INSTANCE.bulkLookup(quest.getRequirements());
         for (int i = 0; i < arrReq.size(); i++) {
-            PanelButtonStorage<DBEntry<IQuest>> btnEdit = new PanelButtonStorage<>(new GuiRectangle(0, i * 16, width - 48, 16, 0), 1,
+            PanelButtonStorage<DBEntry<IQuest>> btnEdit = new PanelButtonStorage<>(new GuiRectangle(0, i * 16, width - 40, 16, 0), 1,
                     QuestTranslation.translate(arrReq.get(i).getValue().getProperty(NativeProps.NAME)), arrReq.get(i));
             canvasPreReq.addPanel(btnEdit);
 
-            PanelButtonStorage<DBEntry<IQuest>> btnType = new PanelButtonStorage<>(new GuiRectangle(width - 48, i * 16, 16, 16, 0), 6, "", arrReq.get(i));
+            PanelButtonStorage<DBEntry<IQuest>> btnType = new PanelButtonStorage<>(new GuiRectangle(width - 40, i * 16, 16, 16, 0), 6, "", arrReq.get(i));
             int arrReqID = arrReq.get(i).getID();
             btnType.setIcon(quest.getRequirementType(arrReqID).getIcon().getTexture());
             if (quest.getRequirementType(arrReqID) == IQuest.RequirementType.NORMAL)
@@ -178,10 +178,15 @@ public class GuiPrerequisiteEditor extends GuiScreenCanvas implements IPEventLis
                 btnType.setTooltip(Collections.singletonList(QuestTranslation.translate("betterquesting.btn.visible_hidden")));
             canvasPreReq.addPanel(btnType);
 
-            PanelButtonStorage<DBEntry<IQuest>> btnUp = new PanelButtonStorage<>(new GuiRectangle(width - 32, i * 16, 16, 16, 0), 7, "", arrReq.get(i));
+            PanelButtonStorage<DBEntry<IQuest>> btnUp = new PanelButtonStorage<>(new GuiRectangle(width - 24, i * 16, 8, 8, 0), 7, "", arrReq.get(i));
             btnUp.setIcon(PresetIcon.ICON_UP.getTexture());
             btnUp.setActive(arrReq.size() > 1);
             canvasPreReq.addPanel(btnUp);
+
+            PanelButtonStorage<DBEntry<IQuest>> btnDown = new PanelButtonStorage<>(new GuiRectangle(width - 24, i * 16 + 8, 8, 8, 0), 8, "", arrReq.get(i));
+            btnDown.setIcon(PresetIcon.ICON_DOWN.getTexture());
+            btnDown.setActive(arrReq.size() > 1);
+            canvasPreReq.addPanel(btnDown);
 
             PanelButtonStorage<DBEntry<IQuest>> btnRem = new PanelButtonStorage<>(new GuiRectangle(width - 16, i * 16, 16, 16, 0), 3, "", arrReq.get(i));
             btnRem.setIcon(PresetIcon.ICON_NEGATIVE.getTexture());
@@ -231,11 +236,15 @@ public class GuiPrerequisiteEditor extends GuiScreenCanvas implements IPEventLis
             DBEntry<IQuest> entry = ((PanelButtonStorage<DBEntry<IQuest>>) btn).getStoredValue();
             quest.setRequirementType(entry.getID(), quest.getRequirementType(entry.getID()).next());
             SendChanges();
-        } else if (btn.getButtonID() == 7) { // Reorder
+        } else if (btn.getButtonID() == 7) { // Reorder Up
             DBEntry<IQuest> entry = ((PanelButtonStorage<DBEntry<IQuest>>) btn).getStoredValue();
-            reorderReq(quest, entry.getID());
+            reorderReq(quest, entry.getID(), -1);
             SendChanges();
-        } else if (btn.getButtonID() == 8) { // Logic
+        } else if (btn.getButtonID() == 8) { // Reorder Down
+            DBEntry<IQuest> entry = ((PanelButtonStorage<DBEntry<IQuest>>) btn).getStoredValue();
+            reorderReq(quest, entry.getID(), 1);
+            SendChanges();
+        } else if (btn.getButtonID() == 9) { // Logic
             EnumLogic[] logicList = EnumLogic.values();
             EnumLogic logic = quest.getProperty(NativeProps.LOGIC_QUEST);
             logic = logicList[(logic.ordinal() + 1) % logicList.length];
@@ -253,7 +262,7 @@ public class GuiPrerequisiteEditor extends GuiScreenCanvas implements IPEventLis
         return false;
     }
 
-    private void reorderReq(IQuest quest, int id) {
+    private void reorderReq(IQuest quest, int id, int direction) {
         int[] orig = quest.getRequirements();
 
         int indexToShift = -1;
@@ -266,7 +275,7 @@ public class GuiPrerequisiteEditor extends GuiScreenCanvas implements IPEventLis
         if (indexToShift < 0)
             return;
 
-        int indexFrom = (indexToShift - 1 + orig.length) % orig.length;
+        int indexFrom = (indexToShift + direction + orig.length) % orig.length;
         int tmp = orig[indexToShift];
         orig[indexToShift] = orig[indexFrom];
         orig[indexFrom] = tmp;

--- a/src/main/java/betterquesting/client/gui2/editors/GuiQuestLinesEditor.java
+++ b/src/main/java/betterquesting/client/gui2/editors/GuiQuestLinesEditor.java
@@ -170,7 +170,7 @@ public class GuiQuestLinesEditor extends GuiScreenCanvas implements IPEventListe
         btnDesign.setActive(selected != null);
         cvRight.addPanel(btnDesign);
 
-        btnTextEditor = new PanelButton(new GuiTransform(GuiAlign.TOP_RIGHT, new GuiPadding(-16, 48, 0, -64), 0), 8, "Aa");
+        btnTextEditor = new PanelButton(new GuiTransform(GuiAlign.TOP_RIGHT, new GuiPadding(-16, 48, 0, -64), 0), 9, "Aa");
         btnTextEditor.setActive(selected != null);
         cvRight.addPanel(btnTextEditor);
 
@@ -290,8 +290,13 @@ public class GuiQuestLinesEditor extends GuiScreenCanvas implements IPEventListe
         {
             DBEntry<IQuestLine> entry = ((PanelButtonStorage<DBEntry<IQuestLine>>) btn).getStoredValue();
             int order = QuestLineDatabase.INSTANCE.getOrderIndex(entry.getID());
-            if (order > 0) SendReorder(order);
-        } else if (btn.getButtonID() == 8) // Big Description Editor
+            if (order > 0) SendReorder(order, -1);
+        } else if (btn.getButtonID() == 7 && btn instanceof PanelButtonStorage) // Move Down
+        {
+            DBEntry<IQuestLine> entry = ((PanelButtonStorage<DBEntry<IQuestLine>>) btn).getStoredValue();
+            int order = QuestLineDatabase.INSTANCE.getOrderIndex(entry.getID());
+            if (order > 0) SendReorder(order, 1);
+        } else if (btn.getButtonID() == 9) // Big Description Editor
         {
             mc.displayGuiScreen(new GuiQuestDescEditor<>(this, selected, QuestTranslation.translate("betterquesting.title.edit_line"), () -> SendChanges(new DBEntry<>(selID, selected))));
         }
@@ -305,13 +310,16 @@ public class GuiQuestLinesEditor extends GuiScreenCanvas implements IPEventListe
 
         for (DBEntry<IQuestLine> entry : QuestLineDatabase.INSTANCE.getSortedEntries()) {
             IQuestLine ql = entry.getValue();
-            PanelButtonStorage<DBEntry<IQuestLine>> tmp = new PanelButtonStorage<>(new GuiRectangle(0, i * 16, w - 32, 16, 0), 5, QuestTranslation.translate(ql.getUnlocalisedName()), entry);
+            PanelButtonStorage<DBEntry<IQuestLine>> tmp = new PanelButtonStorage<>(new GuiRectangle(0, i * 16, w - 24, 16, 0), 5, QuestTranslation.translate(ql.getUnlocalisedName()), entry);
             tmp.setActive(entry.getID() != selID);
             lineList.addPanel(tmp);
-            lineList.addPanel(new PanelButtonStorage<>(new GuiRectangle(w - 32, i * 16, 16, 16, 0), 6, "", entry).setIcon(PresetIcon.ICON_TRASH.getTexture()));
-            PanelButton btnUp = new PanelButtonStorage<>(new GuiRectangle(w - 16, i * 16, 16, 16, 0), 7, "", entry).setIcon(PresetIcon.ICON_UP.getTexture());
+            PanelButton btnUp = new PanelButtonStorage<>(new GuiRectangle(w - 24, i * 16, 8, 8, 0), 7, "", entry).setIcon(PresetIcon.ICON_UP.getTexture());
             btnUp.setActive(QuestLineDatabase.INSTANCE.getSortedEntries().size() > 1);
             lineList.addPanel(btnUp);
+            PanelButton btnDown = new PanelButtonStorage<>(new GuiRectangle(w - 24, i * 16 + 8, 8, 8, 0), 8, "", entry).setIcon(PresetIcon.ICON_DOWN.getTexture());
+            btnDown.setActive(QuestLineDatabase.INSTANCE.getSortedEntries().size() > 1);
+            lineList.addPanel(btnDown);
+            lineList.addPanel(new PanelButtonStorage<>(new GuiRectangle(w - 16, i * 16, 16, 16, 0), 6, "", entry).setIcon(PresetIcon.ICON_TRASH.getTexture()));
             i++;
         }
     }
@@ -328,7 +336,7 @@ public class GuiQuestLinesEditor extends GuiScreenCanvas implements IPEventListe
         NetChapterEdit.sendEdit(payload);
     }
 
-    private void SendReorder(int indexToShift) {
+    private void SendReorder(int indexToShift, int direction) {
         if (indexToShift < 0) return;
         List<DBEntry<IQuestLine>> entries = QuestLineDatabase.INSTANCE.getSortedEntries();
         if (indexToShift >= entries.size()) return;
@@ -337,7 +345,7 @@ public class GuiQuestLinesEditor extends GuiScreenCanvas implements IPEventListe
             chapterIDs[i] = entries.get(i).getID();
         }
 
-        int indexFrom = (indexToShift - 1 + chapterIDs.length) % chapterIDs.length;
+        int indexFrom = (indexToShift + direction + chapterIDs.length) % chapterIDs.length;
         int tmp = chapterIDs[indexToShift];
         chapterIDs[indexToShift] = chapterIDs[indexFrom];
         chapterIDs[indexFrom] = tmp;

--- a/src/main/java/betterquesting/client/gui2/editors/GuiQuestLinesEditor.java
+++ b/src/main/java/betterquesting/client/gui2/editors/GuiQuestLinesEditor.java
@@ -310,13 +310,13 @@ public class GuiQuestLinesEditor extends GuiScreenCanvas implements IPEventListe
 
         for (DBEntry<IQuestLine> entry : QuestLineDatabase.INSTANCE.getSortedEntries()) {
             IQuestLine ql = entry.getValue();
-            PanelButtonStorage<DBEntry<IQuestLine>> tmp = new PanelButtonStorage<>(new GuiRectangle(0, i * 16, w - 24, 16, 0), 5, QuestTranslation.translate(ql.getUnlocalisedName()), entry);
+            PanelButtonStorage<DBEntry<IQuestLine>> tmp = new PanelButtonStorage<>(new GuiRectangle(8, i * 16, w - 24, 16, 0), 5, QuestTranslation.translate(ql.getUnlocalisedName()), entry);
             tmp.setActive(entry.getID() != selID);
             lineList.addPanel(tmp);
-            PanelButton btnUp = new PanelButtonStorage<>(new GuiRectangle(w - 24, i * 16, 8, 8, 0), 7, "", entry).setIcon(PresetIcon.ICON_UP.getTexture());
+            PanelButton btnUp = new PanelButtonStorage<>(new GuiRectangle(0, i * 16, 8, 8, 0), 7, "", entry).setIcon(PresetIcon.ICON_UP.getTexture());
             btnUp.setActive(QuestLineDatabase.INSTANCE.getSortedEntries().size() > 1);
             lineList.addPanel(btnUp);
-            PanelButton btnDown = new PanelButtonStorage<>(new GuiRectangle(w - 24, i * 16 + 8, 8, 8, 0), 8, "", entry).setIcon(PresetIcon.ICON_DOWN.getTexture());
+            PanelButton btnDown = new PanelButtonStorage<>(new GuiRectangle(0, i * 16 + 8, 8, 8, 0), 8, "", entry).setIcon(PresetIcon.ICON_DOWN.getTexture());
             btnDown.setActive(QuestLineDatabase.INSTANCE.getSortedEntries().size() > 1);
             lineList.addPanel(btnDown);
             lineList.addPanel(new PanelButtonStorage<>(new GuiRectangle(w - 16, i * 16, 16, 16, 0), 6, "", entry).setIcon(PresetIcon.ICON_TRASH.getTexture()));

--- a/src/main/java/betterquesting/client/gui2/editors/GuiRewardEditor.java
+++ b/src/main/java/betterquesting/client/gui2/editors/GuiRewardEditor.java
@@ -197,11 +197,11 @@ public class GuiRewardEditor extends GuiScreenCanvas implements IPEventListener,
 
         for (int i = 0; i < dbRew.size(); i++) {
             IReward reward = dbRew.get(i).getValue();
-            qrList.addPanel(new PanelButtonStorage<>(new GuiRectangle(0, i * 16, w - 24, 16, 0), 3, QuestTranslation.translate(reward.getUnlocalisedName()), reward));
-            PanelButton btnUp = new PanelButtonStorage<>(new GuiRectangle(w - 24, i * 16, 8, 8, 0), 4, "", dbRew.get(i)).setIcon(PresetIcon.ICON_UP.getTexture());
+            qrList.addPanel(new PanelButtonStorage<>(new GuiRectangle(8, i * 16, w - 24, 16, 0), 3, QuestTranslation.translate(reward.getUnlocalisedName()), reward));
+            PanelButton btnUp = new PanelButtonStorage<>(new GuiRectangle(0, i * 16, 8, 8, 0), 4, "", dbRew.get(i)).setIcon(PresetIcon.ICON_UP.getTexture());
             btnUp.setActive(dbRew.size() > 1);
             qrList.addPanel(btnUp);
-            PanelButton btnDown = new PanelButtonStorage<>(new GuiRectangle(w - 24, i * 16 + 8, 8, 8, 0), 5, "", dbRew.get(i)).setIcon(PresetIcon.ICON_DOWN.getTexture());
+            PanelButton btnDown = new PanelButtonStorage<>(new GuiRectangle(0, i * 16 + 8, 8, 8, 0), 5, "", dbRew.get(i)).setIcon(PresetIcon.ICON_DOWN.getTexture());
             btnDown.setActive(dbRew.size() > 1);
             qrList.addPanel(btnDown);
             qrList.addPanel(new PanelButtonStorage<>(new GuiRectangle(w - 16, i * 16, 16, 16, 0), 2, "" + TextFormatting.RED + TextFormatting.BOLD + "x", reward));

--- a/src/main/java/betterquesting/client/gui2/editors/GuiRewardEditor.java
+++ b/src/main/java/betterquesting/client/gui2/editors/GuiRewardEditor.java
@@ -209,8 +209,8 @@ public class GuiRewardEditor extends GuiScreenCanvas implements IPEventListener,
     }
 
     private void reorderReq(IQuest quest, int id, int direction) {
-        var tasks = quest.getRewards();
-        List<DBEntry<IReward>> orig = tasks.getEntries();
+        var rewards = quest.getRewards();
+        List<DBEntry<IReward>> orig = rewards.getEntries();
 
         int indexToShift = -1;
         for (int i = 0; i < orig.size(); i++) {
@@ -226,10 +226,10 @@ public class GuiRewardEditor extends GuiScreenCanvas implements IPEventListener,
         DBEntry<IReward> from = orig.get(indexFrom);
         DBEntry<IReward> to = orig.get(indexToShift);
 
-        tasks.removeID(from.getID());
-        tasks.removeID(to.getID());
-        tasks.add(indexToShift, from.getValue());
-        tasks.add(indexFrom, to.getValue());
+        rewards.removeID(from.getID());
+        rewards.removeID(to.getID());
+        rewards.add(indexToShift, from.getValue());
+        rewards.add(indexFrom, to.getValue());
     }
 
     private void SendChanges() {

--- a/src/main/java/betterquesting/client/gui2/editors/GuiRewardEditor.java
+++ b/src/main/java/betterquesting/client/gui2/editors/GuiRewardEditor.java
@@ -22,6 +22,7 @@ import betterquesting.api2.client.gui.panels.content.PanelTextBox;
 import betterquesting.api2.client.gui.panels.lists.CanvasScrolling;
 import betterquesting.api2.client.gui.panels.lists.CanvasSearch;
 import betterquesting.api2.client.gui.themes.presets.PresetColor;
+import betterquesting.api2.client.gui.themes.presets.PresetIcon;
 import betterquesting.api2.client.gui.themes.presets.PresetLine;
 import betterquesting.api2.client.gui.themes.presets.PresetTexture;
 import betterquesting.api2.registry.IFactoryData;
@@ -177,6 +178,14 @@ public class GuiRewardEditor extends GuiScreenCanvas implements IPEventListener,
                     SendChanges();
                 }));
             }
+        } else if (btn.getButtonID() == 4) { // Reorder Up
+            DBEntry<IReward> reward = ((PanelButtonStorage<DBEntry<IReward>>) btn).getStoredValue();
+            reorderReq(quest, reward.getID(), -1);
+            SendChanges();
+        } else if (btn.getButtonID() == 5) { // Reorder Down
+            DBEntry<IReward> reward = ((PanelButtonStorage<DBEntry<IReward>>) btn).getStoredValue();
+            reorderReq(quest, reward.getID(), 1);
+            SendChanges();
         }
     }
 
@@ -188,9 +197,39 @@ public class GuiRewardEditor extends GuiScreenCanvas implements IPEventListener,
 
         for (int i = 0; i < dbRew.size(); i++) {
             IReward reward = dbRew.get(i).getValue();
-            qrList.addPanel(new PanelButtonStorage<>(new GuiRectangle(0, i * 16, w - 16, 16, 0), 3, QuestTranslation.translate(reward.getUnlocalisedName()), reward));
+            qrList.addPanel(new PanelButtonStorage<>(new GuiRectangle(0, i * 16, w - 24, 16, 0), 3, QuestTranslation.translate(reward.getUnlocalisedName()), reward));
+            PanelButton btnUp = new PanelButtonStorage<>(new GuiRectangle(w - 24, i * 16, 8, 8, 0), 4, "", dbRew.get(i)).setIcon(PresetIcon.ICON_UP.getTexture());
+            btnUp.setActive(dbRew.size() > 1);
+            qrList.addPanel(btnUp);
+            PanelButton btnDown = new PanelButtonStorage<>(new GuiRectangle(w - 24, i * 16 + 8, 8, 8, 0), 5, "", dbRew.get(i)).setIcon(PresetIcon.ICON_DOWN.getTexture());
+            btnDown.setActive(dbRew.size() > 1);
+            qrList.addPanel(btnDown);
             qrList.addPanel(new PanelButtonStorage<>(new GuiRectangle(w - 16, i * 16, 16, 16, 0), 2, "" + TextFormatting.RED + TextFormatting.BOLD + "x", reward));
         }
+    }
+
+    private void reorderReq(IQuest quest, int id, int direction) {
+        var tasks = quest.getRewards();
+        List<DBEntry<IReward>> orig = tasks.getEntries();
+
+        int indexToShift = -1;
+        for (int i = 0; i < orig.size(); i++) {
+            if (orig.get(i).getID() == id) {
+                indexToShift = i;
+                break;
+            }
+        }
+        if (indexToShift < 0)
+            return;
+
+        int indexFrom = (indexToShift + direction + orig.size()) % orig.size();
+        DBEntry<IReward> from = orig.get(indexFrom);
+        DBEntry<IReward> to = orig.get(indexToShift);
+
+        tasks.removeID(from.getID());
+        tasks.removeID(to.getID());
+        tasks.add(indexToShift, from.getValue());
+        tasks.add(indexFrom, to.getValue());
     }
 
     private void SendChanges() {

--- a/src/main/java/betterquesting/client/gui2/editors/GuiRewardEditor.java
+++ b/src/main/java/betterquesting/client/gui2/editors/GuiRewardEditor.java
@@ -208,19 +208,12 @@ public class GuiRewardEditor extends GuiScreenCanvas implements IPEventListener,
         }
     }
 
-    private void reorderReq(IQuest quest, int id, int direction) {
-        var rewards = quest.getRewards();
-        List<DBEntry<IReward>> orig = rewards.getEntries();
-
-        int indexToShift = -1;
-        for (int i = 0; i < orig.size(); i++) {
-            if (orig.get(i).getID() == id) {
-                indexToShift = i;
-                break;
-            }
-        }
+    private void reorderReq(IQuest quest, int indexToShift, int direction) {
         if (indexToShift < 0)
             return;
+
+        var rewards = quest.getRewards();
+        List<DBEntry<IReward>> orig = rewards.getEntries();
 
         int indexFrom = (indexToShift + direction + orig.size()) % orig.size();
         DBEntry<IReward> from = orig.get(indexFrom);

--- a/src/main/java/betterquesting/client/gui2/editors/GuiRewardEditor.java
+++ b/src/main/java/betterquesting/client/gui2/editors/GuiRewardEditor.java
@@ -213,16 +213,15 @@ public class GuiRewardEditor extends GuiScreenCanvas implements IPEventListener,
             return;
 
         var rewards = quest.getRewards();
-        List<DBEntry<IReward>> orig = rewards.getEntries();
 
-        int indexFrom = (indexToShift + direction + orig.size()) % orig.size();
-        DBEntry<IReward> from = orig.get(indexFrom);
-        DBEntry<IReward> to = orig.get(indexToShift);
+        int indexFrom = (indexToShift + direction + rewards.size()) % rewards.size();
+        IReward from = rewards.getValue(indexFrom);
+        IReward to = rewards.getValue(indexToShift);
 
-        rewards.removeID(from.getID());
-        rewards.removeID(to.getID());
-        rewards.add(indexToShift, from.getValue());
-        rewards.add(indexFrom, to.getValue());
+        rewards.removeID(indexFrom);
+        rewards.removeID(indexToShift);
+        rewards.add(indexToShift, from);
+        rewards.add(indexFrom, to);
     }
 
     private void SendChanges() {

--- a/src/main/java/betterquesting/client/gui2/editors/GuiTaskEditor.java
+++ b/src/main/java/betterquesting/client/gui2/editors/GuiTaskEditor.java
@@ -213,16 +213,15 @@ public class GuiTaskEditor extends GuiScreenCanvas implements IPEventListener, I
             return;
 
         var tasks = quest.getTasks();
-        List<DBEntry<ITask>> orig = tasks.getEntries();
 
-        int indexFrom = (indexToShift + direction + orig.size()) % orig.size();
-        DBEntry<ITask> from = orig.get(indexFrom);
-        DBEntry<ITask> to = orig.get(indexToShift);
+        int indexFrom = (indexToShift + direction + tasks.size()) % tasks.size();
+        ITask from = tasks.getValue(indexFrom);
+        ITask to = tasks.getValue(indexToShift);
 
-        tasks.removeID(from.getID());
-        tasks.removeID(to.getID());
-        tasks.add(indexToShift, from.getValue());
-        tasks.add(indexFrom, to.getValue());
+        tasks.removeID(indexFrom);
+        tasks.removeID(indexToShift);
+        tasks.add(indexToShift, from);
+        tasks.add(indexFrom, to);
     }
 
     private void SendChanges() {

--- a/src/main/java/betterquesting/client/gui2/editors/GuiTaskEditor.java
+++ b/src/main/java/betterquesting/client/gui2/editors/GuiTaskEditor.java
@@ -208,19 +208,12 @@ public class GuiTaskEditor extends GuiScreenCanvas implements IPEventListener, I
         }
     }
 
-    private void reorderReq(IQuest quest, int id, int direction) {
-        var tasks = quest.getTasks();
-        List<DBEntry<ITask>> orig = tasks.getEntries();
-
-        int indexToShift = -1;
-        for (int i = 0; i < orig.size(); i++) {
-            if (orig.get(i).getID() == id) {
-                indexToShift = i;
-                break;
-            }
-        }
+    private void reorderReq(IQuest quest, int indexToShift, int direction) {
         if (indexToShift < 0)
             return;
+
+        var tasks = quest.getTasks();
+        List<DBEntry<ITask>> orig = tasks.getEntries();
 
         int indexFrom = (indexToShift + direction + orig.size()) % orig.size();
         DBEntry<ITask> from = orig.get(indexFrom);

--- a/src/main/java/betterquesting/client/gui2/editors/GuiTaskEditor.java
+++ b/src/main/java/betterquesting/client/gui2/editors/GuiTaskEditor.java
@@ -22,6 +22,7 @@ import betterquesting.api2.client.gui.panels.content.PanelTextBox;
 import betterquesting.api2.client.gui.panels.lists.CanvasScrolling;
 import betterquesting.api2.client.gui.panels.lists.CanvasSearch;
 import betterquesting.api2.client.gui.themes.presets.PresetColor;
+import betterquesting.api2.client.gui.themes.presets.PresetIcon;
 import betterquesting.api2.client.gui.themes.presets.PresetLine;
 import betterquesting.api2.client.gui.themes.presets.PresetTexture;
 import betterquesting.api2.registry.IFactoryData;
@@ -177,6 +178,14 @@ public class GuiTaskEditor extends GuiScreenCanvas implements IPEventListener, I
                     SendChanges();
                 }));
             }
+        } else if (btn.getButtonID() == 4) { // Reorder Up
+            DBEntry<ITask> task = ((PanelButtonStorage<DBEntry<ITask>>) btn).getStoredValue();
+            reorderReq(quest, task.getID(), -1);
+            SendChanges();
+        } else if (btn.getButtonID() == 5) { // Reorder Down
+            DBEntry<ITask> task = ((PanelButtonStorage<DBEntry<ITask>>) btn).getStoredValue();
+            reorderReq(quest, task.getID(), 1);
+            SendChanges();
         }
     }
 
@@ -188,9 +197,39 @@ public class GuiTaskEditor extends GuiScreenCanvas implements IPEventListener, I
 
         for (int i = 0; i < dbTsk.size(); i++) {
             ITask task = dbTsk.get(i).getValue();
-            qtList.addPanel(new PanelButtonStorage<>(new GuiRectangle(0, i * 16, w - 16, 16, 0), 3, QuestTranslation.translate(task.getUnlocalisedName()), task));
+            qtList.addPanel(new PanelButtonStorage<>(new GuiRectangle(0, i * 16, w - 24, 16, 0), 3, QuestTranslation.translate(task.getUnlocalisedName()), task));
+            PanelButton btnUp = new PanelButtonStorage<>(new GuiRectangle(w - 24, i * 16, 8, 8, 0), 4, "", dbTsk.get(i)).setIcon(PresetIcon.ICON_UP.getTexture());
+            btnUp.setActive(dbTsk.size() > 1);
+            qtList.addPanel(btnUp);
+            PanelButton btnDown = new PanelButtonStorage<>(new GuiRectangle(w - 24, i * 16 + 8, 8, 8, 0), 5, "", dbTsk.get(i)).setIcon(PresetIcon.ICON_DOWN.getTexture());
+            btnDown.setActive(dbTsk.size() > 1);
+            qtList.addPanel(btnDown);
             qtList.addPanel(new PanelButtonStorage<>(new GuiRectangle(w - 16, i * 16, 16, 16, 0), 2, "" + TextFormatting.RED + TextFormatting.BOLD + "x", task));
         }
+    }
+
+    private void reorderReq(IQuest quest, int id, int direction) {
+        var tasks = quest.getTasks();
+        List<DBEntry<ITask>> orig = tasks.getEntries();
+
+        int indexToShift = -1;
+        for (int i = 0; i < orig.size(); i++) {
+            if (orig.get(i).getID() == id) {
+                indexToShift = i;
+                break;
+            }
+        }
+        if (indexToShift < 0)
+            return;
+
+        int indexFrom = (indexToShift + direction + orig.size()) % orig.size();
+        DBEntry<ITask> from = orig.get(indexFrom);
+        DBEntry<ITask> to = orig.get(indexToShift);
+
+        tasks.removeID(from.getID());
+        tasks.removeID(to.getID());
+        tasks.add(indexToShift, from.getValue());
+        tasks.add(indexFrom, to.getValue());
     }
 
     private void SendChanges() {

--- a/src/main/java/betterquesting/client/gui2/editors/GuiTaskEditor.java
+++ b/src/main/java/betterquesting/client/gui2/editors/GuiTaskEditor.java
@@ -197,11 +197,11 @@ public class GuiTaskEditor extends GuiScreenCanvas implements IPEventListener, I
 
         for (int i = 0; i < dbTsk.size(); i++) {
             ITask task = dbTsk.get(i).getValue();
-            qtList.addPanel(new PanelButtonStorage<>(new GuiRectangle(0, i * 16, w - 24, 16, 0), 3, QuestTranslation.translate(task.getUnlocalisedName()), task));
-            PanelButton btnUp = new PanelButtonStorage<>(new GuiRectangle(w - 24, i * 16, 8, 8, 0), 4, "", dbTsk.get(i)).setIcon(PresetIcon.ICON_UP.getTexture());
+            qtList.addPanel(new PanelButtonStorage<>(new GuiRectangle(8, i * 16, w - 24, 16, 0), 3, QuestTranslation.translate(task.getUnlocalisedName()), task));
+            PanelButton btnUp = new PanelButtonStorage<>(new GuiRectangle(0, i * 16, 8, 8, 0), 4, "", dbTsk.get(i)).setIcon(PresetIcon.ICON_UP.getTexture());
             btnUp.setActive(dbTsk.size() > 1);
             qtList.addPanel(btnUp);
-            PanelButton btnDown = new PanelButtonStorage<>(new GuiRectangle(w - 24, i * 16 + 8, 8, 8, 0), 5, "", dbTsk.get(i)).setIcon(PresetIcon.ICON_DOWN.getTexture());
+            PanelButton btnDown = new PanelButtonStorage<>(new GuiRectangle(0, i * 16 + 8, 8, 8, 0), 5, "", dbTsk.get(i)).setIcon(PresetIcon.ICON_DOWN.getTexture());
             btnDown.setActive(dbTsk.size() > 1);
             qtList.addPanel(btnDown);
             qtList.addPanel(new PanelButtonStorage<>(new GuiRectangle(w - 16, i * 16, 16, 16, 0), 2, "" + TextFormatting.RED + TextFormatting.BOLD + "x", task));


### PR DESCRIPTION
changes in this PR:
- add down buttons to the prerequisite and quest line editors.
- add up and down buttons to the task and reward editors.
- shrink the size of the buttons to 8x8 instead of 16x16, allowing both to fit stacked atop each other.
- make the buttons be on the far left side (avoids accidental deletions from misclicks).

supersedes #103